### PR TITLE
test(fixtures): add local fixtures and end-to-end coverage

### DIFF
--- a/tests/fixtures/local/fail/BANNED.txt
+++ b/tests/fixtures/local/fail/BANNED.txt
@@ -1,0 +1,1 @@
+This file exists so that `file_absent` rules targeting `BANNED.txt` fail.

--- a/tests/fixtures/local/fail/dirty.txt
+++ b/tests/fixtures/local/fail/dirty.txt
@@ -1,0 +1,1 @@
+This file contains a forbidden string: DO NOT MERGE

--- a/tests/fixtures/local/fail/tasks.md
+++ b/tests/fixtures/local/fail/tasks.md
@@ -1,0 +1,5 @@
+# Checklist (incomplete)
+
+- [x] Done
+- [ ] Not done yet
+- [ ] Also not done

--- a/tests/fixtures/local/pass/README.md
+++ b/tests/fixtures/local/pass/README.md
@@ -1,0 +1,4 @@
+# Pass Fixture
+
+This file exists so that `file_exists` rules targeting `README.md` pass.
+It contains no forbidden strings.

--- a/tests/fixtures/local/pass/manifest.txt
+++ b/tests/fixtures/local/pass/manifest.txt
@@ -1,0 +1,2 @@
+version: 1
+name: gate-keeper

--- a/tests/fixtures/local/pass/tasks.md
+++ b/tests/fixtures/local/pass/tasks.md
@@ -1,0 +1,5 @@
+# Checklist (all complete)
+
+- [x] First item done
+- [x] Second item done
+- [x] Third item done

--- a/tests/fixtures/local/rules-local.md
+++ b/tests/fixtures/local/rules-local.md
@@ -1,0 +1,19 @@
+# Local Validation Rules
+
+Filesystem-only rule document for end-to-end tests.
+No GitHub rules — every rule here routes to the filesystem backend.
+
+## File Presence
+
+- `README.md` must exist.
+- `BANNED.txt` must not exist.
+
+## Content Checks
+
+- `manifest.txt` must contain the version string.
+- Source files must not contain banned strings.
+- Source files must follow the `src/**/*.py` path glob pattern.
+
+## Task Completion
+
+- [x] All checklist items complete

