### PR TITLE
feat(parser): implement Markdown rule document parser

### DIFF
--- a/src/gate_keeper/parser.py
+++ b/src/gate_keeper/parser.py
@@ -1,0 +1,193 @@
+"""Line-oriented Markdown rule document extractor.
+
+Parses ATX headings, bullet/ordered lists, task checkboxes, and normative
+paragraphs into candidate Rule IR entries.  Classification (kind /
+backend_hint) is deferred to issue #3; all extracted rules carry the neutral
+defaults (semantic_rubric / llm-rubric / low confidence).
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from gate_keeper.models import (
+    Backend,
+    Confidence,
+    Rule,
+    RuleKind,
+    RuleSet,
+    Severity,
+    SourceLocation,
+)
+
+# Multi-word phrases must appear before their single-word prefixes.
+_NORMATIVE_RE = re.compile(
+    r"\b(?:must\s+not|should\s+not|must|should|never|required|forbidden"
+    r"|fail|block|ensure|require)\b",
+    re.IGNORECASE,
+)
+
+_ATX_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*$")
+_TASK_BOX_RE = re.compile(r"^[ \t]*[-*+]\s+\[[ xX]\]\s+(.*)")
+_BULLET_RE = re.compile(r"^[ \t]*[-*+]\s+(.*)")
+_ORDERED_RE = re.compile(r"^[ \t]*\d+[.)]\s+(.*)")
+_CODE_FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
+
+
+def _has_normative(text: str) -> bool:
+    return bool(_NORMATIVE_RE.search(text))
+
+
+def _make_id(path: str, line: int) -> str:
+    stem = re.sub(r"[^a-z0-9]+", "-", Path(path).stem.lower()).strip("-")
+    return f"rule-{stem}-L{line}"
+
+
+def _heading_chain(stack: list[tuple[int, str]]) -> str | None:
+    if not stack:
+        return None
+    return " > ".join(title for _, title in stack)
+
+
+@dataclass
+class _Candidate:
+    text: str
+    line_start: int
+    heading: str | None
+
+
+def _is_block_start(line: str) -> bool:
+    """Return True if *line* begins a new block-level element."""
+    return bool(
+        not line.strip()
+        or _ATX_HEADING_RE.match(line)
+        or _CODE_FENCE_RE.match(line)
+        or _TASK_BOX_RE.match(line)
+        or _BULLET_RE.match(line)
+        or _ORDERED_RE.match(line)
+    )
+
+
+def parse(path: str, content: str) -> RuleSet:
+    """Extract candidate rules from Markdown *content* at *path*."""
+    lines = content.splitlines()
+    heading_stack: list[tuple[int, str]] = []
+    candidates: list[_Candidate] = []
+    in_code_fence = False
+    fence_char = ""
+
+    i = 0
+    while i < len(lines):
+        raw = lines[i]
+        line_no = i + 1  # 1-based
+
+        # Code-fence toggle — skip everything inside a fenced block.
+        fence_m = _CODE_FENCE_RE.match(raw)
+        if fence_m:
+            if not in_code_fence:
+                in_code_fence = True
+                fence_char = fence_m.group(1)[0]
+            elif raw.strip().startswith(fence_char * 3):
+                in_code_fence = False
+                fence_char = ""
+            i += 1
+            continue
+
+        if in_code_fence:
+            i += 1
+            continue
+
+        # ATX heading — update the heading stack; not a rule itself.
+        heading_m = _ATX_HEADING_RE.match(raw)
+        if heading_m:
+            level = len(heading_m.group(1))
+            title = heading_m.group(2)
+            while heading_stack and heading_stack[-1][0] >= level:
+                heading_stack.pop()
+            heading_stack.append((level, title))
+            i += 1
+            continue
+
+        heading = _heading_chain(heading_stack)
+
+        # Task checkbox — always a candidate regardless of normative keywords.
+        task_m = _TASK_BOX_RE.match(raw)
+        if task_m:
+            candidates.append(
+                _Candidate(
+                    text=task_m.group(1).strip(),
+                    line_start=line_no,
+                    heading=heading,
+                )
+            )
+            i += 1
+            continue
+
+        # Bullet list item — candidate only when it contains normative wording.
+        bullet_m = _BULLET_RE.match(raw)
+        if bullet_m:
+            text = bullet_m.group(1).strip()
+            if _has_normative(text):
+                candidates.append(
+                    _Candidate(text=text, line_start=line_no, heading=heading)
+                )
+            i += 1
+            continue
+
+        # Ordered list item — same policy as bullets.
+        ordered_m = _ORDERED_RE.match(raw)
+        if ordered_m:
+            text = ordered_m.group(1).strip()
+            if _has_normative(text):
+                candidates.append(
+                    _Candidate(text=text, line_start=line_no, heading=heading)
+                )
+            i += 1
+            continue
+
+        # Paragraph — collect continuation lines, then filter on normative keywords.
+        stripped = raw.strip()
+        if stripped:
+            para_start = line_no
+            parts = [stripped]
+            i += 1
+            while i < len(lines) and not _is_block_start(lines[i]):
+                nxt = lines[i].strip()
+                if nxt:
+                    parts.append(nxt)
+                i += 1
+            para_text = " ".join(parts)
+            if _has_normative(para_text):
+                candidates.append(
+                    _Candidate(
+                        text=para_text,
+                        line_start=para_start,
+                        heading=heading,
+                    )
+                )
+            continue
+
+        i += 1
+
+    rules = [
+        Rule(
+            id=_make_id(path, c.line_start),
+            title=c.text[:80],
+            source=SourceLocation(path=path, line=c.line_start, heading=c.heading),
+            text=c.text,
+            kind=RuleKind.SEMANTIC_RUBRIC,
+            severity=Severity.WARNING,
+            backend_hint=Backend.LLM_RUBRIC,
+            confidence=Confidence.LOW,
+            params={},
+        )
+        for c in candidates
+    ]
+    return RuleSet(rules=rules)
+
+
+def parse_file(path: str | Path) -> RuleSet:
+    """Parse a Markdown file and return the extracted rule set."""
+    p = Path(path)
+    return parse(str(p), p.read_text(encoding="utf-8"))

--- a/src/gate_keeper/parser.py
+++ b/src/gate_keeper/parser.py
@@ -32,7 +32,7 @@ _ATX_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*$")
 _TASK_BOX_RE = re.compile(r"^[ \t]*[-*+]\s+\[[ xX]\]\s+(.*)")
 _BULLET_RE = re.compile(r"^[ \t]*[-*+]\s+(.*)")
 _ORDERED_RE = re.compile(r"^[ \t]*\d+[.)]\s+(.*)")
-_CODE_FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
+_CODE_FENCE_RE = re.compile(r"^( {0,3})(`{3,}|~{3,})")
 
 
 def _has_normative(text: str) -> bool:
@@ -76,6 +76,7 @@ def parse(path: str, content: str) -> RuleSet:
     candidates: list[_Candidate] = []
     in_code_fence = False
     fence_char = ""
+    fence_len = 0
 
     i = 0
     while i < len(lines):
@@ -85,12 +86,15 @@ def parse(path: str, content: str) -> RuleSet:
         # Code-fence toggle — skip everything inside a fenced block.
         fence_m = _CODE_FENCE_RE.match(raw)
         if fence_m:
+            marker = fence_m.group(2)
             if not in_code_fence:
                 in_code_fence = True
-                fence_char = fence_m.group(1)[0]
-            elif raw.strip().startswith(fence_char * 3):
+                fence_char = marker[0]
+                fence_len = len(marker)
+            elif marker[0] == fence_char and len(marker) >= fence_len:
                 in_code_fence = False
                 fence_char = ""
+                fence_len = 0
             i += 1
             continue
 

--- a/tests/fixtures/parser/basic-rules.md
+++ b/tests/fixtures/parser/basic-rules.md
@@ -1,0 +1,28 @@
+# Contribution Rules
+
+All contributors must follow these guidelines.
+
+## Code Quality
+
+- Code must be reviewed before merging.
+- Tests should pass on all supported platforms.
+- Never commit secrets or credentials to the repository.
+- Comments are optional but encouraged.
+
+## Documentation
+
+1. Every public API must have a docstring.
+2. Examples should be accurate and runnable.
+3. Keep the README up to date.
+
+## Checklist Items
+
+- [ ] Tests pass
+- [x] Code reviewed
+- [ ] Documentation updated
+
+## Narrative Section
+
+This project started in 2024 as an internal tool.
+The team grew quickly and adopted open-source practices.
+We welcome contributions from the community.

--- a/tests/fixtures/parser/narrative-only.md
+++ b/tests/fixtures/parser/narrative-only.md
@@ -1,0 +1,17 @@
+# Project History
+
+This project started as an experiment in 2023.
+
+## Team
+
+The team is distributed across several time zones.
+We hold weekly syncs on Fridays.
+
+## Overview
+
+- The codebase uses Python.
+- Tests run via pytest.
+- CI is configured with GitHub Actions.
+
+1. The project has three main modules.
+2. Each module has its own test suite.

--- a/tests/fixtures/parser/normative-paragraphs.md
+++ b/tests/fixtures/parser/normative-paragraphs.md
@@ -1,0 +1,32 @@
+# Policy Document
+
+This document defines required behaviors for the system.
+
+## Authentication
+
+Users must authenticate before accessing any protected resource.
+Sessions must expire after 24 hours of inactivity.
+
+This paragraph has no normative content and should be ignored.
+
+## Authorization
+
+Access control should follow the principle of least privilege.
+Administrators must never share credentials with other users.
+
+## Code Fences Are Ignored
+
+```
+must not parse this line
+should not extract this either
+```
+
+~~~
+require this to be skipped too
+~~~
+
+## Nested Headings
+
+### Specific Rules
+
+The system must validate all inputs before processing.

--- a/tests/fixtures/parser/pr-checklist.md
+++ b/tests/fixtures/parser/pr-checklist.md
@@ -1,0 +1,14 @@
+# PR Merge Gates
+
+## Required Checks
+
+All of the following must be satisfied before merging.
+
+- [ ] CI checks pass
+- [ ] At least one non-author approval
+- [x] Branch is up to date with main
+- [ ] No blocking labels present
+
+## Advisory
+
+Consider adding a migration note if you changed the schema.

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,371 @@
+"""Tests for the Markdown rule document parser."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gate_keeper.models import Backend, Confidence, RuleKind, Severity
+from gate_keeper.parser import parse, parse_file
+
+FIXTURES = Path(__file__).parent / "fixtures" / "parser"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse(content: str) -> list:
+    return parse("test.md", content).rules
+
+
+def _texts(content: str) -> list[str]:
+    return [r.text for r in _parse(content)]
+
+
+# ---------------------------------------------------------------------------
+# ATX heading context
+# ---------------------------------------------------------------------------
+
+class TestHeadingContext:
+    def test_rule_under_heading_carries_heading(self):
+        md = "## Quality\n\n- Code must be reviewed.\n"
+        rules = _parse(md)
+        assert len(rules) == 1
+        assert rules[0].source.heading == "Quality"
+
+    def test_rule_under_nested_headings_uses_chain(self):
+        md = "# Top\n\n## Sub\n\n- Tests must pass.\n"
+        rules = _parse(md)
+        assert rules[0].source.heading == "Top > Sub"
+
+    def test_rule_before_any_heading_has_no_heading(self):
+        md = "- Code must be reviewed.\n"
+        rules = _parse(md)
+        assert rules[0].source.heading is None
+
+    def test_heading_resets_at_same_level(self):
+        md = "## Section A\n\n## Section B\n\n- Must follow B.\n"
+        rules = _parse(md)
+        assert rules[0].source.heading == "Section B"
+
+    def test_deeper_heading_nests_under_parent(self):
+        md = "# Root\n\n## Child\n\n### Grandchild\n\n- Must comply.\n"
+        rules = _parse(md)
+        assert rules[0].source.heading == "Root > Child > Grandchild"
+
+
+# ---------------------------------------------------------------------------
+# Bullet list rules
+# ---------------------------------------------------------------------------
+
+class TestBulletRules:
+    def test_normative_bullet_extracted(self):
+        texts = _texts("- Code must be reviewed.\n")
+        assert texts == ["Code must be reviewed."]
+
+    def test_non_normative_bullet_ignored(self):
+        assert _texts("- This is a note.\n") == []
+
+    def test_must_not_bullet_extracted(self):
+        texts = _texts("- You must not commit secrets.\n")
+        assert len(texts) == 1
+        assert "must not" in texts[0]
+
+    def test_should_not_bullet_extracted(self):
+        texts = _texts("- You should not skip tests.\n")
+        assert len(texts) == 1
+
+    def test_never_keyword_extracted(self):
+        texts = _texts("- Never push directly to main.\n")
+        assert len(texts) == 1
+
+    def test_required_keyword_extracted(self):
+        texts = _texts("- Tests are required before merge.\n")
+        assert len(texts) == 1
+
+    def test_forbidden_keyword_extracted(self):
+        texts = _texts("- Force-push is forbidden on main.\n")
+        assert len(texts) == 1
+
+    def test_fail_keyword_extracted(self):
+        texts = _texts("- Builds that fail must be fixed.\n")
+        assert len(texts) == 1
+
+    def test_block_keyword_extracted(self):
+        texts = _texts("- Unresolved threads block merging.\n")
+        assert len(texts) == 1
+
+    def test_ensure_keyword_extracted(self):
+        texts = _texts("- Ensure tests pass before review.\n")
+        assert len(texts) == 1
+
+    def test_require_keyword_extracted(self):
+        texts = _texts("- PR rules require an approval.\n")
+        assert len(texts) == 1
+
+    def test_case_insensitive_match(self):
+        texts = _texts("- MUST be reviewed.\n")
+        assert len(texts) == 1
+
+    def test_star_bullet(self):
+        texts = _texts("* Tests must pass.\n")
+        assert len(texts) == 1
+
+    def test_plus_bullet(self):
+        texts = _texts("+ Changes must be reviewed.\n")
+        assert len(texts) == 1
+
+    def test_multiple_normative_bullets(self):
+        md = "- Must review.\n- Should test.\n- Just a note.\n"
+        assert len(_texts(md)) == 2
+
+    def test_partial_word_not_matched(self):
+        # "required" inside "prerequisites" should not match
+        assert _texts("- Check all prerequisites.\n") == []
+
+
+# ---------------------------------------------------------------------------
+# Ordered list rules
+# ---------------------------------------------------------------------------
+
+class TestOrderedListRules:
+    def test_normative_ordered_item_extracted(self):
+        texts = _texts("1. Every PR must have a description.\n")
+        assert len(texts) == 1
+
+    def test_non_normative_ordered_item_ignored(self):
+        assert _texts("1. First step in the process.\n") == []
+
+    def test_ordered_item_with_period_delimiter(self):
+        texts = _texts("2. Tests should pass before review.\n")
+        assert len(texts) == 1
+
+    def test_ordered_item_with_paren_delimiter(self):
+        texts = _texts("3) PRs must be reviewed.\n")
+        assert len(texts) == 1
+
+    def test_ordered_list_heading_context(self):
+        md = "## Checks\n\n1. CI must succeed.\n"
+        rules = _parse(md)
+        assert rules[0].source.heading == "Checks"
+
+
+# ---------------------------------------------------------------------------
+# Task checkboxes
+# ---------------------------------------------------------------------------
+
+class TestTaskCheckboxes:
+    def test_unchecked_task_extracted(self):
+        texts = _texts("- [ ] Tests pass\n")
+        assert texts == ["Tests pass"]
+
+    def test_checked_task_extracted(self):
+        texts = _texts("- [x] Code reviewed\n")
+        assert texts == ["Code reviewed"]
+
+    def test_uppercase_x_extracted(self):
+        texts = _texts("- [X] Docs updated\n")
+        assert texts == ["Docs updated"]
+
+    def test_task_without_normative_keyword_still_extracted(self):
+        # Task checkboxes are always candidates — they encode intent by structure.
+        texts = _texts("- [ ] Deploy the release\n")
+        assert texts == ["Deploy the release"]
+
+    def test_task_heading_context(self):
+        md = "## Merge Gate\n\n- [ ] CI passes\n"
+        rules = _parse(md)
+        assert rules[0].source.heading == "Merge Gate"
+
+    def test_checked_and_unchecked_both_extracted(self):
+        md = "- [ ] Step one\n- [x] Step two\n"
+        assert len(_texts(md)) == 2
+
+
+# ---------------------------------------------------------------------------
+# Normative paragraphs
+# ---------------------------------------------------------------------------
+
+class TestNormativeParagraphs:
+    def test_normative_paragraph_extracted(self):
+        texts = _texts("Users must authenticate before accessing resources.\n")
+        assert len(texts) == 1
+
+    def test_non_normative_paragraph_ignored(self):
+        assert _texts("This project started in 2023.\n") == []
+
+    def test_multiline_paragraph_joined(self):
+        md = "Users must authenticate\nbefore accessing resources.\n"
+        rules = _parse(md)
+        assert len(rules) == 1
+        assert "Users must authenticate before accessing resources." == rules[0].text
+
+    def test_paragraph_heading_context(self):
+        md = "## Auth\n\nUsers must authenticate first.\n"
+        rules = _parse(md)
+        assert rules[0].source.heading == "Auth"
+
+    def test_paragraph_split_by_blank_line(self):
+        md = "First must pass.\n\nSecond should succeed.\n"
+        assert len(_parse(md)) == 2
+
+    def test_non_normative_paragraph_between_rules_ignored(self):
+        md = "Must do A.\n\nThis is just a note.\n\nMust do B.\n"
+        texts = _texts(md)
+        assert len(texts) == 2
+        assert "Must do A." in texts
+        assert "Must do B." in texts
+
+
+# ---------------------------------------------------------------------------
+# Code fence exclusion
+# ---------------------------------------------------------------------------
+
+class TestCodeFenceExclusion:
+    def test_backtick_fence_content_ignored(self):
+        md = "```\nmust not parse this\n```\n"
+        assert _texts(md) == []
+
+    def test_tilde_fence_content_ignored(self):
+        md = "~~~\nrequire this to be skipped\n~~~\n"
+        assert _texts(md) == []
+
+    def test_rule_before_and_after_fence_extracted(self):
+        md = "- Must pass.\n```\nmust not be here\n```\n- Should follow up.\n"
+        texts = _texts(md)
+        assert len(texts) == 2
+        assert "Must pass." in texts
+        assert "Should follow up." in texts
+
+    def test_long_fence_marker_handled(self):
+        md = "````\nmust not parse this\n````\n"
+        assert _texts(md) == []
+
+
+# ---------------------------------------------------------------------------
+# Source location metadata
+# ---------------------------------------------------------------------------
+
+class TestSourceLocation:
+    def test_line_number_is_one_based(self):
+        rules = _parse("- Must review.\n")
+        assert rules[0].source.line == 1
+
+    def test_line_number_of_second_rule(self):
+        md = "- Must review.\n- Should test.\n"
+        rules = _parse(md)
+        assert rules[1].source.line == 2
+
+    def test_line_number_after_heading(self):
+        md = "# Title\n\n- Must review.\n"
+        rules = _parse(md)
+        assert rules[0].source.line == 3
+
+    def test_paragraph_line_number_at_start(self):
+        md = "Line one.\nMust pass.\n"
+        rules = _parse(md)
+        assert rules[0].source.line == 1
+
+    def test_source_path_preserved(self):
+        rules = parse("docs/rules.md", "- Must follow.\n").rules
+        assert rules[0].source.path == "docs/rules.md"
+
+    def test_id_is_stable_for_same_input(self):
+        rules_a = _parse("- Must review.\n")
+        rules_b = _parse("- Must review.\n")
+        assert rules_a[0].id == rules_b[0].id
+
+    def test_ids_are_unique_within_ruleset(self):
+        md = "- Must review.\n- Should test.\n- Never skip.\n"
+        rules = _parse(md)
+        ids = [r.id for r in rules]
+        assert len(ids) == len(set(ids))
+
+
+# ---------------------------------------------------------------------------
+# IR field defaults
+# ---------------------------------------------------------------------------
+
+class TestIRDefaults:
+    def test_kind_is_semantic_rubric(self):
+        rules = _parse("- Must review.\n")
+        assert rules[0].kind is RuleKind.SEMANTIC_RUBRIC
+
+    def test_backend_hint_is_llm_rubric(self):
+        rules = _parse("- Must review.\n")
+        assert rules[0].backend_hint is Backend.LLM_RUBRIC
+
+    def test_confidence_is_low(self):
+        rules = _parse("- Must review.\n")
+        assert rules[0].confidence is Confidence.LOW
+
+    def test_severity_is_warning(self):
+        rules = _parse("- Must review.\n")
+        assert rules[0].severity is Severity.WARNING
+
+    def test_params_is_empty_dict(self):
+        rules = _parse("- Must review.\n")
+        assert rules[0].params == {}
+
+
+# ---------------------------------------------------------------------------
+# Fixture file integration
+# ---------------------------------------------------------------------------
+
+class TestFixtureFiles:
+    def test_basic_rules_fixture(self):
+        rules = parse_file(FIXTURES / "basic-rules.md").rules
+        texts = [r.text for r in rules]
+        # Three normative bullets + three task checkboxes; two normative ordered items
+        # Non-normative bullets and narrative ignored
+        normative_bullets = [t for t in texts if any(
+            kw in t.lower() for kw in ("must", "should", "never")
+        )]
+        assert len(normative_bullets) >= 3
+        # Task checkboxes always present regardless of keywords
+        task_texts = {"Tests pass", "Code reviewed", "Documentation updated"}
+        assert task_texts.issubset(set(texts))
+
+    def test_narrative_only_fixture_yields_no_rules(self):
+        rules = parse_file(FIXTURES / "narrative-only.md").rules
+        assert rules == []
+
+    def test_pr_checklist_fixture(self):
+        rules = parse_file(FIXTURES / "pr-checklist.md").rules
+        texts = [r.text for r in rules]
+        # Normative bullet + 4 task checkboxes
+        assert "CI checks pass" in texts
+        assert "At least one non-author approval" in texts
+        assert "Branch is up to date with main" in texts
+        assert "No blocking labels present" in texts
+        # Also the normative bullet "All of the following must be satisfied..."
+        normative = [t for t in texts if "must" in t.lower()]
+        assert len(normative) >= 1
+
+    def test_normative_paragraphs_fixture(self):
+        rules = parse_file(FIXTURES / "normative-paragraphs.md").rules
+        texts = [r.text for r in rules]
+        # Code fence content must not appear
+        assert not any("must not parse" in t for t in texts)
+        assert not any("should not extract" in t for t in texts)
+        # Normative paragraphs must appear
+        assert any("must authenticate" in t for t in texts)
+        assert any("must expire" in t or "must" in t for t in texts)
+
+    def test_fixture_rules_have_stable_ids(self):
+        rules_a = parse_file(FIXTURES / "basic-rules.md").rules
+        rules_b = parse_file(FIXTURES / "basic-rules.md").rules
+        assert [r.id for r in rules_a] == [r.id for r in rules_b]
+
+    def test_fixture_rules_have_correct_source_path(self):
+        fixture_path = FIXTURES / "basic-rules.md"
+        rules = parse_file(fixture_path).rules
+        for rule in rules:
+            assert rule.source.path == str(fixture_path)
+
+    def test_fixture_rules_heading_context_present(self):
+        rules = parse_file(FIXTURES / "basic-rules.md").rules
+        # Rules under "Code Quality" section should carry that heading
+        code_quality_rules = [r for r in rules if r.source.heading == "Contribution Rules > Code Quality"]
+        assert len(code_quality_rules) >= 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -242,6 +242,21 @@ class TestCodeFenceExclusion:
         md = "````\nmust not parse this\n````\n"
         assert _texts(md) == []
 
