### PR TITLE
feat(filesystem): add local filesystem backend

### DIFF
--- a/src/gate_keeper/backends/filesystem.py
+++ b/src/gate_keeper/backends/filesystem.py
@@ -1,0 +1,208 @@
+"""Filesystem and text backend for gate-keeper.
+
+Evaluates a single compiled Rule against a local target path.
+Never raises — all exceptions are translated into diagnostics.
+"""
+from __future__ import annotations
+
+import fnmatch
+import re
+from pathlib import Path
+
+from gate_keeper.models import (
+    Backend,
+    Diagnostic,
+    Evidence,
+    Rule,
+    RuleKind,
+    Status,
+)
+
+_FILESYSTEM_KINDS = frozenset(
+    {
+        RuleKind.FILE_EXISTS,
+        RuleKind.FILE_ABSENT,
+        RuleKind.PATH_MATCHES,
+        RuleKind.TEXT_REQUIRED,
+        RuleKind.TEXT_FORBIDDEN,
+        RuleKind.MARKDOWN_TASKS_COMPLETE,
+    }
+)
+
+_TASK_CHECKED_RE = re.compile(r"^[ \t]*[-*+]\s+\[[xX]\]", re.MULTILINE)
+_TASK_UNCHECKED_RE = re.compile(r"^[ \t]*[-*+]\s+\[ \]", re.MULTILINE)
+
+
+def _diag(rule: Rule, status: Status, message: str, evidence: list[Evidence]) -> Diagnostic:
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=Backend.FILESYSTEM,
+        status=status,
+        severity=rule.severity,
+        message=message,
+        evidence=evidence,
+    )
+
+
+def check(rule: Rule, target: str | Path) -> Diagnostic:
+    """Evaluate *rule* against *target*. Returns a Diagnostic; never raises."""
+    try:
+        return _dispatch(rule, Path(target))
+    except Exception as exc:  # noqa: BLE001
+        return _diag(
+            rule,
+            Status.ERROR,
+            f"internal error: {exc}",
+            [Evidence(kind="exception", data={"type": type(exc).__name__, "message": str(exc)})],
+        )
+
+
+def _dispatch(rule: Rule, target: Path) -> Diagnostic:
+    kind = rule.kind
+
+    if kind not in _FILESYSTEM_KINDS:
+        return _diag(
+            rule,
+            Status.UNSUPPORTED,
+            f"rule kind {kind.value!r} is not supported by the filesystem backend",
+            [Evidence(kind="backend_capability", data={"backend": "filesystem", "kind": kind.value})],
+        )
+
+    if kind is RuleKind.FILE_EXISTS:
+        return _file_exists(rule, target)
+    if kind is RuleKind.FILE_ABSENT:
+        return _file_absent(rule, target)
+    if kind is RuleKind.PATH_MATCHES:
+        return _path_matches(rule, target)
+    if kind is RuleKind.TEXT_REQUIRED:
+        return _text_required(rule, target)
+    if kind is RuleKind.TEXT_FORBIDDEN:
+        return _text_forbidden(rule, target)
+    # RuleKind.MARKDOWN_TASKS_COMPLETE
+    return _markdown_tasks_complete(rule, target)
+
+
+def _file_exists(rule: Rule, target: Path) -> Diagnostic:
+    path_str = str(target)
+    exists = target.exists()
+    evidence = [Evidence(kind="file_stat", data={"path": path_str, "exists": exists})]
+    if exists:
+        return _diag(rule, Status.PASS, f"{path_str} exists.", evidence)
+    return _diag(rule, Status.FAIL, f"{path_str} does not exist.", evidence)
+
+
+def _file_absent(rule: Rule, target: Path) -> Diagnostic:
+    path_str = str(target)
+    exists = target.exists()
+    evidence = [Evidence(kind="file_stat", data={"path": path_str, "exists": exists})]
+    if not exists:
+        return _diag(rule, Status.PASS, f"{path_str} is absent.", evidence)
+    return _diag(rule, Status.FAIL, f"{path_str} exists but must be absent.", evidence)
+
+
+def _path_matches(rule: Rule, target: Path) -> Diagnostic:
+    pattern = rule.params.get("pattern")
+    if not pattern:
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            "params.pattern is required for path_matches but was not provided",
+            [Evidence(kind="params_error", data={"missing": "pattern"})],
+        )
+    path_str = str(target)
+    matched = fnmatch.fnmatch(path_str, pattern) or fnmatch.fnmatch(target.name, pattern)
+    evidence = [Evidence(kind="path_match", data={"path": path_str, "pattern": pattern, "matched": matched})]
+    if matched:
+        return _diag(rule, Status.PASS, f"{path_str} matches pattern {pattern!r}.", evidence)
+    return _diag(rule, Status.FAIL, f"{path_str} does not match pattern {pattern!r}.", evidence)
+
+
+def _read_file(rule: Rule, target: Path) -> tuple[str | None, Diagnostic | None]:
+    """Return (content, None) on success or (None, unavailable_diagnostic) on failure."""
+    path_str = str(target)
+    if not target.exists():
+        return None, _diag(
+            rule,
+            Status.UNAVAILABLE,
+            f"{path_str} does not exist; cannot read for text check.",
+            [Evidence(kind="file_stat", data={"path": path_str, "exists": False})],
+        )
+    if not target.is_file():
+        return None, _diag(
+            rule,
+            Status.UNAVAILABLE,
+            f"{path_str} is not a regular file.",
+            [Evidence(kind="file_stat", data={"path": path_str, "is_file": False})],
+        )
+    try:
+        return target.read_text(encoding="utf-8"), None
+    except OSError as exc:
+        return None, _diag(
+            rule,
+            Status.UNAVAILABLE,
+            f"cannot read {path_str}: {exc}",
+            [Evidence(kind="io_error", data={"path": path_str, "error": str(exc)})],
+        )
+
+
+def _text_required(rule: Rule, target: Path) -> Diagnostic:
+    pattern = rule.params.get("pattern")
+    if not pattern:
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            "params.pattern is required for text_required but was not provided",
+            [Evidence(kind="params_error", data={"missing": "pattern"})],
+        )
+    content, err = _read_file(rule, target)
+    if err is not None:
+        return err
+    path_str = str(target)
+    use_regex = bool(rule.params.get("regex", False))
+    if use_regex:
+        match_count = len(re.findall(pattern, content))
+    else:
+        match_count = content.count(pattern)
+    evidence = [Evidence(kind="text_match", data={"path": path_str, "pattern": pattern, "match_count": match_count})]
+    if match_count > 0:
+        return _diag(rule, Status.PASS, f"{path_str} contains {pattern!r}.", evidence)
+    return _diag(rule, Status.FAIL, f"{path_str} does not contain {pattern!r}.", evidence)
+
+
+def _text_forbidden(rule: Rule, target: Path) -> Diagnostic:
+    pattern = rule.params.get("pattern")
+    if not pattern:
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            "params.pattern is required for text_forbidden but was not provided",
+            [Evidence(kind="params_error", data={"missing": "pattern"})],
+        )
+    content, err = _read_file(rule, target)
+    if err is not None:
+        return err
+    path_str = str(target)
+    use_regex = bool(rule.params.get("regex", False))
+    if use_regex:
+        match_count = len(re.findall(pattern, content))
+    else:
+        match_count = content.count(pattern)
+    evidence = [Evidence(kind="text_match", data={"path": path_str, "pattern": pattern, "match_count": match_count})]
+    if match_count == 0:
+        return _diag(rule, Status.PASS, f"{path_str} does not contain forbidden pattern {pattern!r}.", evidence)
+    return _diag(rule, Status.FAIL, f"{path_str} contains forbidden pattern {pattern!r}.", evidence)
+
+
+def _markdown_tasks_complete(rule: Rule, target: Path) -> Diagnostic:
+    content, err = _read_file(rule, target)
+    if err is not None:
+        return err
+    path_str = str(target)
+    checked = len(_TASK_CHECKED_RE.findall(content))
+    unchecked = len(_TASK_UNCHECKED_RE.findall(content))
+    total = checked + unchecked
+    evidence = [Evidence(kind="markdown_tasks", data={"path": path_str, "checked": checked, "unchecked": unchecked, "total": total})]
+    if unchecked:
+        return _diag(rule, Status.FAIL, f"{path_str} has {unchecked} unchecked task(s) of {total}.", evidence)
+    return _diag(rule, Status.PASS, f"{path_str} has all {total} task(s) checked.", evidence)

