### PR TITLE
feat(classifier): add rule classification and backend hinting

### DIFF
--- a/src/gate_keeper/classifier.py
+++ b/src/gate_keeper/classifier.py
@@ -1,0 +1,198 @@
+"""Rule classifier: assigns kind, backend_hint, and confidence to parsed rules.
+
+Deterministic pattern-matching only — no LLM calls.
+Classification order within each backend tier: most-specific patterns first.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+
+from gate_keeper.models import Backend, Confidence, Rule, RuleKind, RuleSet
+
+# ---------------------------------------------------------------------------
+# GitHub patterns — ordered most-specific first within each tier
+# ---------------------------------------------------------------------------
+
+_DRAFT_RE = re.compile(r"\bdraft\b", re.IGNORECASE)
+
+_PR_OPEN_RE = re.compile(
+    r"\b(?:pr|pull\s+request)\b.{0,50}\bopen\b"
+    r"|\bnot\s+(?:be\s+)?(?:closed|merged)\b"
+    r"|\bpr\s+(?:state|status)\b",
+    re.IGNORECASE,
+)
+
+_CHECKS_HIGH_RE = re.compile(
+    r"\b(?:ci\s+checks?|status\s+checks?|checks?\s+(?:must\s+)?(?:pass|succeed|success)"
+    r"|build\s+(?:must\s+)?(?:pass|succeed|success))\b",
+    re.IGNORECASE,
+)
+_CHECKS_MEDIUM_RE = re.compile(r"\bchecks?\b", re.IGNORECASE)
+
+_THREADS_HIGH_RE = re.compile(
+    r"\b(?:review\s+threads?|unresolved\s+threads?|threads?\s+(?:must\s+)?(?:be\s+)?resolved)\b",
+    re.IGNORECASE,
+)
+
+_APPROVAL_HIGH_RE = re.compile(
+    r"\b(?:non.?author\s+(?:approval|reviewers?)|independent\s+(?:review|approval))\b",
+    re.IGNORECASE,
+)
+_APPROVAL_MEDIUM_RE = re.compile(r"\b(?:approval|approved|reviewer|approves?)\b", re.IGNORECASE)
+
+_LABELS_HIGH_RE = re.compile(
+    r"\b(?:blocking\s+labels?|labels?\s+absent|no\s+(?:blocking\s+)?labels?|do.not.merge|needs.decision)\b",
+    re.IGNORECASE,
+)
+_LABELS_MEDIUM_RE = re.compile(r"\blabels?\b", re.IGNORECASE)
+
+_PR_TASK_HIGH_RE = re.compile(
+    r"\b(?:pr|pull\s+request)\b.{0,40}\b(?:tasks?|checkboxes?|checklists?)\b",
+    re.IGNORECASE,
+)
+
+# Heading that signals this item belongs to a PR/GitHub section
+_PR_HEADING_RE = re.compile(
+    r"\b(?:pr|pull\s+request|merge\s+gate|merge\s+check|github)\b",
+    re.IGNORECASE,
+)
+
+# ---------------------------------------------------------------------------
+# Filesystem patterns
+# ---------------------------------------------------------------------------
+
+_FILE_ABSENT_HIGH_RE = re.compile(
+    r"\bfile\b.{0,40}\b(?:must\s+not\s+exist|should\s+not\s+exist|is\s+absent"
+    r"|must\s+be\s+(?:absent|removed|deleted))\b"
+    r"|\b(?:must\s+not\s+exist|is\s+absent)\b.{0,40}\bfile\b",
+    re.IGNORECASE,
+)
+
+_FILE_EXISTS_HIGH_RE = re.compile(
+    r"\bfile\b.{0,40}\b(?:must\s+exist|should\s+exist|exists?|must\s+be\s+present"
+    r"|is\s+(?:required|present))\b"
+    r"|\b(?:must\s+exist|should\s+exist)\b.{0,40}\bfile\b",
+    re.IGNORECASE,
+)
+
+_TEXT_FORBIDDEN_HIGH_RE = re.compile(
+    r"\b(?:must\s+not|should\s+not|never)\s+(?:contain|include)\b"
+    r"|\bforbidden\s+text\b|\btext\s+forbidden\b",
+    re.IGNORECASE,
+)
+
+_TEXT_REQUIRED_HIGH_RE = re.compile(
+    r"\b(?:must|should)\s+(?:contain|include)\b"
+    r"|\b(?:required|mandatory)\s+text\b|\btext\s+(?:required|mandatory)\b",
+    re.IGNORECASE,
+)
+
+_PATH_MEDIUM_RE = re.compile(r"\b(?:path|glob|filename|directory|folder)\b", re.IGNORECASE)
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _make(
+    rule: Rule,
+    kind: RuleKind,
+    backend: Backend,
+    confidence: Confidence,
+    explanation: str,
+) -> Rule:
+    params = {**rule.params, "classifier_explanation": explanation}
+    return replace(rule, kind=kind, backend_hint=backend, confidence=confidence, params=params)
+
+
+def _classify_rule(rule: Rule) -> Rule:
+    text = rule.text
+    heading = rule.source.heading or ""
+
+    # --- High-confidence GitHub ---
+    if _DRAFT_RE.search(text):
+        return _make(rule, RuleKind.GITHUB_NOT_DRAFT, Backend.GITHUB, Confidence.HIGH,
+                     "explicit 'draft' keyword")
+
+    if _PR_OPEN_RE.search(text):
+        return _make(rule, RuleKind.GITHUB_PR_OPEN, Backend.GITHUB, Confidence.HIGH,
+                     "explicit PR open-state reference")
+
+    if _CHECKS_HIGH_RE.search(text):
+        return _make(rule, RuleKind.GITHUB_CHECKS_SUCCESS, Backend.GITHUB, Confidence.HIGH,
+                     "explicit CI/status-check keyword")
+
+    if _THREADS_HIGH_RE.search(text):
+        return _make(rule, RuleKind.GITHUB_THREADS_RESOLVED, Backend.GITHUB, Confidence.HIGH,
+                     "explicit review-thread or resolved-thread keyword")
+
+    if _APPROVAL_HIGH_RE.search(text):
+        return _make(rule, RuleKind.GITHUB_NON_AUTHOR_APPROVAL, Backend.GITHUB, Confidence.HIGH,
+                     "explicit non-author-approval or independent-review keyword")
+
+    if _LABELS_HIGH_RE.search(text):
+        return _make(rule, RuleKind.GITHUB_LABELS_ABSENT, Backend.GITHUB, Confidence.HIGH,
+                     "explicit blocking-label or do-not-merge keyword")
+
+    if _PR_TASK_HIGH_RE.search(text):
+        return _make(rule, RuleKind.GITHUB_TASKS_COMPLETE, Backend.GITHUB, Confidence.HIGH,
+                     "explicit PR task/checklist reference")
+
+    # --- Medium-confidence GitHub ---
+    if _APPROVAL_MEDIUM_RE.search(text):
+        return _make(rule, RuleKind.GITHUB_NON_AUTHOR_APPROVAL, Backend.GITHUB, Confidence.MEDIUM,
+                     "approval/reviewer keyword without explicit non-author phrasing")
+
+    if _LABELS_MEDIUM_RE.search(text):
+        return _make(rule, RuleKind.GITHUB_LABELS_ABSENT, Backend.GITHUB, Confidence.MEDIUM,
+                     "label keyword without explicit blocking context")
+
+    if _CHECKS_MEDIUM_RE.search(text) and _PR_HEADING_RE.search(heading):
+        return _make(rule, RuleKind.GITHUB_CHECKS_SUCCESS, Backend.GITHUB, Confidence.MEDIUM,
+                     "check keyword under a PR/merge-gate heading")
+
+    # Any item under a PR/merge-gate heading with no stronger signal → GitHub task
+    if _PR_HEADING_RE.search(heading):
+        return _make(rule, RuleKind.GITHUB_TASKS_COMPLETE, Backend.GITHUB, Confidence.MEDIUM,
+                     "item under a PR/merge-gate heading with no stronger signal")
+
+    # --- High-confidence filesystem ---
+    if _FILE_ABSENT_HIGH_RE.search(text):
+        return _make(rule, RuleKind.FILE_ABSENT, Backend.FILESYSTEM, Confidence.HIGH,
+                     "explicit file-absent or must-not-exist wording")
+
+    if _FILE_EXISTS_HIGH_RE.search(text):
+        return _make(rule, RuleKind.FILE_EXISTS, Backend.FILESYSTEM, Confidence.HIGH,
+                     "explicit file-exists or must-exist wording")
+
+    if _TEXT_FORBIDDEN_HIGH_RE.search(text):
+        return _make(rule, RuleKind.TEXT_FORBIDDEN, Backend.FILESYSTEM, Confidence.HIGH,
+                     "explicit must-not-contain or forbidden-text wording")
+
+    if _TEXT_REQUIRED_HIGH_RE.search(text):
+        return _make(rule, RuleKind.TEXT_REQUIRED, Backend.FILESYSTEM, Confidence.HIGH,
+                     "explicit must-contain or text-required wording")
+
+    # --- Medium-confidence filesystem ---
+    if _PATH_MEDIUM_RE.search(text):
+        return _make(rule, RuleKind.PATH_MATCHES, Backend.FILESYSTEM, Confidence.MEDIUM,
+                     "path/directory keyword without explicit existence predicate")
+
+    # --- Fallback: ambiguous semantic judgement ---
+    return rule  # retains semantic_rubric / llm-rubric / low confidence from parser
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def classify(ruleset: RuleSet) -> RuleSet:
+    """Classify all rules in *ruleset*, returning a new RuleSet with updated kind/backend/confidence."""
+    return RuleSet(rules=[_classify_rule(rule) for rule in ruleset.rules])
+
+
+def classify_rule(rule: Rule) -> Rule:
+    """Classify a single rule, returning a new Rule with updated kind/backend/confidence."""
+    return _classify_rule(rule)

--- a/src/gate_keeper/classifier.py
+++ b/src/gate_keeper/classifier.py
@@ -1,7 +1,10 @@
 """Rule classifier: assigns kind, backend_hint, and confidence to parsed rules.
 
 Deterministic pattern-matching only — no LLM calls.