+    def test_indented_fence_skipped(self):
+        md = "   ```\nmust not parse this\n   ```\n"
+        assert _texts(md) == []
+
+    def test_short_close_does_not_end_long_fence(self):
+        # A ``` close must not terminate a ```` opener early.
+        md = "````\nmust not parse this\n```\nstill inside fence\n````\n"
+        assert _texts(md) == []
+
+    def test_longer_close_ends_long_fence(self):
+        # A ````` close is fine for a ```` opener (>= length).
+        md = "````\nmust not parse this\n`````\n- Must come after.\n"
+        texts = _texts(md)
+        assert texts == ["Must come after."]
+
 
 # ---------------------------------------------------------------------------
 # Source location metadata


### PR DESCRIPTION
## Summary

- Implements `src/gate_keeper/parser.py`: a line-oriented Markdown extractor with no AST library dependency.
- Parses ATX headings (tracks enclosing heading chain as context), bullet/ordered list items, task checkboxes (`- [ ]` / `- [x]`), and normative paragraphs.
- Normative keywords matched case-insensitively at word boundaries: `must`, `must not`, `should`, `should not`, `never`, `required`, `forbidden`, `fail`, `block`, `ensure`, `require`.
- Task checkboxes are always extracted; bullets, ordered items, and paragraphs require a normative keyword hit.
- Code-fenced blocks (backtick and tilde, any length ≥ 3) are skipped entirely.
- Each extracted item becomes one `Rule` with stable `id` (file stem + 1-based line), `title`, `source` (path, line, heading chain), and `text`; `kind`/`backend_hint` carry neutral defaults (`semantic_rubric` / `llm-rubric`) pending classification in issue #3.
- Adds four fixture Markdown files under `tests/fixtures/parser/` and 61 new tests in `tests/test_parser.py`.

Closes #2

## Validation

```
uv sync
uv run pytest
```

Results: **84 passed** (61 new parser tests + 23 pre-existing model/CLI tests) in 0.12 s, zero failures.