### PR TITLE
Adopt growing-agents-md scaffold and document dogfooding policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 ## Project Overview
 
 <!-- Replace this section in-place. Remove the placeholder line once filled. -->
-- Local-first CLI that compiles rule documents (AGENTS.md, SKILL.md, PR checklists) into compiler-style pass/fail with evidence.
+- Local-first CLI that compiles rule documents (AGENTS.md, PR checklists) into compiler-style pass/fail with evidence.
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,44 @@
-# Repository Guidance
+# Agent Guidelines
 
-- Keep `gate-keeper` usable as a local CLI without GitHub or network access.
-- Prefer deterministic checks over LLM judgement whenever the required evidence
-  is available.
-- Treat missing evidence as fail-closed.
-- Keep GitHub support isolated behind a backend boundary.
-- Do not make `gh aw` a package dependency; document composition instead.
-- Use `uv` for dependency management and command execution.
+<!-- Do not restructure or delete sections. Update individual values in-place when they change. -->
+
+## Core Principles
+
+- Keep this file under 20-30 lines of visible guidance.
+- Keep only repo-specific, non-obvious instructions here.
+
+## Project Overview
+
+<!-- Replace this section in-place. Remove the placeholder line once filled. -->
+- Local-first CLI that compiles rule documents (AGENTS.md, SKILL.md, PR checklists) into compiler-style pass/fail with evidence.
+
+## Commands
+
+<!-- Replace this section in-place. Remove the placeholder block once filled. -->
+~~~sh
+uv sync
+uv run gate-keeper --help
+uv run pytest
+~~~
+
+## Code Conventions
+
+<!-- Replace this section in-place. Remove the placeholder line once filled. -->
+- Prefer deterministic backends over LLM rubric whenever evidence is available.
+- Treat missing evidence as fail-closed; do not paper over with defaults.
+- Keep `gh aw` out of package dependencies; document composition only.
+- Self-gating on this repo is advisory by default; promote per-rule to required, see docs/dogfooding.md.
+
+## Architecture
+
+<!-- Replace this section in-place. Remove the placeholder line once filled. -->
+- Pipeline: rule extraction -> IR -> backend routing -> evidence-bearing result.
+- GitHub support sits behind a backend boundary so core works without network or `gh`.
+- `uv` is the supported workflow runner.
+
+## Maintenance Notes
+
+<!-- This section is permanent. Do not delete. -->
+- Delete stale or inferable guidance.
+- Update commands and architecture when workflows change.
+- Keep durable rules here; move detail to dedicated docs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -1,0 +1,41 @@
+# Dogfooding gate-keeper on gate-keeper
+
+`gate-keeper` is exercised against its own PRs to surface compiler/backend gaps
+early. The rule of thumb in `AGENTS.md` is: **self-gating is advisory by default;
+promote per-rule to required.** This document defines the promotion path.
+
+## Why advisory first
+
+Hard-gating an unproven rule on its own repo creates a deadlock: a bug in
+`gate-keeper` blocks the PR that would fix it. Advisory mode runs the same
+checks but reports as PR comments only, never as a required status.
+
+## Promotion criteria (per rule)
+
+A single rule may be promoted from advisory to required when **all** hold:
+
+1. The rule has produced no false positive across the trailing 10 merged PRs
+   that touched the relevant scope.
+2. The rule has produced at least one true positive (caught a real violation),
+   or its absence has been explicitly justified in an issue.
+3. The deterministic backend is the source of truth for the rule. LLM-rubric
+   rules stay advisory until a deterministic equivalent exists or an explicit
+   exception is recorded here.
+4. Fail-closed behaviour on missing evidence has been validated against a
+   synthetic PR that withholds the evidence.
+
+Promotion is per-rule, not per-ruleset. Demotion is always allowed and does
+not require ceremony beyond an issue noting the trigger.
+
+## Issue hygiene
+
+Every false positive, false negative, or unclear failure observed during
+self-gating is filed as an issue with the `area:dogfood` label, ideally from
+the PR that surfaced it. Without an issue the signal is lost; the advisory
+phase is worthless if findings are not captured.
+
+## Out of scope
+
+- External repos consuming `gate-keeper` set their own promotion policy.
+- This document does not list specific rules. Rule-level state lives next to
+  the rule definitions.

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -1,4 +1,4 @@
-# Dogfooding gate-keeper on gate-keeper
+# Dogfooding gate-keeper on itself
 
 `gate-keeper` is exercised against its own PRs to surface compiler/backend gaps
 early. The rule of thumb in `AGENTS.md` is: **self-gating is advisory by default;
@@ -21,7 +21,7 @@ A single rule may be promoted from advisory to required when **all** hold:
 3. The deterministic backend is the source of truth for the rule. LLM-rubric
    rules stay advisory until a deterministic equivalent exists or an explicit
    exception is recorded here.
-4. Fail-closed behaviour on missing evidence has been validated against a
+4. Fail-closed behavior on missing evidence has been validated against a
    synthetic PR that withholds the evidence.
 
 Promotion is per-rule, not per-ruleset. Demotion is always allowed and does


### PR DESCRIPTION
Closes #22

## Summary

- Rewrite `AGENTS.md` to the canonical `growing-agents-md` scaffold; one-line pointer to `docs/dogfooding.md` for self-gating policy.
- Symlink `CLAUDE.md` → `AGENTS.md` so the Claude Code view stays drift-free.
- Add `docs/dogfooding.md` defining the advisory→required promotion criteria (per-rule, fail-closed, `area:dogfood` issue hygiene).

## Validation

| Command | Result |
|---|---|
| `python3 .../growing-agents-md/scripts/growing_agents_md.py lint` | pass |
| `uv run pytest` | 1 passed |

## Test plan

- [x] AGENTS.md lint passes against the canonical schema.
- [x] AGENTS.md references `docs/dogfooding.md` for self-gating policy.
- [x] `CLAUDE.md` resolves to `AGENTS.md` via symlink.
- [x] `docs/dogfooding.md` documents per-rule promotion criteria.
- [x] No new package dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)