### PR TITLE
feat: MVP gate-keeper implementation

### DIFF
--- a/docs/example-rules.md
+++ b/docs/example-rules.md
@@ -1,0 +1,7 @@
+# Example Rules
+
+These rules are intentionally small and deterministic for the MVP.
+
+- The repository must include a `README.md` file.
+- `AGENTS.md` must mention `uv run pytest`.
+- `checklist.md` must have every task complete.

--- a/src/gate_keeper/backends/__init__.py
+++ b/src/gate_keeper/backends/__init__.py
@@ -1,0 +1,5 @@
+"""Validation backends for gate-keeper."""
+
+from .filesystem import evaluate_ruleset
+
+__all__ = ["evaluate_ruleset"]

--- a/src/gate_keeper/backends/filesystem.py
+++ b/src/gate_keeper/backends/filesystem.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fnmatch import fnmatch
+from pathlib import Path
+import re
+
+from gate_keeper.models import Backend, Diagnostic, DiagnosticReport, Evidence, Rule, RuleKind, Severity, SourceLocation, Status
+
+_TASK_RE = re.compile(r"^\s*[-*+]\s+\[(?P<state>[ xX])\]\s+(?P<body>.+?)\s*$")
+
+
+@dataclass(frozen=True)
+class BackendContext:
+    root: Path
+
+
+def _make_diag(rule: Rule, status: Status, message: str, evidence: list[Evidence], *, backend: Backend | None = None) -> Diagnostic:
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=backend or rule.backend_hint,
+        status=status,
+        severity=rule.severity,
+        message=message,
+        evidence=evidence,
+    )
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _resolve_subject(root: Path, rule: Rule) -> Path:
+    path = rule.params.get("path")
+    if path:
+        subject = Path(str(path))
+        if subject.is_absolute():
+            return subject
+        return root / subject
+    return root
+
+
+def _iter_paths(root: Path) -> list[Path]:
+    if root.is_file():
+        return [root]
+    if not root.exists():
+        return []
+    return [p for p in root.rglob("*") if p.is_file()]
+
+
+def _taskbox_state(text: str) -> tuple[int, int]:
+    complete = 0
+    total = 0
+    for line in text.splitlines():
+        match = _TASK_RE.match(line)
+        if match:
+            total += 1
+            if match.group("state").lower() == "x":
+                complete += 1
+    return complete, total
+
+
+def _evaluate_file_exists(rule: Rule, root: Path) -> Diagnostic:
+    subject = _resolve_subject(root, rule)
+    if subject.exists():
+        return _make_diag(
+            rule,
+            Status.PASS,
+            f"found required path {subject}",
+            [Evidence(kind="filesystem.path", data={"path": str(subject), "exists": True})],
+        )
+    return _make_diag(
+        rule,
+        Status.FAIL,
+        f"required path missing: {subject}",
+        [Evidence(kind="filesystem.path", data={"path": str(subject), "exists": False})],
+    )
+
+
+def _evaluate_file_absent(rule: Rule, root: Path) -> Diagnostic:
+    subject = _resolve_subject(root, rule)
+    if subject.exists():
+        return _make_diag(
+            rule,
+            Status.FAIL,
+            f"forbidden path exists: {subject}",
+            [Evidence(kind="filesystem.path", data={"path": str(subject), "exists": True})],
+        )
+    return _make_diag(
+        rule,
+        Status.PASS,
+        f"forbidden path absent as required: {subject}",
+        [Evidence(kind="filesystem.path", data={"path": str(subject), "exists": False})],
+    )
+
+
+def _evaluate_path_matches(rule: Rule, root: Path) -> Diagnostic:
+    pattern = str(rule.params.get("pattern") or rule.params.get("path") or "").strip()
+    if not pattern:
+        return _make_diag(
+            rule,
+            Status.UNSUPPORTED,
+            "path pattern rule is missing a pattern",
+            [Evidence(kind="filesystem.error", data={"reason": "missing pattern"})],
+        )
+    matches = []
+    for path in _iter_paths(root):
+        rel = path.relative_to(root) if root.exists() and root.is_dir() and path.is_relative_to(root) else path
+        if fnmatch(str(rel), pattern) or fnmatch(path.name, pattern):
+            matches.append(str(rel))
+    if matches:
+        return _make_diag(
+            rule,
+            Status.PASS,
+            f"found path(s) matching {pattern}",
+            [Evidence(kind="filesystem.path_match", data={"pattern": pattern, "matches": matches})],
+        )
+    return _make_diag(
+        rule,
+        Status.FAIL,
+        f"no path matched {pattern}",
+        [Evidence(kind="filesystem.path_match", data={"pattern": pattern, "matches": []})],
+    )
+
+
+def _search_text(rule: Rule, root: Path, *, forbidden: bool) -> Diagnostic:
+    subject = _resolve_subject(root, rule)
+    pattern = str(rule.params.get("pattern") or "").strip()
+    if not pattern:
+        return _make_diag(
+            rule,
+            Status.UNSUPPORTED,
+            "text rule is missing a pattern",
+            [Evidence(kind="filesystem.error", data={"reason": "missing pattern"})],
+        )
+    if not subject.exists():
+        return _make_diag(
+            rule,
+            Status.UNAVAILABLE,
+            f"required evidence unavailable: {subject} does not exist",
+            [Evidence(kind="filesystem.path", data={"path": str(subject), "exists": False})],
+        )
+
+    paths = [subject] if subject.is_file() else [p for p in subject.rglob("*") if p.is_file()]
+    matches: list[dict[str, object]] = []
+    scanned: list[str] = []
+    for path in paths:
+        scanned.append(str(path))
+        try:
+            text = _read_text(path)
+        except OSError as exc:  # pragma: no cover - filesystem-specific
+            return _make_diag(
+                rule,
+                Status.UNAVAILABLE,
+                f"required evidence unavailable: unable to read {path}",
+                [Evidence(kind="filesystem.error", data={"path": str(path), "error": str(exc)})],
+            )
+        found = pattern in text
+        if forbidden and found:
+            matches.append({"path": str(path), "found": True})
+        elif not forbidden and found:
+            matches.append({"path": str(path), "found": True})
+
+    if forbidden:
+        if matches:
+            return _make_diag(
+                rule,
+                Status.FAIL,
+                f"forbidden text found: {pattern}",
+                [Evidence(kind="filesystem.text_match", data={"pattern": pattern, "matches": matches, "scanned": scanned})],
+            )
+        return _make_diag(
+            rule,
+            Status.PASS,
+            f"forbidden text absent: {pattern}",
+            [Evidence(kind="filesystem.text_match", data={"pattern": pattern, "matches": [], "scanned": scanned})],
+        )
+
+    if matches:
+        return _make_diag(
+            rule,
+            Status.PASS,
+            f"required text found: {pattern}",
+            [Evidence(kind="filesystem.text_match", data={"pattern": pattern, "matches": matches, "scanned": scanned})],
+        )
+    return _make_diag(
+        rule,
+        Status.FAIL,
+        f"required text missing: {pattern}",
+        [Evidence(kind="filesystem.text_match", data={"pattern": pattern, "matches": [], "scanned": scanned})],
+    )
+
+
+def _evaluate_tasks_complete(rule: Rule, root: Path) -> Diagnostic:
+    subject = _resolve_subject(root, rule)
+    if not subject.exists():
+        return _make_diag(
+            rule,
+            Status.UNAVAILABLE,
+            f"required evidence unavailable: {subject} does not exist",
+            [Evidence(kind="filesystem.path", data={"path": str(subject), "exists": False})],
+        )
+    if subject.is_dir():
+        files = [p for p in subject.rglob("*.md") if p.is_file()]
+        if not files:
+            files = [p for p in subject.rglob("*") if p.is_file()]
+        if not files:
+            return _make_diag(
+                rule,
+                Status.UNSUPPORTED,
+                f"no markdown files found under {subject}",
+                [Evidence(kind="filesystem.error", data={"reason": "no markdown files found", "path": str(subject)})],
+            )
+        target = files[0]
+    else:
+        target = subject
+    try:
+        text = _read_text(target)
+    except OSError as exc:  # pragma: no cover - filesystem-specific
+        return _make_diag(
+            rule,
+            Status.UNAVAILABLE,
+            f"required evidence unavailable: unable to read {target}",
+            [Evidence(kind="filesystem.error", data={"path": str(target), "error": str(exc)})],
+        )
+    complete, total = _taskbox_state(text)
+    if total == 0:
+        return _make_diag(
+            rule,
+            Status.UNSUPPORTED,
+            f"no markdown task boxes found in {target}",
+            [Evidence(kind="filesystem.taskboxes", data={"path": str(target), "complete": 0, "total": 0})],
+        )
+    if complete != total:
+        return _make_diag(
+            rule,
+            Status.FAIL,
+            f"markdown tasks incomplete in {target}: {complete}/{total} complete",
+            [Evidence(kind="filesystem.taskboxes", data={"path": str(target), "complete": complete, "total": total})],
+        )
+    return _make_diag(
+        rule,
+        Status.PASS,
+        f"all markdown tasks complete in {target}: {complete}/{total}",
+        [Evidence(kind="filesystem.taskboxes", data={"path": str(target), "complete": complete, "total": total})],
+    )
+
+
+def evaluate_rule(rule: Rule, target: str | Path) -> Diagnostic:
+    root = Path(target)
+    if rule.kind == RuleKind.FILE_EXISTS:
+        return _evaluate_file_exists(rule, root)
+    if rule.kind == RuleKind.FILE_ABSENT:
+        return _evaluate_file_absent(rule, root)
+    if rule.kind == RuleKind.PATH_MATCHES:
+        return _evaluate_path_matches(rule, root)
+    if rule.kind == RuleKind.TEXT_REQUIRED:
+        return _search_text(rule, root, forbidden=False)
+    if rule.kind == RuleKind.TEXT_FORBIDDEN:
+        return _search_text(rule, root, forbidden=True)
+    if rule.kind == RuleKind.MARKDOWN_TASKS_COMPLETE:
+        return _evaluate_tasks_complete(rule, root)
+    return _make_diag(
+        rule,
+        Status.UNSUPPORTED,
+        f"backend does not support {rule.kind.value}",
+        [Evidence(kind="filesystem.error", data={"reason": "unsupported kind", "kind": rule.kind.value})],
+        backend=Backend.FILESYSTEM,
+    )
+
+
+def evaluate_ruleset(ruleset, target: str | Path) -> DiagnosticReport:
+    return DiagnosticReport(diagnostics=[evaluate_rule(rule, target) for rule in ruleset.rules])
+
+
+__all__ = ["evaluate_rule", "evaluate_ruleset"]