--- a/src/gate_keeper/backends/filesystem.py
+++ b/src/gate_keeper/backends/filesystem.py
@@ -31,6 +31,7 @@ _FILESYSTEM_KINDS = frozenset(
 
 _TASK_CHECKED_RE = re.compile(r"^[ \t]*[-*+]\s+\[[xX]\]", re.MULTILINE)
 _TASK_UNCHECKED_RE = re.compile(r"^[ \t]*[-*+]\s+\[ \]", re.MULTILINE)
+_FENCE_START_RE = re.compile(r"^[ \t]*(`{3,}|~{3,})")
 
 
 def _diag(rule: Rule, status: Status, message: str, evidence: list[Evidence]) -> Diagnostic:
@@ -137,7 +138,7 @@ def _read_file(rule: Rule, target: Path) -> tuple[str | None, Diagnostic | None]
         )
     try:
         return target.read_text(encoding="utf-8"), None
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         return None, _diag(
             rule,
             Status.UNAVAILABLE,
@@ -194,13 +195,37 @@ def _text_forbidden(rule: Rule, target: Path) -> Diagnostic:
     return _diag(rule, Status.FAIL, f"{path_str} contains forbidden pattern {pattern!r}.", evidence)
 
 
+def _strip_fenced_blocks(text: str) -> str:
+    """Return *text* with fenced code block contents removed (fence lines included)."""
+    out: list[str] = []
+    in_fence = False
+    fence_char = ""
+    fence_len = 0
+    for line in text.splitlines(keepends=True):
+        m = _FENCE_START_RE.match(line)
+        if m:
+            marker = m.group(1)
+            if not in_fence:
+                in_fence = True
+                fence_char = marker[0]
+                fence_len = len(marker)
+            elif marker[0] == fence_char and len(marker) >= fence_len:
+                in_fence = False
+                fence_char = ""
+                fence_len = 0
+        elif not in_fence:
+            out.append(line)
+    return "".join(out)
+
+
 def _markdown_tasks_complete(rule: Rule, target: Path) -> Diagnostic:
     content, err = _read_file(rule, target)
     if err is not None:
         return err
     path_str = str(target)
-    checked = len(_TASK_CHECKED_RE.findall(content))
-    unchecked = len(_TASK_UNCHECKED_RE.findall(content))
+    scannable = _strip_fenced_blocks(content)
+    checked = len(_TASK_CHECKED_RE.findall(scannable))
+    unchecked = len(_TASK_UNCHECKED_RE.findall(scannable))
     total = checked + unchecked
     evidence = [Evidence(kind="markdown_tasks", data={"path": path_str, "checked": checked, "unchecked": unchecked, "total": total})]
     if unchecked:

--- a/tests/fixtures/filesystem/content.txt
+++ b/tests/fixtures/filesystem/content.txt
@@ -1,0 +1,3 @@
+This file contains the word uv and is used for text backend tests.
+It has multiple lines.
+The tool is called gate-keeper.

--- a/tests/fixtures/filesystem/nested/deep.txt
+++ b/tests/fixtures/filesystem/nested/deep.txt
@@ -1,0 +1,1 @@
+nested file for path_matches tests

--- a/tests/fixtures/filesystem/tasks_all_checked.md
+++ b/tests/fixtures/filesystem/tasks_all_checked.md
@@ -1,0 +1,5 @@
+# Checklist
+
+- [x] Write the implementation
+- [x] Add tests
+- [X] Open a PR

--- a/tests/fixtures/filesystem/tasks_none.md
+++ b/tests/fixtures/filesystem/tasks_none.md
@@ -1,0 +1,3 @@
+# Notes
+
+This file has no task checkboxes, only plain text.

--- a/tests/fixtures/filesystem/tasks_with_unchecked.md
+++ b/tests/fixtures/filesystem/tasks_with_unchecked.md
@@ -1,0 +1,5 @@
+# Checklist
+
+- [x] Write the implementation
+- [ ] Add tests
+- [ ] Open a PR

--- a/tests/test_filesystem_backend.py
+++ b/tests/test_filesystem_backend.py
@@ -1,0 +1,309 @@
+"""Tests for gate_keeper.backends.filesystem."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gate_keeper.backends.filesystem import check
+from gate_keeper.models import (
+    Backend,
+    Confidence,
+    Rule,
+    RuleKind,
+    Severity,
+    SourceLocation,
+    Status,
+)
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "filesystem"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _rule(kind: RuleKind, params: dict | None = None) -> Rule:
+    return Rule(
+        id="test-rule",
+        title="Test rule",
+        source=SourceLocation(path="test.md", line=1),
+        text="test rule text",
+        kind=kind,
+        severity=Severity.ERROR,
+        backend_hint=Backend.FILESYSTEM,
+        confidence=Confidence.HIGH,
+        params=params or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# file_exists
+# ---------------------------------------------------------------------------
+
+
+class TestFileExists:
+    def test_pass_when_file_present(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.FILE_EXISTS), target)
+        assert diag.status is Status.PASS
+        assert diag.backend is Backend.FILESYSTEM
+
+    def test_fail_when_file_missing(self, tmp_path):
+        target = tmp_path / "nonexistent.txt"
+        diag = check(_rule(RuleKind.FILE_EXISTS), target)
+        assert diag.status is Status.FAIL
+
+    def test_evidence_contains_path(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.FILE_EXISTS), target)
+        assert any(e.kind == "file_stat" for e in diag.evidence)
+        assert any(e.data.get("exists") is True for e in diag.evidence)
+
+    def test_unavailable_not_returned_for_missing(self, tmp_path):
+        # file_exists should return fail (not unavailable) for a missing path
+        diag = check(_rule(RuleKind.FILE_EXISTS), tmp_path / "ghost.txt")
+        assert diag.status is Status.FAIL
+
+
+# ---------------------------------------------------------------------------
+# file_absent
+# ---------------------------------------------------------------------------
+
+
+class TestFileAbsent:
+    def test_pass_when_file_missing(self, tmp_path):
+        target = tmp_path / "absent.txt"
+        diag = check(_rule(RuleKind.FILE_ABSENT), target)
+        assert diag.status is Status.PASS
+
+    def test_fail_when_file_present(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.FILE_ABSENT), target)
+        assert diag.status is Status.FAIL
+
+    def test_evidence_contains_exists_true(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.FILE_ABSENT), target)
+        assert any(e.data.get("exists") is True for e in diag.evidence)
+
+
+# ---------------------------------------------------------------------------
+# path_matches
+# ---------------------------------------------------------------------------
+
+
+class TestPathMatches:
+    def test_pass_name_glob(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.PATH_MATCHES, {"pattern": "*.txt"}), target)
+        assert diag.status is Status.PASS
+
+    def test_fail_name_glob_mismatch(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.PATH_MATCHES, {"pattern": "*.md"}), target)
+        assert diag.status is Status.FAIL
+
+    def test_pass_full_path_glob(self):
+        target = _FIXTURES / "nested" / "deep.txt"
+        path_str = str(target)
+        diag = check(_rule(RuleKind.PATH_MATCHES, {"pattern": path_str}), target)
+        assert diag.status is Status.PASS
+
+    def test_unavailable_when_pattern_missing(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.PATH_MATCHES, {}), target)
+        assert diag.status is Status.UNAVAILABLE
+
+    def test_evidence_contains_pattern(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.PATH_MATCHES, {"pattern": "*.txt"}), target)
+        assert any(e.kind == "path_match" for e in diag.evidence)
+        assert any("pattern" in e.data for e in diag.evidence)
+
+
+# ---------------------------------------------------------------------------
+# text_required
+# ---------------------------------------------------------------------------
+
+
+class TestTextRequired:
+    def test_pass_substring_found(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": "uv"}), target)
+        assert diag.status is Status.PASS
+
+    def test_fail_substring_not_found(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": "MISSING_TOKEN_XYZ"}), target)
+        assert diag.status is Status.FAIL
+
+    def test_unavailable_when_pattern_missing(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.TEXT_REQUIRED, {}), target)
+        assert diag.status is Status.UNAVAILABLE
+
+    def test_unavailable_when_file_missing(self, tmp_path):
+        target = tmp_path / "no_such_file.txt"
+        diag = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": "uv"}), target)
+        assert diag.status is Status.UNAVAILABLE
+
+    def test_regex_mode_pass(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": r"gate.keeper", "regex": True}), target)
+        assert diag.status is Status.PASS
+
+    def test_regex_mode_fail(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": r"NEVER_MATCHES_\d{99}", "regex": True}), target)
+        assert diag.status is Status.FAIL
+
+    def test_evidence_match_count(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": "uv"}), target)
+        ev = next(e for e in diag.evidence if e.kind == "text_match")
+        assert ev.data["match_count"] >= 1
+
+    def test_unavailable_on_directory_target(self, tmp_path):
+        diag = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": "uv"}), tmp_path)
+        assert diag.status is Status.UNAVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# text_forbidden
+# ---------------------------------------------------------------------------
+
+
+class TestTextForbidden:
+    def test_pass_when_pattern_absent(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.TEXT_FORBIDDEN, {"pattern": "FORBIDDEN_XYZ"}), target)
+        assert diag.status is Status.PASS
+
+    def test_fail_when_pattern_present(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.TEXT_FORBIDDEN, {"pattern": "uv"}), target)
+        assert diag.status is Status.FAIL
+
+    def test_unavailable_when_pattern_missing(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.TEXT_FORBIDDEN, {}), target)
+        assert diag.status is Status.UNAVAILABLE
+
+    def test_unavailable_when_file_missing(self, tmp_path):
+        target = tmp_path / "no_such_file.txt"
+        diag = check(_rule(RuleKind.TEXT_FORBIDDEN, {"pattern": "anything"}), target)
+        assert diag.status is Status.UNAVAILABLE
+
+    def test_regex_mode_pass(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.TEXT_FORBIDDEN, {"pattern": r"NEVER_\d{99}", "regex": True}), target)
+        assert diag.status is Status.PASS
+
+    def test_regex_mode_fail(self):
+        target = _FIXTURES / "content.txt"
+        diag = check(_rule(RuleKind.TEXT_FORBIDDEN, {"pattern": r"gate.keeper", "regex": True}), target)
+        assert diag.status is Status.FAIL
+
+
+# ---------------------------------------------------------------------------
+# markdown_tasks_complete
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownTasksComplete:
+    def test_pass_all_checked(self):
+        target = _FIXTURES / "tasks_all_checked.md"
+        diag = check(_rule(RuleKind.MARKDOWN_TASKS_COMPLETE), target)
+        assert diag.status is Status.PASS
+
+    def test_fail_has_unchecked(self):
+        target = _FIXTURES / "tasks_with_unchecked.md"
+        diag = check(_rule(RuleKind.MARKDOWN_TASKS_COMPLETE), target)
+        assert diag.status is Status.FAIL
+
+    def test_pass_no_task_checkboxes(self):
+        target = _FIXTURES / "tasks_none.md"
+        diag = check(_rule(RuleKind.MARKDOWN_TASKS_COMPLETE), target)
+        assert diag.status is Status.PASS
+
+    def test_unavailable_when_file_missing(self, tmp_path):
+        target = tmp_path / "no_such_file.md"
+        diag = check(_rule(RuleKind.MARKDOWN_TASKS_COMPLETE), target)
+        assert diag.status is Status.UNAVAILABLE
+
+    def test_evidence_counts(self):
+        target = _FIXTURES / "tasks_with_unchecked.md"
+        diag = check(_rule(RuleKind.MARKDOWN_TASKS_COMPLETE), target)
+        ev = next(e for e in diag.evidence if e.kind == "markdown_tasks")
+        assert ev.data["unchecked"] == 2
+        assert ev.data["checked"] == 1
+        assert ev.data["total"] == 3
+
+    def test_evidence_counts_all_checked(self):
+        target = _FIXTURES / "tasks_all_checked.md"
+        diag = check(_rule(RuleKind.MARKDOWN_TASKS_COMPLETE), target)
+        ev = next(e for e in diag.evidence if e.kind == "markdown_tasks")
+        assert ev.data["unchecked"] == 0
+        assert ev.data["checked"] == 3
+        assert ev.data["total"] == 3
+
+    def test_tmp_path_all_checked(self, tmp_path):
+        f = tmp_path / "checklist.md"
+        f.write_text("- [x] done\n- [x] also done\n")
+        diag = check(_rule(RuleKind.MARKDOWN_TASKS_COMPLETE), f)
+        assert diag.status is Status.PASS
+
+    def test_tmp_path_unchecked(self, tmp_path):
+        f = tmp_path / "checklist.md"
+        f.write_text("- [x] done\n- [ ] not done\n")
+        diag = check(_rule(RuleKind.MARKDOWN_TASKS_COMPLETE), f)
+        assert diag.status is Status.FAIL
+
+
+# ---------------------------------------------------------------------------
+# Unsupported rule kind
+# ---------------------------------------------------------------------------
+
+
+class TestUnsupported:
+    def test_github_kind_returns_unsupported(self):
+        diag = check(_rule(RuleKind.GITHUB_PR_OPEN), _FIXTURES / "content.txt")
+        assert diag.status is Status.UNSUPPORTED
+        assert diag.backend is Backend.FILESYSTEM
+
+    def test_semantic_rubric_returns_unsupported(self):
+        diag = check(_rule(RuleKind.SEMANTIC_RUBRIC), _FIXTURES / "content.txt")
+        assert diag.status is Status.UNSUPPORTED
+
+    def test_unsupported_evidence_contains_kind(self):
+        diag = check(_rule(RuleKind.GITHUB_CHECKS_SUCCESS), _FIXTURES / "content.txt")
+        assert any("kind" in e.data for e in diag.evidence)
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic contract — all results conform to the model
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticContract:
+    """Every returned Diagnostic round-trips through to_dict / from_dict."""
+
+    def _assert_valid(self, diag):
+        from gate_keeper.models import Diagnostic
+        d = Diagnostic.from_dict(diag.to_dict())
+        assert d.rule_id == diag.rule_id
+        assert d.status == diag.status
+
+    def test_file_exists_pass(self):
+        self._assert_valid(check(_rule(RuleKind.FILE_EXISTS), _FIXTURES / "content.txt"))
+
+    def test_file_exists_fail(self, tmp_path):
+        self._assert_valid(check(_rule(RuleKind.FILE_EXISTS), tmp_path / "x.txt"))
+
+    def test_text_required_unavailable(self, tmp_path):
+        self._assert_valid(check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": "x"}), tmp_path / "x.txt"))
+
+    def test_unsupported(self):
+        self._assert_valid(check(_rule(RuleKind.GITHUB_PR_OPEN), _FIXTURES / "content.txt"))

--- a/tests/test_filesystem_backend.py
+++ b/tests/test_filesystem_backend.py
@@ -261,6 +261,42 @@ class TestMarkdownTasksComplete:
         diag = check(_rule(RuleKind.MARKDOWN_TASKS_COMPLETE), f)
         assert diag.status is Status.FAIL
 
+    def test_checkboxes_inside_code_block_ignored(self, tmp_path):
+        f = tmp_path / "doc.md"
+        f.write_text(
+            "Real tasks:\n- [x] done\n\n```\n- [ ] inside code block\n```\n"
+        )
+        diag = check(_rule(RuleKind.MARKDOWN_TASKS_COMPLETE), f)
+        assert diag.status is Status.PASS
+        ev = next(e for e in diag.evidence if e.kind == "markdown_tasks")
+        assert ev.data["unchecked"] == 0
+        assert ev.data["checked"] == 1
+
+    def test_unavailable_on_non_utf8_file(self, tmp_path):
+        f = tmp_path / "latin1.md"
+        f.write_bytes(b"- [x] done \xff\n")
+        diag = check(_rule(RuleKind.MARKDOWN_TASKS_COMPLETE), f)
+        assert diag.status is Status.UNAVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# UnicodeDecodeError → unavailable (P2 fix)
+# ---------------------------------------------------------------------------
+
+
+class TestUnicodeDecodeError:
+    def test_text_required_non_utf8_is_unavailable(self, tmp_path):
+        f = tmp_path / "latin1.txt"
+        f.write_bytes(b"hello \xff world")
+        diag = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": "hello"}), f)
+        assert diag.status is Status.UNAVAILABLE
+
+    def test_text_forbidden_non_utf8_is_unavailable(self, tmp_path):
+        f = tmp_path / "latin1.txt"
+        f.write_bytes(b"hello \xff world")
+        diag = check(_rule(RuleKind.TEXT_FORBIDDEN, {"pattern": "hello"}), f)
+        assert diag.status is Status.UNAVAILABLE
+
 
 # ---------------------------------------------------------------------------
 # Unsupported rule kind


### PR DESCRIPTION
## Summary

- Implements `src/gate_keeper/backends/filesystem.py` with a single public `check(rule, target)` function returning a `Diagnostic`
- Supports all six filesystem rule kinds: `file_exists`, `file_absent`, `path_matches`, `text_required`, `text_forbidden`, `markdown_tasks_complete`
- Fail-closed: missing target → `unavailable`; missing required `params.pattern` → `unavailable`; unsupported rule kind → `unsupported`; internal exceptions → `error`
- `markdown_tasks_complete` parses `- [ ]` / `- [x]` patterns; passes when all boxes are checked or no checkboxes exist
- Adds `src/gate_keeper/backends/__init__.py` package init and five fixture files under `tests/fixtures/filesystem/`

## Validation

```
uv sync
uv run pytest
```

Result: **203 passed in 0.30s** (41 new tests in `tests/test_filesystem_backend.py`, 162 pre-existing)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)