--- a/tests/test_e2e_local.py
+++ b/tests/test_e2e_local.py
@@ -1,0 +1,217 @@
+"""End-to-end tests: parse → classify → filesystem backend → diagnostics → exit code.
+
+Drives the full local pipeline without GitHub auth or network access.
+Each test covers a specific filesystem rule kind against purpose-built fixtures
+under tests/fixtures/local/{pass,fail}/.
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from gate_keeper import classifier, parser
+from gate_keeper.backends.filesystem import check
+from gate_keeper.diagnostics import EXIT_FAIL, EXIT_OK, compute_exit_code
+from gate_keeper.models import Backend, RuleKind, Status
+
+FIXTURES = Path(__file__).parent / "fixtures" / "local"
+RULES_DOC = FIXTURES / "rules-local.md"
+PASS_DIR = FIXTURES / "pass"
+FAIL_DIR = FIXTURES / "fail"
+
+
+def _ruleset():
+    rs = parser.parse_file(RULES_DOC)
+    return classifier.classify(rs)
+
+
+def _rules(kind: RuleKind) -> list:
+    return [
+        r
+        for r in _ruleset().rules
+        if r.kind is kind and r.backend_hint is Backend.FILESYSTEM
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Passing fixture — every rule kind passes against pass/
+# ---------------------------------------------------------------------------
+
+
+class TestPassingFixture:
+    """All filesystem rule kinds produce PASS diagnostics against pass/ fixtures."""
+
+    def test_file_exists_readme_present(self):
+        rules = _rules(RuleKind.FILE_EXISTS)
+        assert rules, "rules-local.md must produce a FILE_EXISTS rule"
+        diags = [check(r, PASS_DIR / "README.md") for r in rules]
+        assert all(d.status is Status.PASS for d in diags)
+        assert compute_exit_code(diags) == EXIT_OK
+
+    def test_file_absent_banned_txt_missing(self):
+        rules = _rules(RuleKind.FILE_ABSENT)
+        assert rules, "rules-local.md must produce a FILE_ABSENT rule"
+        # pass/ has no BANNED.txt → absent → passes
+        diags = [check(r, PASS_DIR / "BANNED.txt") for r in rules]
+        assert all(d.status is Status.PASS for d in diags)
+        assert compute_exit_code(diags) == EXIT_OK
+
+    def test_text_required_manifest_contains_version(self):
+        rules = _rules(RuleKind.TEXT_REQUIRED)
+        assert rules, "rules-local.md must produce a TEXT_REQUIRED rule"
+        rules = [replace(r, params={**r.params, "pattern": "version: 1"}) for r in rules]
+        diags = [check(r, PASS_DIR / "manifest.txt") for r in rules]
+        assert all(d.status is Status.PASS for d in diags)
+        assert compute_exit_code(diags) == EXIT_OK
+
+    def test_text_forbidden_clean_readme(self):
+        rules = _rules(RuleKind.TEXT_FORBIDDEN)
+        assert rules, "rules-local.md must produce a TEXT_FORBIDDEN rule"
+        rules = [replace(r, params={**r.params, "pattern": "DO NOT MERGE"}) for r in rules]
+        diags = [check(r, PASS_DIR / "README.md") for r in rules]
+        assert all(d.status is Status.PASS for d in diags)
+        assert compute_exit_code(diags) == EXIT_OK
+
+    def test_path_matches_md_extension(self):
+        rules = _rules(RuleKind.PATH_MATCHES)
+        assert rules, "rules-local.md must produce a PATH_MATCHES rule"
+        rules = [replace(r, params={**r.params, "pattern": "*.md"}) for r in rules]
+        diags = [check(r, PASS_DIR / "README.md") for r in rules]
+        assert all(d.status is Status.PASS for d in diags)
+        assert compute_exit_code(diags) == EXIT_OK
+
+    def test_markdown_tasks_complete_all_checked(self):
+        rules = _rules(RuleKind.MARKDOWN_TASKS_COMPLETE)
+        assert rules, "rules-local.md must produce a MARKDOWN_TASKS_COMPLETE rule"
+        diags = [check(r, PASS_DIR / "tasks.md") for r in rules]
+        assert all(d.status is Status.PASS for d in diags)
+        assert compute_exit_code(diags) == EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+# Failing fixture — every rule kind produces a non-pass status and exit code 1
+# ---------------------------------------------------------------------------
+
+
+class TestFailingFixture:
+    """At least one diagnostic fails or is unavailable → exit code 1."""
+
+    def test_file_exists_readme_absent_fails(self):
+        rules = _rules(RuleKind.FILE_EXISTS)
+        # fail/ has no README.md
+        diags = [check(r, FAIL_DIR / "README.md") for r in rules]
+        assert any(d.status is Status.FAIL for d in diags)
+        assert compute_exit_code(diags) == EXIT_FAIL
+
+    def test_file_absent_banned_txt_present_fails(self):
+        rules = _rules(RuleKind.FILE_ABSENT)
+        # fail/ has BANNED.txt → present → fails
+        diags = [check(r, FAIL_DIR / "BANNED.txt") for r in rules]
+        assert any(d.status is Status.FAIL for d in diags)
+        assert compute_exit_code(diags) == EXIT_FAIL
+
+    def test_text_required_missing_file_is_unavailable(self):
+        rules = _rules(RuleKind.TEXT_REQUIRED)
+        rules = [replace(r, params={**r.params, "pattern": "version: 1"}) for r in rules]
+        # fail/ has no manifest.txt → UNAVAILABLE → non-zero exit
+        diags = [check(r, FAIL_DIR / "manifest.txt") for r in rules]
+        assert all(d.status is Status.UNAVAILABLE for d in diags)
+        assert compute_exit_code(diags) == EXIT_FAIL
+
+    def test_text_forbidden_dirty_file_fails(self):
+        rules = _rules(RuleKind.TEXT_FORBIDDEN)
+        rules = [replace(r, params={**r.params, "pattern": "DO NOT MERGE"}) for r in rules]
+        diags = [check(r, FAIL_DIR / "dirty.txt") for r in rules]
+        assert any(d.status is Status.FAIL for d in diags)
+        assert compute_exit_code(diags) == EXIT_FAIL
+
+    def test_path_matches_wrong_extension_fails(self):
+        rules = _rules(RuleKind.PATH_MATCHES)
+        rules = [replace(r, params={**r.params, "pattern": "*.md"}) for r in rules]
+        # dirty.txt doesn't match *.md
+        diags = [check(r, FAIL_DIR / "dirty.txt") for r in rules]
+        assert any(d.status is Status.FAIL for d in diags)
+        assert compute_exit_code(diags) == EXIT_FAIL
+
+    def test_markdown_tasks_incomplete_fails(self):
+        rules = _rules(RuleKind.MARKDOWN_TASKS_COMPLETE)
+        diags = [check(r, FAIL_DIR / "tasks.md") for r in rules]
+        assert any(d.status is Status.FAIL for d in diags)
+        assert compute_exit_code(diags) == EXIT_FAIL
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic contract — output fields and JSON round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticContract:
+    """Every diagnostic carries the required fields and survives JSON round-trip."""
+
+    def test_all_required_fields_present(self):
+        rules = _rules(RuleKind.FILE_EXISTS)
+        for rule in rules:
+            diag = check(rule, PASS_DIR / "README.md")
+            assert diag.rule_id
+            assert diag.source
+            assert diag.backend is Backend.FILESYSTEM
+            assert diag.status
+            assert diag.severity
+            assert diag.message
+            assert isinstance(diag.evidence, list)
+
+    def test_diagnostic_round_trips_json(self):
+        from gate_keeper.models import Diagnostic
+
+        rules = _rules(RuleKind.FILE_EXISTS)
+        for rule in rules:
+            diag = check(rule, PASS_DIR / "README.md")
+            rebuilt = Diagnostic.from_dict(diag.to_dict())
+            assert rebuilt.rule_id == diag.rule_id
+            assert rebuilt.status == diag.status
+            assert rebuilt.backend == diag.backend
+
+    def test_exit_code_is_zero_when_all_pass(self):
+        rules = _rules(RuleKind.FILE_EXISTS)
+        diags = [check(r, PASS_DIR / "README.md") for r in rules]
+        assert compute_exit_code(diags) == EXIT_OK
+
+    def test_exit_code_is_one_when_any_fail(self):
+        rules = _rules(RuleKind.FILE_EXISTS)
+        diags = [check(r, FAIL_DIR / "README.md") for r in rules]
+        assert compute_exit_code(diags) == EXIT_FAIL
+
+
+# ---------------------------------------------------------------------------
+# Smoke test: compile docs/example-rules.md still emits valid JSON
+# ---------------------------------------------------------------------------
+
+
+class TestCompileSmoke:
+    """compile emits valid RuleSet JSON with the correct shape."""
+
+    def test_example_rules_compile_exits_zero(self, capsys):
+        import json
+
+        from gate_keeper.cli import main
+
+        repo_root = Path(__file__).parent.parent
+        rc = main(["compile", str(repo_root / "docs" / "example-rules.md"), "--format", "json"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert "rules" in data
+        assert len(data["rules"]) > 0
+
+    def test_example_rules_has_filesystem_and_github_rules(self, capsys):
+        import json
+
+        from gate_keeper.cli import main
+
+        repo_root = Path(__file__).parent.parent
+        main(["compile", str(repo_root / "docs" / "example-rules.md"), "--format", "json"])
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        backends = {r["backend_hint"] for r in data["rules"]}
+        assert "filesystem" in backends
+        assert "github" in backends

--- a/tests/test_e2e_local.py
+++ b/tests/test_e2e_local.py
@@ -209,7 +209,8 @@ class TestCompileSmoke:
         from gate_keeper.cli import main
 
         repo_root = Path(__file__).parent.parent
-        main(["compile", str(repo_root / "docs" / "example-rules.md"), "--format", "json"])
+        rc = main(["compile", str(repo_root / "docs" / "example-rules.md"), "--format", "json"])
+        assert rc == 0
         out = capsys.readouterr().out
         data = json.loads(out)
         backends = {r["backend_hint"] for r in data["rules"]}


### PR DESCRIPTION
## Summary

- Adds `tests/fixtures/local/rules-local.md` — a filesystem-only rule document covering all six filesystem rule kinds
- Adds `tests/fixtures/local/pass/` and `tests/fixtures/local/fail/` fixture directories (7 small, readable files)
- Adds `tests/test_e2e_local.py` with 18 tests driving the full `parse → classify → filesystem backend → diagnostics → exit_code` pipeline

No GitHub auth, network, or `gh` calls required by any test. Does not add a `validate` CLI command (tracked in #8).

## Validation

```
uv sync
uv run pytest          # 229 passed in 0.36s
uv run gate-keeper compile docs/example-rules.md --format json
# exit 0, 9 rules extracted
```

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)