--- a/src/gate_keeper/classifier.py
+++ b/src/gate_keeper/classifier.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from pathlib import Path
+from typing import Iterable
+
+from gate_keeper.models import Backend, Confidence, Rule, RuleKind, RuleSet, Severity
+from gate_keeper.parser import ParsedDocument, ParsedRuleCandidate, extract_candidates
+
+_PATH_RE = re.compile(
+    r"(?P<path>(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_.-]+(?:\.[A-Za-z0-9_.-]+)?)"
+)
+_BACKTICK_RE = re.compile(r"`([^`]+)`")
+_QUOTED_RE = re.compile(r'(?<!\\)(?:"([^\"]+)"|\'([^\']+)\')')
+
+_GITHUB_HINT_WORDS = (
+    "pull request",
+    "pr ",
+    "draft",
+    "review",
+    "thread",
+    "status check",
+    "checks",
+    "label",
+    "labels",
+    "approval",
+    "approved",
+    "github",
+)
+
+_FILESYSTEM_HINT_WORDS = (
+    "file",
+    "path",
+    "directory",
+    "folder",
+    "exists",
+    "exist",
+    "absent",
+    "present",
+    "required",
+    "forbidden",
+    "contain",
+    "include",
+    "mention",
+    "match",
+    "name",
+    "named",
+    "text",
+    "task",
+    "checklist",
+)
+
+
+def _clean_title(text: str, limit: int = 72) -> str:
+    collapsed = re.sub(r"\s+", " ", text.strip())
+    if len(collapsed) <= limit:
+        return collapsed
+    return collapsed[: limit - 1].rstrip() + "…"
+
+
+def _extract_quoted_snippet(text: str) -> str | None:
+    for match in _BACKTICK_RE.findall(text):
+        if match.strip() and "/" not in match and "." not in match:
+            return match.strip()
+    quoted = _QUOTED_RE.search(text)
+    if quoted:
+        value = (quoted.group(1) or quoted.group(2) or "").strip()
+        if value and "/" not in value and "." not in value:
+            return value
+    return None
+
+
+def _extract_path_like(text: str) -> str | None:
+    for candidate in _BACKTICK_RE.findall(text):
+        if "/" in candidate or "." in candidate:
+            return candidate.strip()
+    for quoted in _QUOTED_RE.findall(text):
+        value = next((item for item in quoted if item), "").strip()
+        if "/" in value or "." in value:
+            return value
+    for match in _PATH_RE.finditer(text):
+        path = match.group("path")
+        if any(sep in path for sep in ("/", ".")):
+            return path
+    return None
+
+
+def _extract_pattern(text: str) -> str | None:
+    snippet = _extract_quoted_snippet(text)
+    if snippet:
+        return snippet
+    path = _extract_path_like(text)
+    if path and not path.endswith((".md", ".txt", ".rst", ".py", ".json", ".yml", ".yaml")):
+        return path
+    lowered = re.sub(r"^\s*[-*+]\s+", "", text).strip()
+    lowered = re.sub(
+        r"^(must|must not|should|should not|never|required|forbidden|fail|block|ensure|require)\b[:\s-]*",
+        "",
+        lowered,
+        flags=re.IGNORECASE,
+    )
+    return lowered or None
+
+
+def _has_any(text: str, terms: Iterable[str]) -> bool:
+    lowered = text.lower()
+    return any(term in lowered for term in terms)
+
+
+def _determine_kind(candidate: ParsedRuleCandidate) -> tuple[RuleKind, Backend, Confidence, str]:
+    text = candidate.text.lower()
+    heading = (candidate.source.heading or "").lower()
+    context = f"{heading} {text}".strip()
+
+    if candidate.structure == "task":
+        return (
+            RuleKind.MARKDOWN_TASKS_COMPLETE,
+            Backend.FILESYSTEM,
+            Confidence.HIGH,
+            "Task checkbox extracted from Markdown checklist.",
+        )
+
+    if _has_any(context, _GITHUB_HINT_WORDS):
+        if "draft" in context:
+            return (RuleKind.GITHUB_NOT_DRAFT, Backend.GITHUB, Confidence.HIGH, "GitHub draft-state rule.")
+        if "status" in context or "check" in context or "checks" in context:
+            return (RuleKind.GITHUB_CHECKS_SUCCESS, Backend.GITHUB, Confidence.HIGH, "GitHub status-check rule.")
+        if "thread" in context:
+            return (RuleKind.GITHUB_THREADS_RESOLVED, Backend.GITHUB, Confidence.HIGH, "GitHub review-thread rule.")
+        if "approval" in context or "approved" in context:
+            return (RuleKind.GITHUB_NON_AUTHOR_APPROVAL, Backend.GITHUB, Confidence.MEDIUM, "GitHub approval rule.")
+        if "label" in context:
+            return (RuleKind.GITHUB_LABELS_ABSENT, Backend.GITHUB, Confidence.HIGH, "GitHub label gate.")
+        if "task" in context or "todo" in context:
+            return (RuleKind.GITHUB_TASKS_COMPLETE, Backend.GITHUB, Confidence.MEDIUM, "GitHub task-list rule.")
+        return (RuleKind.GITHUB_PR_OPEN, Backend.GITHUB, Confidence.MEDIUM, "GitHub PR-state rule.")
+
+    if _has_any(context, _FILESYSTEM_HINT_WORDS):
+        path = _extract_path_like(candidate.text)
+        if "absent" in context or "forbidden" in context or "must not" in context or "never" in context:
+            if "path" in context or "name" in context or "match" in context:
+                return (RuleKind.PATH_MATCHES, Backend.FILESYSTEM, Confidence.MEDIUM, "Filesystem path-pattern rule.")
+            return (RuleKind.FILE_ABSENT, Backend.FILESYSTEM, Confidence.HIGH, "Filesystem absence rule.")
+        if "match" in context or "regex" in context or "glob" in context or "named" in context:
+            return (RuleKind.PATH_MATCHES, Backend.FILESYSTEM, Confidence.HIGH, "Filesystem path-pattern rule.")
+        if "task" in context or "checklist" in context:
+            return (RuleKind.MARKDOWN_TASKS_COMPLETE, Backend.FILESYSTEM, Confidence.HIGH, "Filesystem Markdown task rule.")
+        if path and ("file" in context or "exist" in context or "present" in context or "must include" in context or "must have" in context) and "mention" not in context and "text" not in context:
+            return (RuleKind.FILE_EXISTS, Backend.FILESYSTEM, Confidence.HIGH, "Filesystem existence rule.")
+        if "mention" in context or "contain" in context or "include" in context or "text" in context:
+            return (RuleKind.TEXT_REQUIRED, Backend.FILESYSTEM, Confidence.HIGH, "Filesystem text-required rule.")
+        if "exist" in context or "present" in context or "require" in context or "must" in context:
+            return (RuleKind.FILE_EXISTS, Backend.FILESYSTEM, Confidence.HIGH, "Filesystem existence rule.")
+
+    return (
+        RuleKind.SEMANTIC_RUBRIC,
+        Backend.LLM_RUBRIC,
+        Confidence.LOW,
+        "Ambiguous rule routed to the semantic rubric backend.",
+    )
+
+
+def _severity_for_text(text: str) -> Severity:
+    lowered = text.lower()
+    if "should not" in lowered or "should" in lowered:
+        return Severity.WARNING
+    return Severity.ERROR
+
+
+def _build_params(candidate: ParsedRuleCandidate, kind: RuleKind) -> dict[str, object]:
+    text = candidate.text
+    params: dict[str, object] = {}
+    path = _extract_path_like(text)
+    pattern = _extract_pattern(text)
+
+    if kind in {RuleKind.FILE_EXISTS, RuleKind.FILE_ABSENT, RuleKind.PATH_MATCHES, RuleKind.TEXT_REQUIRED, RuleKind.TEXT_FORBIDDEN, RuleKind.MARKDOWN_TASKS_COMPLETE}:
+        if path:
+            params["path"] = path
+        if kind in {RuleKind.TEXT_REQUIRED, RuleKind.TEXT_FORBIDDEN, RuleKind.PATH_MATCHES} and pattern:
+            params["pattern"] = pattern
+        if kind == RuleKind.MARKDOWN_TASKS_COMPLETE:
+            params.setdefault("path", path or candidate.source.path)
+
+    if kind == RuleKind.GITHUB_PR_OPEN:
+        params["target"] = pattern or text
+    elif kind == RuleKind.GITHUB_NOT_DRAFT:
+        params["target"] = pattern or text
+    elif kind == RuleKind.GITHUB_LABELS_ABSENT:
+        if path:
+            params["label"] = path
+    elif kind in {RuleKind.GITHUB_TASKS_COMPLETE, RuleKind.GITHUB_CHECKS_SUCCESS, RuleKind.GITHUB_THREADS_RESOLVED, RuleKind.GITHUB_NON_AUTHOR_APPROVAL}:
+        params["target"] = pattern or text
+
+    return params
+
+
+def classify_candidate(candidate: ParsedRuleCandidate, *, document_stem: str, index: int) -> tuple[Rule, str]:
+    kind, backend_hint, confidence, explanation = _determine_kind(candidate)
+    title = _clean_title(candidate.text)
+    rule = Rule(
+        id=f"{document_stem}-{index}",
+        title=title,
+        source=candidate.source,
+        text=candidate.text,
+        kind=kind,
+        severity=_severity_for_text(candidate.text),
+        backend_hint=backend_hint,
+        confidence=confidence,
+        params=_build_params(candidate, kind),
+    )
+    return rule, explanation
+
+
+def classify_candidates(document: ParsedDocument) -> tuple[RuleSet, list[str]]:
+    rules: list[Rule] = []
+    explanations: list[str] = []
+    stem = Path(document.path).stem or "rule"
+    for index, candidate in enumerate(document.candidates, start=1):
+        rule, explanation = classify_candidate(candidate, document_stem=stem, index=index)
+        rules.append(rule)
+        explanations.append(explanation)
+    return RuleSet(rules=rules), explanations
+
+
+def compile_document(document_path: str | Path, content: str) -> tuple[RuleSet, list[str]]:
+    parsed = extract_candidates(document_path, content)
+    return classify_candidates(parsed)
+
+
+__all__ = [
+    "classify_candidate",
+    "classify_candidates",
+    "compile_document",
+]

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
 import argparse