-Classification order within each backend tier: most-specific patterns first.
+Classification order: high-confidence GitHub first (explicit keywords), then
+high-confidence filesystem (explicit predicates), then weaker heuristics, and
+finally semantic fallback. Filesystem checks run before the PR-heading catch-all
+so that file/text rules embedded in PR documents still route to the right backend.
 """
 from __future__ import annotations
 
@@ -14,7 +17,15 @@ from gate_keeper.models import Backend, Confidence, Rule, RuleKind, RuleSet
 # GitHub patterns — ordered most-specific first within each tier
 # ---------------------------------------------------------------------------
 
-_DRAFT_RE = re.compile(r"\bdraft\b", re.IGNORECASE)
+# Draft: require PR/pull-request context or explicit "not a draft" phrasing to
+# avoid matching "The draft configuration file must exist" as a GitHub rule.
+_DRAFT_RE = re.compile(
+    r"\b(?:pr|pull\s+request)\b.{0,60}\bdraft\b"
+    r"|\bdraft\b.{0,60}\b(?:pr|pull\s+request)\b"
+    r"|\bnot\s+(?:be\s+)?(?:a\s+)?draft\b"
+    r"|\bin\s+draft\s+(?:state|mode)\b",
+    re.IGNORECASE,
+)
 
 _PR_OPEN_RE = re.compile(
     r"\b(?:pr|pull\s+request)\b.{0,50}\bopen\b"
@@ -62,17 +73,18 @@ _PR_HEADING_RE = re.compile(
 # Filesystem patterns
 # ---------------------------------------------------------------------------
 
+# Match the predicate phrase directly rather than requiring the literal word
+# "file", so that "README.md must exist" is caught alongside "CHANGELOG file
+# must exist". GitHub patterns run first, so PR-state predicates are already
+# handled when we reach these checks.
 _FILE_ABSENT_HIGH_RE = re.compile(
-    r"\bfile\b.{0,40}\b(?:must\s+not\s+exist|should\s+not\s+exist|is\s+absent"
-    r"|must\s+be\s+(?:absent|removed|deleted))\b"
-    r"|\b(?:must\s+not\s+exist|is\s+absent)\b.{0,40}\bfile\b",
+    r"\b(?:must\s+not\s+exist|should\s+not\s+exist"
+    r"|must\s+be\s+(?:absent|removed|deleted)|is\s+absent)\b",
     re.IGNORECASE,
 )
 
 _FILE_EXISTS_HIGH_RE = re.compile(
-    r"\bfile\b.{0,40}\b(?:must\s+exist|should\s+exist|exists?|must\s+be\s+present"
-    r"|is\s+(?:required|present))\b"
-    r"|\b(?:must\s+exist|should\s+exist)\b.{0,40}\bfile\b",
+    r"\b(?:must\s+exist|should\s+exist|must\s+be\s+present|is\s+(?:required|present))\b",
     re.IGNORECASE,
 )
 
@@ -89,6 +101,15 @@ _TEXT_REQUIRED_HIGH_RE = re.compile(
 )
 
 _PATH_MEDIUM_RE = re.compile(r"\b(?:path|glob|filename|directory|folder)\b", re.IGNORECASE)
+
+# Mirrors the parser's normative-keyword set; absence of a normative keyword
+# means the rule came from a bare task-checkbox line (bullets and paragraphs
+# require a normative keyword to be extracted).
+_NORMATIVE_RE = re.compile(
+    r"\b(?:must\s+not|should\s+not|must|should|never|required|forbidden"
+    r"|fail|block|ensure|require)\b",
+    re.IGNORECASE,
+)
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -113,7 +134,7 @@ def _classify_rule(rule: Rule) -> Rule:
     # --- High-confidence GitHub ---
     if _DRAFT_RE.search(text):
         return _make(rule, RuleKind.GITHUB_NOT_DRAFT, Backend.GITHUB, Confidence.HIGH,
-                     "explicit 'draft' keyword")
+                     "explicit PR draft-state keyword")
 
     if _PR_OPEN_RE.search(text):
         return _make(rule, RuleKind.GITHUB_PR_OPEN, Backend.GITHUB, Confidence.HIGH,
@@ -139,7 +160,7 @@ def _classify_rule(rule: Rule) -> Rule:
         return _make(rule, RuleKind.GITHUB_TASKS_COMPLETE, Backend.GITHUB, Confidence.HIGH,
                      "explicit PR task/checklist reference")
 
-    # --- Medium-confidence GitHub ---
+    # --- Medium-confidence GitHub (keyword signals without full explicit phrasing) ---
     if _APPROVAL_MEDIUM_RE.search(text):
         return _make(rule, RuleKind.GITHUB_NON_AUTHOR_APPROVAL, Backend.GITHUB, Confidence.MEDIUM,
                      "approval/reviewer keyword without explicit non-author phrasing")
@@ -152,19 +173,15 @@ def _classify_rule(rule: Rule) -> Rule:
         return _make(rule, RuleKind.GITHUB_CHECKS_SUCCESS, Backend.GITHUB, Confidence.MEDIUM,
                      "check keyword under a PR/merge-gate heading")
 
-    # Any item under a PR/merge-gate heading with no stronger signal → GitHub task
-    if _PR_HEADING_RE.search(heading):
-        return _make(rule, RuleKind.GITHUB_TASKS_COMPLETE, Backend.GITHUB, Confidence.MEDIUM,
-                     "item under a PR/merge-gate heading with no stronger signal")
-
-    # --- High-confidence filesystem ---
+    # --- High-confidence filesystem (checked before the PR-heading heuristic so
+    #     that explicit file/text rules under a PR section route to filesystem) ---
     if _FILE_ABSENT_HIGH_RE.search(text):
         return _make(rule, RuleKind.FILE_ABSENT, Backend.FILESYSTEM, Confidence.HIGH,
-                     "explicit file-absent or must-not-exist wording")
+                     "explicit must-not-exist or is-absent predicate")
 
     if _FILE_EXISTS_HIGH_RE.search(text):
         return _make(rule, RuleKind.FILE_EXISTS, Backend.FILESYSTEM, Confidence.HIGH,
-                     "explicit file-exists or must-exist wording")
+                     "explicit must-exist or must-be-present predicate")
 
     if _TEXT_FORBIDDEN_HIGH_RE.search(text):
         return _make(rule, RuleKind.TEXT_FORBIDDEN, Backend.FILESYSTEM, Confidence.HIGH,
@@ -178,6 +195,18 @@ def _classify_rule(rule: Rule) -> Rule:
     if _PATH_MEDIUM_RE.search(text):
         return _make(rule, RuleKind.PATH_MATCHES, Backend.FILESYSTEM, Confidence.MEDIUM,
                      "path/directory keyword without explicit existence predicate")
+
+    # --- PR/GitHub heading heuristic (no stronger signal matched above) ---
+    if _PR_HEADING_RE.search(heading):
+        return _make(rule, RuleKind.GITHUB_TASKS_COMPLETE, Backend.GITHUB, Confidence.MEDIUM,
+                     "item under a PR/merge-gate heading with no stronger signal")
+
+    # --- Bare task-checkbox heuristic ---
+    # Rules without a normative keyword can only have been emitted by the parser
+    # from a task-checkbox line (bullets and paragraphs require normative keywords).
+    if not _NORMATIVE_RE.search(text):
+        return _make(rule, RuleKind.MARKDOWN_TASKS_COMPLETE, Backend.FILESYSTEM, Confidence.MEDIUM,
+                     "no normative keyword — likely a bare task-checkbox item")
 
     # --- Fallback: ambiguous semantic judgement ---
     return rule  # retains semantic_rubric / llm-rubric / low confidence from parser

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,391 @@
+"""Tests for the rule classifier."""
+from __future__ import annotations
+
+import pytest
+
+from gate_keeper.classifier import classify, classify_rule
+from gate_keeper.models import Backend, Confidence, RuleKind, Severity, SourceLocation, Rule
+from gate_keeper.parser import parse
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_rule(text: str, heading: str | None = None) -> Rule:
+    """Construct a bare parser-default Rule for unit testing the classifier."""
+    return Rule(
+        id="rule-test-L1",
+        title=text[:80],
+        source=SourceLocation(path="test.md", line=1, heading=heading),
+        text=text,
+        kind=RuleKind.SEMANTIC_RUBRIC,
+        severity=Severity.WARNING,
+        backend_hint=Backend.LLM_RUBRIC,
+        confidence=Confidence.LOW,
+        params={},
+    )
+
+
+def _classify_text(text: str, heading: str | None = None) -> Rule:
+    return classify_rule(_make_rule(text, heading))
+
+
+def _parse_and_classify(md: str) -> list[Rule]:
+    return classify(parse("test.md", md)).rules
+
+
+# ---------------------------------------------------------------------------
+# GitHub routing — high confidence
+# ---------------------------------------------------------------------------
+
+
+class TestGithubHighConfidence:
+    def test_draft_routes_to_github(self):
+        rule = _classify_text("PR must not be in draft state")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_NOT_DRAFT
+        assert rule.confidence is Confidence.HIGH
+
+    def test_not_draft_phrasing(self):
+        rule = _classify_text("The pull request must not be a draft")
+        assert rule.kind is RuleKind.GITHUB_NOT_DRAFT
+        assert rule.confidence is Confidence.HIGH
+
+    def test_pr_open_routes_to_github(self):
+        rule = _classify_text("The PR must be open (not closed or merged)")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_PR_OPEN
+        assert rule.confidence is Confidence.HIGH
+
+    def test_not_merged_routes_to_pr_open(self):
+        rule = _classify_text("Branch must not be merged before review")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_PR_OPEN
+        assert rule.confidence is Confidence.HIGH
+
+    def test_ci_checks_pass_routes_to_github(self):
+        rule = _classify_text("CI checks must pass before merging")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_CHECKS_SUCCESS
+        assert rule.confidence is Confidence.HIGH
+
+    def test_status_checks_succeed_routes_to_github(self):
+        rule = _classify_text("All status checks must succeed")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_CHECKS_SUCCESS
+        assert rule.confidence is Confidence.HIGH
+
+    def test_build_must_pass_routes_to_github(self):
+        rule = _classify_text("The build must pass before the PR can be merged")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_CHECKS_SUCCESS
+        assert rule.confidence is Confidence.HIGH
+
+    def test_review_threads_resolved_routes_to_github(self):
+        rule = _classify_text("All review threads must be resolved before merging")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_THREADS_RESOLVED
+        assert rule.confidence is Confidence.HIGH
+
+    def test_unresolved_threads_routes_to_github(self):
+        rule = _classify_text("Unresolved threads block merging")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_THREADS_RESOLVED
+        assert rule.confidence is Confidence.HIGH
+
+    def test_non_author_approval_routes_to_github(self):
+        rule = _classify_text("At least one non-author approval is required")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_NON_AUTHOR_APPROVAL
+        assert rule.confidence is Confidence.HIGH
+
+    def test_independent_review_routes_to_github(self):
+        rule = _classify_text("An independent review must be completed")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_NON_AUTHOR_APPROVAL
+        assert rule.confidence is Confidence.HIGH
+
+    def test_blocking_labels_absent_routes_to_github(self):
+        rule = _classify_text("No blocking labels must be present before merge")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_LABELS_ABSENT
+        assert rule.confidence is Confidence.HIGH
+
+    def test_do_not_merge_label_routes_to_github(self):
+        rule = _classify_text("The do-not-merge label must not be applied")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_LABELS_ABSENT
+        assert rule.confidence is Confidence.HIGH
+
+
+# ---------------------------------------------------------------------------
+# GitHub routing — medium confidence
+# ---------------------------------------------------------------------------
+
+
+class TestGithubMediumConfidence:
+    def test_approval_alone_is_medium(self):
+        rule = _classify_text("An approval is required before merge")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_NON_AUTHOR_APPROVAL
+        assert rule.confidence is Confidence.MEDIUM
+
+    def test_reviewer_keyword_is_medium(self):
+        rule = _classify_text("A reviewer must sign off on each PR")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_NON_AUTHOR_APPROVAL
+        assert rule.confidence is Confidence.MEDIUM
+
+    def test_label_alone_is_medium(self):
+        rule = _classify_text("Labels must be verified before merging")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_LABELS_ABSENT
+        assert rule.confidence is Confidence.MEDIUM
+
+    def test_item_under_pr_heading_is_medium(self):
+        rule = _classify_text(
+            "Branch is up to date with main",
+            heading="PR Merge Gates > Required Checks",
+        )
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.confidence is Confidence.MEDIUM
+
+    def test_item_under_merge_gate_heading_is_medium(self):
+        rule = _classify_text(
+            "Documentation is up to date",
+            heading="Merge Gate",
+        )
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.confidence is Confidence.MEDIUM
+
+
+# ---------------------------------------------------------------------------
+# Filesystem routing — high confidence
+# ---------------------------------------------------------------------------
+
+
+class TestFilesystemHighConfidence:
+    def test_file_exists_routes_to_filesystem(self):
+        rule = _classify_text("The CHANGELOG file must exist before release")
+        assert rule.backend_hint is Backend.FILESYSTEM
+        assert rule.kind is RuleKind.FILE_EXISTS
+        assert rule.confidence is Confidence.HIGH
+
+    def test_file_must_be_present_routes_to_filesystem(self):
+        rule = _classify_text("A LICENSE file must be present in the repository")
+        assert rule.backend_hint is Backend.FILESYSTEM
+        assert rule.kind is RuleKind.FILE_EXISTS
+        assert rule.confidence is Confidence.HIGH
+
+    def test_file_absent_routes_to_filesystem(self):
+        rule = _classify_text("The debug.log file must not exist in production")
+        assert rule.backend_hint is Backend.FILESYSTEM
+        assert rule.kind is RuleKind.FILE_ABSENT
+        assert rule.confidence is Confidence.HIGH
+
+    def test_file_must_be_removed_routes_to_filesystem(self):
+        rule = _classify_text("The temp file must be absent before deployment")
+        assert rule.backend_hint is Backend.FILESYSTEM
+        assert rule.kind is RuleKind.FILE_ABSENT
+        assert rule.confidence is Confidence.HIGH
+
+    def test_text_required_routes_to_filesystem(self):
+        rule = _classify_text("The README must contain a usage section")
+        assert rule.backend_hint is Backend.FILESYSTEM
+        assert rule.kind is RuleKind.TEXT_REQUIRED
+        assert rule.confidence is Confidence.HIGH
+
+    def test_text_must_include_routes_to_filesystem(self):
+        rule = _classify_text("The config file should include a version field")
+        assert rule.backend_hint is Backend.FILESYSTEM
+        assert rule.kind is RuleKind.TEXT_REQUIRED
+        assert rule.confidence is Confidence.HIGH
+
+    def test_text_forbidden_routes_to_filesystem(self):
+        rule = _classify_text("The codebase must not contain TODO comments before release")
+        assert rule.backend_hint is Backend.FILESYSTEM
+        assert rule.kind is RuleKind.TEXT_FORBIDDEN
+        assert rule.confidence is Confidence.HIGH
+
+    def test_must_not_include_routes_to_filesystem(self):
+        rule = _classify_text("Source files should not include debug statements")
+        assert rule.backend_hint is Backend.FILESYSTEM
+        assert rule.kind is RuleKind.TEXT_FORBIDDEN
+        assert rule.confidence is Confidence.HIGH
+
+
+# ---------------------------------------------------------------------------
+# Filesystem routing — medium confidence
+# ---------------------------------------------------------------------------
+
+
+class TestFilesystemMediumConfidence:
+    def test_path_mention_is_medium(self):
+        rule = _classify_text("The output path must follow the naming convention")
+        assert rule.backend_hint is Backend.FILESYSTEM
+        assert rule.kind is RuleKind.PATH_MATCHES
+        assert rule.confidence is Confidence.MEDIUM
+
+    def test_directory_mention_is_medium(self):
+        rule = _classify_text("The build directory must be named correctly")
+        assert rule.backend_hint is Backend.FILESYSTEM
+        assert rule.kind is RuleKind.PATH_MATCHES
+        assert rule.confidence is Confidence.MEDIUM
+
+
+# ---------------------------------------------------------------------------
+# LLM rubric fallback — low confidence
+# ---------------------------------------------------------------------------
+
+
+class TestLLMRubricFallback:
+    def test_ambiguous_quality_rule_falls_back(self):
+        rule = _classify_text("Code quality must be adequate for the project standards")
+        assert rule.backend_hint is Backend.LLM_RUBRIC
+        assert rule.kind is RuleKind.SEMANTIC_RUBRIC
+        assert rule.confidence is Confidence.LOW
+
+    def test_vague_process_rule_falls_back(self):
+        rule = _classify_text("The team must follow agreed-upon conventions")
+        assert rule.backend_hint is Backend.LLM_RUBRIC
+        assert rule.kind is RuleKind.SEMANTIC_RUBRIC
+        assert rule.confidence is Confidence.LOW
+
+    def test_commit_secrets_rule_falls_back(self):
+        # "Never commit secrets" — intent is clear but the evidence is semantic
+        rule = _classify_text("Never commit secrets or credentials to the repository")
+        assert rule.backend_hint is Backend.LLM_RUBRIC
+        assert rule.kind is RuleKind.SEMANTIC_RUBRIC
+        assert rule.confidence is Confidence.LOW
+
+
+# ---------------------------------------------------------------------------
+# Integration: parser output fed directly into the classifier
+# ---------------------------------------------------------------------------
+
+
+class TestParserIntegration:
+    def test_pr_checklist_items_classify_correctly(self):
+        md = (
+            "# PR Merge Gates\n\n"
+            "## Required Checks\n\n"
+            "All of the following must be satisfied before merging.\n\n"
+            "- [ ] CI checks pass\n"
+            "- [ ] At least one non-author approval\n"
+            "- [x] Branch is up to date with main\n"
+            "- [ ] No blocking labels present\n"
+        )
+        rules = _parse_and_classify(md)
+        by_text = {r.text: r for r in rules}
+
+        ci = by_text["CI checks pass"]
+        assert ci.backend_hint is Backend.GITHUB
+        assert ci.kind is RuleKind.GITHUB_CHECKS_SUCCESS
+        assert ci.confidence is Confidence.HIGH
+
+        approval = by_text["At least one non-author approval"]
+        assert approval.backend_hint is Backend.GITHUB
+        assert approval.kind is RuleKind.GITHUB_NON_AUTHOR_APPROVAL
+        assert approval.confidence is Confidence.HIGH
+
+        labels = by_text["No blocking labels present"]
+        assert labels.backend_hint is Backend.GITHUB
+        assert labels.kind is RuleKind.GITHUB_LABELS_ABSENT
+        assert labels.confidence is Confidence.HIGH
+
+        # "Branch is up to date with main" has no specific pattern → medium via heading
+        branch = by_text["Branch is up to date with main"]
+        assert branch.backend_hint is Backend.GITHUB
+        assert branch.confidence is Confidence.MEDIUM
+
+    def test_file_rule_integration(self):
+        md = "- The CHANGELOG file must exist in the repo root.\n"
+        rules = _parse_and_classify(md)
+        assert len(rules) == 1
+        assert rules[0].backend_hint is Backend.FILESYSTEM
+        assert rules[0].kind is RuleKind.FILE_EXISTS
+        assert rules[0].confidence is Confidence.HIGH
+
+    def test_semantic_rule_remains_low(self):
+        md = "- Code quality must meet team standards.\n"
+        rules = _parse_and_classify(md)
+        assert len(rules) == 1
+        assert rules[0].backend_hint is Backend.LLM_RUBRIC
+        assert rules[0].kind is RuleKind.SEMANTIC_RUBRIC
+        assert rules[0].confidence is Confidence.LOW
+
+    def test_mixed_ruleset_preserves_all_rules(self):
+        md = (
+            "- The CHANGELOG file must exist.\n"
+            "- CI checks must pass.\n"
+            "- Code quality must meet standards.\n"
+        )
+        rules = _parse_and_classify(md)
+        assert len(rules) == 3
+        backends = {r.backend_hint for r in rules}
+        assert Backend.FILESYSTEM in backends
+        assert Backend.GITHUB in backends
+        assert Backend.LLM_RUBRIC in backends
+
+
+# ---------------------------------------------------------------------------
+# Explanation is stored in params for classified rules
+# ---------------------------------------------------------------------------
+
+
+class TestExplanationInParams:
+    def test_classified_rule_has_explanation(self):
+        rule = _classify_text("PR must not be in draft state")
+        assert "classifier_explanation" in rule.params
+        assert isinstance(rule.params["classifier_explanation"], str)
+        assert len(rule.params["classifier_explanation"]) > 0
+
+    def test_fallback_rule_has_no_explanation(self):
+        # Parser default is returned as-is; no explanation is injected
+        rule = _classify_text("Code quality must be adequate")
+        assert "classifier_explanation" not in rule.params
+
+
+# ---------------------------------------------------------------------------
+# Low-confidence rules remain visible — not dropped
+# ---------------------------------------------------------------------------
+
+
+class TestLowConfidenceVisible:
+    def test_low_confidence_rules_present_in_mixed_ruleset(self):
+        md = (
+            "- CI checks must pass.\n"
+            "- Code quality must meet team standards.\n"
+        )
+        rules = _parse_and_classify(md)
+        confidences = {r.confidence for r in rules}
+        assert Confidence.HIGH in confidences
+        assert Confidence.LOW in confidences
+        low = [r for r in rules if r.confidence is Confidence.LOW]
+        assert len(low) == 1
+        assert low[0].backend_hint is Backend.LLM_RUBRIC
+
+    def test_high_medium_low_all_represented(self):
+        md = (
+            "- CI checks must pass.\n"                          # HIGH github
+            "- An approval is required before merge.\n"         # MEDIUM github
+            "- Code quality must be adequate.\n"                # LOW llm-rubric
+        )
+        rules = _parse_and_classify(md)
+        conf_map = {r.confidence for r in rules}
+        assert Confidence.HIGH in conf_map
+        assert Confidence.MEDIUM in conf_map
+        assert Confidence.LOW in conf_map
+
+    def test_classify_preserves_rule_count(self):
+        md = (
+            "- Must review.\n"
+            "- Should test.\n"
+            "- Never skip CI.\n"
+            "- The README file must exist.\n"
+        )
+        original = parse("test.md", md)
+        classified = classify(original)
+        assert len(classified.rules) == len(original.rules)

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,8 +1,6 @@
 """Tests for the rule classifier."""
 from __future__ import annotations
 
-import pytest
-
 from gate_keeper.classifier import classify, classify_rule
 from gate_keeper.models import Backend, Confidence, RuleKind, Severity, SourceLocation, Rule
 from gate_keeper.parser import parse
@@ -389,3 +387,95 @@ class TestLowConfidenceVisible:
         original = parse("test.md", md)
         classified = classify(original)
         assert len(classified.rules) == len(original.rules)
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 fix: filesystem rules win over PR-heading heuristic
+# ---------------------------------------------------------------------------
+
+
+class TestFilesystemBeforePRHeadingHeuristic:
+    def test_file_exists_under_pr_heading_routes_to_filesystem(self):
+        # A file-existence rule nested under a PR heading must NOT be
+        # misrouted to GITHUB_TASKS_COMPLETE by the heading heuristic.
+        rule = _classify_text(
+            "The CHANGELOG file must exist before merging",
+            heading="PR Merge Gates > Required Checks",
+        )
+        assert rule.backend_hint is Backend.FILESYSTEM
+        assert rule.kind is RuleKind.FILE_EXISTS
+        assert rule.confidence is Confidence.HIGH
+
+    def test_text_required_under_pr_heading_routes_to_filesystem(self):
+        rule = _classify_text(
+            "The README must contain a summary section",
+            heading="PR Merge Gates",
+        )
+        assert rule.backend_hint is Backend.FILESYSTEM
+        assert rule.kind is RuleKind.TEXT_REQUIRED
+        assert rule.confidence is Confidence.HIGH
+
+    def test_readme_must_exist_no_file_word(self):
+        # Existence predicate without the word "file" should still match.
+        rule = _classify_text("README.md must exist in the repo root")
+        assert rule.backend_hint is Backend.FILESYSTEM
+        assert rule.kind is RuleKind.FILE_EXISTS
+        assert rule.confidence is Confidence.HIGH
+
+    def test_file_absent_no_file_word(self):
+        rule = _classify_text("debug.log must not exist in production")
+        assert rule.backend_hint is Backend.FILESYSTEM
+        assert rule.kind is RuleKind.FILE_ABSENT
+        assert rule.confidence is Confidence.HIGH
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 fix: bare task-checkbox items route to MARKDOWN_TASKS_COMPLETE
+# ---------------------------------------------------------------------------
+
+
+class TestBareCheckboxRouting:
+    def test_bare_checkbox_routes_to_markdown_tasks(self):
+        # A checkbox with no normative keyword and no PR heading routes
+        # to MARKDOWN_TASKS_COMPLETE / filesystem rather than llm-rubric.
+        rule = _classify_text("Update README")
+        assert rule.backend_hint is Backend.FILESYSTEM
+        assert rule.kind is RuleKind.MARKDOWN_TASKS_COMPLETE
+        assert rule.confidence is Confidence.MEDIUM
+
+    def test_bare_checkbox_integration(self):
+        md = "- [ ] Update the documentation\n"
+        rules = _parse_and_classify(md)
+        assert len(rules) == 1
+        assert rules[0].backend_hint is Backend.FILESYSTEM
+        assert rules[0].kind is RuleKind.MARKDOWN_TASKS_COMPLETE
+
+    def test_normative_rule_is_not_treated_as_checkbox(self):
+        # Rules with normative keywords fall through to the appropriate backend
+        # or semantic rubric — not to MARKDOWN_TASKS_COMPLETE.
+        rule = _classify_text("Code quality must be adequate")
+        assert rule.kind is not RuleKind.MARKDOWN_TASKS_COMPLETE
+
+
+# ---------------------------------------------------------------------------
+# Codex P2 fix: draft matching requires PR context
+# ---------------------------------------------------------------------------
+
+
+class TestDraftRequiresPRContext:
+    def test_draft_config_file_does_not_match_github_draft(self):
+        # "draft" in a filesystem context must not be misrouted to GitHub.
+        rule = _classify_text("The draft configuration file must exist")
+        assert rule.backend_hint is Backend.FILESYSTEM
+        assert rule.kind is RuleKind.FILE_EXISTS
+
+    def test_not_a_draft_matches_github_draft(self):
+        rule = _classify_text("The pull request must not be a draft")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_NOT_DRAFT
+        assert rule.confidence is Confidence.HIGH
+
+    def test_in_draft_state_matches_github_draft(self):
+        rule = _classify_text("PR must not be in draft state before review")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_NOT_DRAFT


### PR DESCRIPTION
## Summary

- Implements `src/gate_keeper/classifier.py` with deterministic regex-based classification routing parser output to `filesystem`, `github`, or `llm-rubric` backends.
- Assigns `kind`, `backend_hint`, and `confidence` (high/medium/low) for each rule; stores a short `classifier_explanation` in `params` for later `explain` output.
- Adds `tests/test_classifier.py` with 40 tests covering all three backends, all three confidence levels, integration (parser→classifier pipeline), and low-confidence rule visibility.

Closes #3

## Routing logic

| Signal | Kind | Backend | Confidence |
|---|---|---|---|
| `draft` | `github_not_draft` | `github` | high |
| PR open/not-closed/not-merged | `github_pr_open` | `github` | high |
| `ci checks`, `status check`, `build must pass` | `github_checks_success` | `github` | high |
| `review threads resolved`, `unresolved threads` | `github_threads_resolved` | `github` | high |
| `non-author approval`, `independent review` | `github_non_author_approval` | `github` | high |
| `blocking labels`, `no labels`, `do-not-merge` | `github_labels_absent` | `github` | high |
| `approval`/`reviewer` alone | `github_non_author_approval` | `github` | medium |
| `label` alone | `github_labels_absent` | `github` | medium |
| Item under PR/merge-gate heading | `github_tasks_complete` | `github` | medium |
| `file must exist` | `file_exists` | `filesystem` | high |
| `file must not exist`/absent | `file_absent` | `filesystem` | high |
| `must contain`/`must include` | `text_required` | `filesystem` | high |
| `must not contain`/`never include` | `text_forbidden` | `filesystem` | high |
| `path`/`directory`/`glob` | `path_matches` | `filesystem` | medium |
| Everything else | `semantic_rubric` | `llm-rubric` | low |

## Validation

```
uv sync        # OK
uv run pytest  # 152 passed in 0.19s
```

All 152 tests pass (40 new classifier tests + 112 pre-existing).