+import json
+from pathlib import Path
+import sys
 
 from gate_keeper import __version__
+from gate_keeper.backends.filesystem import evaluate_ruleset
+from gate_keeper.classifier import compile_document
+from gate_keeper.diagnostics import exit_code_for_report, render_diagnostic_json, render_diagnostic_text
+from gate_keeper.models import DiagnosticReport, RuleSet
+from gate_keeper.parser import extract_candidates
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -19,6 +27,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="extract rules from a document into the rule IR",
     )
     compile_parser.add_argument("document", help="path to a rule document")
+    compile_parser.add_argument(
+        "--format",
+        choices=["json", "text"],
+        default="json",
+        help="output format",
+    )
 
     validate_parser = subparsers.add_parser(
         "validate",
@@ -28,12 +42,122 @@ def build_parser() -> argparse.ArgumentParser:
     validate_parser.add_argument("--target", required=True, help="artifact or PR to validate")
     validate_parser.add_argument(
         "--backend",
-        choices=["auto", "filesystem", "github", "llm"],
+        choices=["auto", "filesystem", "github", "llm-rubric"],
         default="auto",
         help="validation backend to use",
     )
+    validate_parser.add_argument(
+        "--format",
+        choices=["json", "text"],
+        default="text",
+        help="output format",
+    )
+
+    explain_parser = subparsers.add_parser(
+        "explain",
+        help="show how rules map to backends",
+    )
+    explain_parser.add_argument("document", help="path to a rule document")
+    explain_parser.add_argument(
+        "--format",
+        choices=["json", "text"],
+        default="text",
+        help="output format",
+    )
 
     return parser
+
+
+def _read_document(path: str | Path) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _emit(text: str) -> None:
+    try:
+        sys.stdout.write(text)
+        if not text.endswith("\n"):
+            sys.stdout.write("\n")
+    except BrokenPipeError:  # pragma: no cover - shell pipeline behavior
+        pass
+
+
+def _compile_command(document: str, output_format: str) -> int:
+    try:
+        content = _read_document(document)
+    except OSError as exc:
+        sys.stderr.write(f"gate-keeper compile: unable to read {document!r}: {exc}\n")
+        return 2
+    ruleset, explanations = compile_document(document, content)
+    if output_format == "json":
+        _emit(json.dumps(ruleset.to_dict(), indent=2, sort_keys=True))
+    else:
+        lines = [f"{Path(document).name}: {len(ruleset.rules)} rule(s)"]
+        for rule, explanation in zip(ruleset.rules, explanations, strict=True):
+            lines.append(
+                f"- {rule.id} [{rule.backend_hint.value}/{rule.kind.value}/{rule.confidence.value}] {rule.title}"
+            )
+            lines.append(f"  source: {rule.source.path}:{rule.source.line}")
+            if rule.source.heading:
+                lines.append(f"  heading: {rule.source.heading}")
+            lines.append(f"  explanation: {explanation}")
+        _emit("\n".join(lines))
+    return 0
+
+
+def _validate_command(document: str, target: str, backend: str, output_format: str) -> int:
+    try:
+        content = _read_document(document)
+    except OSError as exc:
+        sys.stderr.write(f"gate-keeper validate: unable to read {document!r}: {exc}\n")
+        return 2
+
+    ruleset, _ = compile_document(document, content)
+
+    if backend == "filesystem" or backend == "auto":
+        report = evaluate_ruleset(ruleset, target)
+    else:
+        sys.stderr.write(
+            f"gate-keeper validate: backend {backend!r} is not implemented in this MVP\n"
+        )
+        return 1
+
+    if output_format == "json":
+        _emit(render_diagnostic_json(report))
+    else:
+        _emit(render_diagnostic_text(report) or "")
+    return exit_code_for_report(report)
+
+
+def _explain_command(document: str, output_format: str) -> int:
+    try:
+        content = _read_document(document)
+    except OSError as exc:
+        sys.stderr.write(f"gate-keeper explain: unable to read {document!r}: {exc}\n")
+        return 2
+    parsed = extract_candidates(document, content)
+    ruleset, explanations = compile_document(document, content)
+    if output_format == "json":
+        payload = {
+            "document": document,
+            "candidate_count": len(parsed.candidates),
+            "rules": [
+                {
+                    **rule.to_dict(),
+                    "explanation": explanation,
+                }
+                for rule, explanation in zip(ruleset.rules, explanations, strict=True)
+            ],
+        }
+        _emit(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        lines = [f"{document}: {len(ruleset.rules)} rule(s)"]
+        for rule, explanation in zip(ruleset.rules, explanations, strict=True):
+            lines.append(
+                f"- {rule.id}: {rule.kind.value} -> {rule.backend_hint.value} ({rule.confidence.value})"
+            )
+            lines.append(f"  {explanation}")
+        _emit("\n".join(lines))
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -44,5 +168,12 @@ def main(argv: list[str] | None = None) -> int:
         parser.print_help()
         return 0
 
-    parser.error(f"{args.command!r} is planned but not implemented in the scaffold")
+    if args.command == "compile":
+        return _compile_command(args.document, args.format)
+    if args.command == "validate":
+        return _validate_command(args.rules, args.target, args.backend, args.format)
+    if args.command == "explain":
+        return _explain_command(args.document, args.format)
+
+    parser.error(f"unknown command: {args.command}")
     return 2

--- a/src/gate_keeper/diagnostics.py
+++ b/src/gate_keeper/diagnostics.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+
+from gate_keeper.models import Diagnostic, DiagnosticReport, Status
+
+_FAILURE_STATUSES = {
+    Status.FAIL,
+    Status.UNAVAILABLE,
+    Status.UNSUPPORTED,
+    Status.ERROR,
+}
+
+
+def render_diagnostic_text(report: DiagnosticReport) -> str:
+    lines: list[str] = []
+    for diagnostic in report.diagnostics:
+        source = diagnostic.source
+        header = (
+            f"{source.path}:{source.line}: "
+            f"[{diagnostic.backend.value}] {diagnostic.rule_id} "
+            f"{diagnostic.status.value}/{diagnostic.severity.value}: {diagnostic.message}"
+        )
+        if source.heading:
+            header += f" ({source.heading})"
+        lines.append(header)
+        for evidence in diagnostic.evidence:
+            payload = json.dumps(evidence.data, sort_keys=True)
+            lines.append(f"  evidence[{evidence.kind}]: {payload}")
+        if diagnostic.remediation:
+            lines.append(f"  remediation: {diagnostic.remediation}")
+    return "\n".join(lines)
+
+
+def render_diagnostic_json(report: DiagnosticReport) -> str:
+    return json.dumps(report.to_dict(), indent=2, sort_keys=True)
+
+
+def exit_code_for_report(report: DiagnosticReport) -> int:
+    if any(diagnostic.status in _FAILURE_STATUSES for diagnostic in report.diagnostics):
+        return 1
+    return 0
+
+
+def diagnostic_from_error(rule_id: str, message: str, *, severity: str = "error") -> Diagnostic:
+    from gate_keeper.models import Backend, Evidence, Severity, SourceLocation, Status
+
+    return Diagnostic(
+        rule_id=rule_id,
+        source=SourceLocation(path="<cli>", line=1),
+        backend=Backend.FILESYSTEM,
+        status=Status.ERROR,
+        severity=Severity(severity),
+        message=message,
+        evidence=[Evidence(kind="cli_error", data={"message": message})],
+    )
+
+
+__all__ = ["render_diagnostic_text", "render_diagnostic_json", "exit_code_for_report"]

--- a/src/gate_keeper/parser.py
+++ b/src/gate_keeper/parser.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from pathlib import Path
+
+from gate_keeper.models import SourceLocation
+
+_NORMATIVE_KEYWORDS = (
+    "must",
+    "must not",
+    "should",
+    "should not",
+    "never",
+    "required",
+    "forbidden",
+    "fail",
+    "block",
+    "ensure",
+    "require",
+)
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(?P<title>.+?)\s*$")
+_TASK_RE = re.compile(r"^\s*[-*+]\s+\[(?P<state>[ xX])\]\s+(?P<body>.+?)\s*$")
+_LIST_RE = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+(?P<body>.+?)\s*$")
+_FENCE_RE = re.compile(r"^\s*(```|~~~)")
+
+
+@dataclass(frozen=True)
+class ParsedRuleCandidate:
+    """Line-oriented rule candidate extracted from a Markdown document."""
+
+    text: str
+    source: SourceLocation
+    start_line: int
+    end_line: int
+    structure: str
+    raw: str
+
+
+@dataclass(frozen=True)
+class ParsedDocument:
+    path: str
+    candidates: list[ParsedRuleCandidate]
+
+
+def _heading_context(stack: list[str]) -> str | None:
+    if not stack:
+        return None
+    return " > ".join(stack)
+
+
+def _looks_normative_paragraph(text: str) -> bool:
+    lowered = text.lower()
+    return any(keyword in lowered for keyword in _NORMATIVE_KEYWORDS)
+
+
+def _clean_inline(text: str) -> str:
+    text = text.strip()
+    if text.startswith("- ") or text.startswith("* ") or text.startswith("+ "):
+        return text[2:].strip()
+    return text
+
+
+def extract_candidates(document_path: str | Path, content: str) -> ParsedDocument:
+    """Extract deterministic rule candidates from a Markdown document.
+
+    The MVP parser is intentionally line-oriented: it captures headings, list
+    items, task checkboxes, and normative paragraphs. Code blocks are skipped.
+    """
+
+    path = str(document_path)
+    heading_stack: list[str] = []
+    candidates: list[ParsedRuleCandidate] = []
+    in_code_block = False
+
+    for line_no, raw_line in enumerate(content.splitlines(), start=1):
+        stripped = raw_line.rstrip("\n")
+
+        if _FENCE_RE.match(stripped):
+            in_code_block = not in_code_block
+            continue
+        if in_code_block:
+            continue
+
+        heading_match = _HEADING_RE.match(stripped)
+        if heading_match:
+            level = len(heading_match.group(1))
+            title = heading_match.group("title").strip()
+            heading_stack = heading_stack[: max(level - 1, 0)]
+            heading_stack.append(title)
+            continue
+
+        body = None
+        structure = None
+        task_match = _TASK_RE.match(stripped)
+        if task_match:
+            body = task_match.group("body").strip()
+            structure = "task"
+        else:
+            list_match = _LIST_RE.match(stripped)
+            if list_match:
+                body = list_match.group("body").strip()
+                structure = "list"
+            else:
+                paragraph = stripped.strip()
+                if paragraph and _looks_normative_paragraph(paragraph):
+                    body = paragraph
+                    structure = "paragraph"
+
+        if not body or not structure:
+            continue
+
+        candidate = ParsedRuleCandidate(
+            text=_clean_inline(body),
+            source=SourceLocation(path=path, line=line_no, heading=_heading_context(heading_stack)),
+            start_line=line_no,
+            end_line=line_no,
+            structure=structure,
+            raw=stripped,
+        )
+        candidates.append(candidate)
+
+    return ParsedDocument(path=path, candidates=candidates)
+
+
+__all__ = ["ParsedRuleCandidate", "ParsedDocument", "extract_candidates"]

--- a/tests/fixtures/local/fail/AGENTS.md
+++ b/tests/fixtures/local/fail/AGENTS.md
@@ -1,0 +1,3 @@
+# Fixture AGENTS
+
+- Run tests before merging.

--- a/tests/fixtures/local/fail/checklist.md
+++ b/tests/fixtures/local/fail/checklist.md
@@ -1,0 +1,4 @@
+# Checklist
+
+- [x] First task
+- [ ] Second task

--- a/tests/fixtures/local/pass/AGENTS.md
+++ b/tests/fixtures/local/pass/AGENTS.md
@@ -1,0 +1,3 @@
+# Fixture AGENTS
+
+- Run `uv run pytest` before merging.

--- a/tests/fixtures/local/pass/README.md
+++ b/tests/fixtures/local/pass/README.md
@@ -1,0 +1,3 @@
+# Pass Fixture
+
+This target exists so `README.md` can be validated.

--- a/tests/fixtures/local/pass/checklist.md
+++ b/tests/fixtures/local/pass/checklist.md
@@ -1,0 +1,4 @@
+# Checklist
+
+- [x] First task
+- [x] Second task

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from gate_keeper.classifier import classify_candidate, compile_document
+from gate_keeper.models import Backend, Confidence, RuleKind
+from gate_keeper.parser import ParsedRuleCandidate
+from gate_keeper.models import SourceLocation
+
+
+def _candidate(text: str, *, structure: str = "list", heading: str | None = None) -> ParsedRuleCandidate:
+    return ParsedRuleCandidate(
+        text=text,
+        source=SourceLocation(path="rules.md", line=1, heading=heading),
+        start_line=1,
+        end_line=1,
+        structure=structure,
+        raw=text,
+    )
+
+
+def test_classifier_routes_filesystem_rules():
+    rule, explanation = classify_candidate(
+        _candidate("The repository must include a README.md file."),
+        document_stem="rules",
+        index=1,
+    )
+    assert rule.kind is RuleKind.FILE_EXISTS
+    assert rule.backend_hint is Backend.FILESYSTEM
+    assert rule.confidence is Confidence.HIGH
+    assert rule.params["path"] == "README.md"
+    assert "Filesystem" in explanation
+
+
+def test_classifier_routes_github_rules():
+    rule, _ = classify_candidate(
+        _candidate("Pull requests must not be drafts."),
+        document_stem="rules",
+        index=1,
+    )
+    assert rule.kind is RuleKind.GITHUB_NOT_DRAFT
+    assert rule.backend_hint is Backend.GITHUB
+
+
+def test_classifier_routes_ambiguous_rules_to_semantic_rubric():
+    rule, _ = classify_candidate(
+        _candidate("This should generally be a good experience for humans."),
+        document_stem="rules",
+        index=1,
+    )
+    assert rule.kind is RuleKind.SEMANTIC_RUBRIC
+    assert rule.backend_hint is Backend.LLM_RUBRIC
+    assert rule.confidence is Confidence.LOW
+
+
+def test_compile_document_produces_rule_set():
+    content = """# Example Rules\n\n- The repository must include a README.md file.\n- AGENTS.md must mention `uv run pytest`.\n- checklist.md must have every task complete.\n"""
+    ruleset, explanations = compile_document("docs/example-rules.md", content)
+    assert len(ruleset.rules) == len(explanations)
+    assert {rule.kind for rule in ruleset.rules} >= {
+        RuleKind.FILE_EXISTS,
+        RuleKind.TEXT_REQUIRED,
+        RuleKind.MARKDOWN_TASKS_COMPLETE,
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
 from gate_keeper.cli import main
 
 
@@ -5,3 +10,45 @@ def test_help_exits_successfully(capsys):
     assert main([]) == 0
     captured = capsys.readouterr()
     assert "Compile natural-language rules" in captured.out
+
+
+def test_compile_command_emits_json(capsys):
+    assert main(["compile", "docs/example-rules.md", "--format", "json"]) == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert len(payload["rules"]) == 3
+    assert payload["rules"][0]["source"]["path"] == "docs/example-rules.md"
+
+
+def test_validate_command_uses_local_filesystem_backend(capsys):
+    target = Path("tests/fixtures/local/pass")
+    assert main([
+        "validate",
+        "docs/example-rules.md",
+        "--target",
+        str(target),
+        "--backend",
+        "auto",
+        "--format",
+        "json",
+    ]) == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert all(diag["status"] == "pass" for diag in payload["diagnostics"])
+
+
+def test_validate_command_reports_failures(capsys):
+    target = Path("tests/fixtures/local/fail")
+    assert main([
+        "validate",
+        "docs/example-rules.md",
+        "--target",
+        str(target),
+        "--backend",
+        "auto",
+        "--format",
+        "json",
+    ]) == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert any(diag["status"] != "pass" for diag in payload["diagnostics"])

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from gate_keeper.diagnostics import exit_code_for_report, render_diagnostic_json, render_diagnostic_text
+from gate_keeper.models import Backend, Diagnostic, DiagnosticReport, Evidence, Severity, SourceLocation, Status
+
+
+def _report(status: Status = Status.PASS) -> DiagnosticReport:
+    return DiagnosticReport(
+        diagnostics=[
+            Diagnostic(
+                rule_id="r1",
+                source=SourceLocation(path="doc.md", line=12, heading="Rules"),
+                backend=Backend.FILESYSTEM,
+                status=status,
+                severity=Severity.ERROR,
+                message="missing evidence",
+                evidence=[Evidence(kind="text_match", data={"match_count": 0})],
+            )
+        ]
+    )
+
+
+def test_text_renderer_includes_required_fields():
+    text = render_diagnostic_text(_report(Status.FAIL))
+    assert "doc.md:12" in text
+    assert "r1" in text
+    assert "filesystem" in text
+    assert "fail/error" in text
+    assert "evidence[text_match]" in text
+
+
+def test_json_renderer_round_trips():
+    report = _report(Status.UNAVAILABLE)
+    json_text = render_diagnostic_json(report)
+    assert '"status": "unavailable"' in json_text
+    assert '"rule_id": "r1"' in json_text
+
+
+def test_exit_code_policy():
+    assert exit_code_for_report(_report(Status.PASS)) == 0
+    assert exit_code_for_report(_report(Status.FAIL)) == 1
+    assert exit_code_for_report(_report(Status.UNAVAILABLE)) == 1
+    assert exit_code_for_report(_report(Status.UNSUPPORTED)) == 1

--- a/tests/test_filesystem_backend.py
+++ b/tests/test_filesystem_backend.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from gate_keeper.backends.filesystem import evaluate_rule, evaluate_ruleset
+from gate_keeper.models import Backend, Confidence, Rule, RuleKind, RuleSet, Severity, SourceLocation
+
+
+def _rule(rule_id: str, kind: RuleKind, **params) -> Rule:
+    return Rule(
+        id=rule_id,
+        title=rule_id,
+        source=SourceLocation(path="rules.md", line=1),
+        text=rule_id,
+        kind=kind,
+        severity=Severity.ERROR,
+        backend_hint=Backend.FILESYSTEM,
+        confidence=Confidence.HIGH,
+        params=params,
+    )
+
+
+def test_filesystem_backend_pass_fail_and_unavailable(tmp_path):
+    root = tmp_path / "target"
+    root.mkdir()
+    (root / "README.md").write_text("hello", encoding="utf-8")
+    (root / "notes.md").write_text("keep calm", encoding="utf-8")
+    (root / "checklist.md").write_text("- [x] done\n- [x] done too\n", encoding="utf-8")
+
+    report = evaluate_ruleset(
+        RuleSet(
+            rules=[
+                _rule("exists", RuleKind.FILE_EXISTS, path="README.md"),
+                _rule("required", RuleKind.TEXT_REQUIRED, path="notes.md", pattern="keep"),
+                _rule("tasks", RuleKind.MARKDOWN_TASKS_COMPLETE, path="checklist.md"),
+                _rule("missing text", RuleKind.TEXT_REQUIRED, path="missing.md", pattern="hello"),
+                _rule("absent", RuleKind.FILE_ABSENT, path="forbidden.md"),
+            ]
+        ),
+        root,
+    )
+
+    statuses = [diagnostic.status.value for diagnostic in report.diagnostics]
+    assert statuses == ["pass", "pass", "pass", "unavailable", "pass"]
+
+
+def test_filesystem_backend_reports_fail_for_missing_required_file(tmp_path):
+    root = tmp_path / "target"
+    root.mkdir()
+    diag = evaluate_rule(_rule("exists", RuleKind.FILE_EXISTS, path="README.md"), root)
+    assert diag.status.value == "fail"
+    assert diag.backend is Backend.FILESYSTEM
+
+
+def test_filesystem_backend_reports_unsupported_for_unsupported_kind(tmp_path):
+    root = tmp_path / "target"
+    root.mkdir()
+    diag = evaluate_rule(_rule("semantic", RuleKind.SEMANTIC_RUBRIC), root)
+    assert diag.status.value == "unsupported"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gate_keeper.parser import extract_candidates
+
+
+def test_parser_extracts_normative_lists_and_tasks_from_agents_md():
+    content = Path("AGENTS.md").read_text(encoding="utf-8")
+    parsed = extract_candidates("AGENTS.md", content)
+
+    assert parsed.candidates
+    assert any("fail-closed" in candidate.text for candidate in parsed.candidates)
+    assert all(candidate.start_line == candidate.end_line for candidate in parsed.candidates)
+    assert all(candidate.source.path == "AGENTS.md" for candidate in parsed.candidates)
+
+
+def test_parser_ignores_code_blocks():
+    content = """# Example\n\n```md\n- must not be extracted\n```\n\nNarrative text without a rule.\n"""
+    parsed = extract_candidates("snippet.md", content)
+    assert parsed.candidates == []
+
+
+def test_parser_handles_pr_checklist_snippet():
+    content = """## PR checklist\n\n- [ ] Write tests\n- [x] Update docs\n- [ ] Ensure release notes are correct\n"""
+    parsed = extract_candidates("pr.md", content)
+    texts = [candidate.text for candidate in parsed.candidates]
+    assert texts == ["Write tests", "Update docs", "Ensure release notes are correct"]
+    assert all(candidate.source.heading == "PR checklist" for candidate in parsed.candidates)
+
+
+def test_parser_skips_narrative_paragraphs_without_normative_words():
+    content = """# Notes\n\nThis paragraph is just background information.\n\nAnother plain sentence.\n"""
+    parsed = extract_candidates("notes.md", content)
+    assert parsed.candidates == []


### PR DESCRIPTION
Implements the MVP pipeline end to end in a fail-closed way.

Closes #2
Closes #3
Closes #4
Closes #5
Closes #6
Closes #7

Verification:
- uv run pytest -q
- uv run gate-keeper compile docs/example-rules.md --format json
- uv run gate-keeper validate docs/example-rules.md --target tests/fixtures/local/pass --backend auto --format json
- uv run gate-keeper validate docs/example-rules.md --target tests/fixtures/local/fail --backend auto --format json