### PR TITLE
feat(orchestrator): validation orchestrator and backend registry (#8)

### DIFF
--- a/src/gate_keeper/backends/__init__.py
+++ b/src/gate_keeper/backends/__init__.py
@@ -1,0 +1,43 @@
+"""Backend registry for gate-keeper.
+
+Maps backend name strings to callable check functions.  Each entry wraps a
+module-level ``check(rule, target) -> Diagnostic`` function so callers can
+look up backends by name without importing modules directly.
+
+Registered names (all three must be present for `--backend` choices):
+  ``filesystem``, ``github``, ``llm-rubric``
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from gate_keeper.models import Diagnostic, Rule
+
+# Import backend modules — avoid circular deps by keeping these as plain imports.
+from gate_keeper.backends import filesystem as _fs
+from gate_keeper.backends import github as _gh
+from gate_keeper.backends import llm_rubric as _llm
+
+# Registry: name -> check callable
+_REGISTRY: dict[str, Callable[[Rule, str | Path], Diagnostic]] = {
+    _fs.name: _fs.check,
+    _gh.name: _gh.check,
+    _llm.name: _llm.check,
+}
+
+#: Sorted list of all registered backend names (used for argparse ``choices``).
+BACKEND_NAMES: list[str] = sorted(_REGISTRY)
+
+
+def get(name: str) -> Callable[[Rule, str | Path], Diagnostic] | None:
+    """Return the check callable for *name*, or ``None`` if not registered."""
+    return _REGISTRY.get(name)
+
+
+def is_registered(name: str) -> bool:
+    """Return True if *name* is a known backend."""
+    return name in _REGISTRY
+
+
+__all__ = ["BACKEND_NAMES", "get", "is_registered"]

--- a/src/gate_keeper/backends/base.py
+++ b/src/gate_keeper/backends/base.py
@@ -1,0 +1,24 @@
+"""Backend protocol for gate-keeper validation backends.
+
+Each backend receives a Rule and a target, and returns a Diagnostic.
+Implementations must never raise — unexpected errors become ERROR diagnostics.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+from gate_keeper.models import Diagnostic, Rule
+
+
+class BackendImpl(Protocol):
+    """Protocol that every validation backend must satisfy."""
+
+    name: str
+
+    def check(self, rule: Rule, target: str | Path) -> Diagnostic:
+        """Evaluate *rule* against *target* and return a Diagnostic; never raises."""
+        ...
+
+
+__all__ = ["BackendImpl"]

--- a/src/gate_keeper/backends/filesystem.py
+++ b/src/gate_keeper/backends/filesystem.py
@@ -9,6 +9,8 @@ import fnmatch
 import re
 from pathlib import Path
 
+name = "filesystem"
+
 from gate_keeper.models import (
     Backend,
     Diagnostic,

--- a/src/gate_keeper/backends/github.py
+++ b/src/gate_keeper/backends/github.py
@@ -1,0 +1,31 @@
+"""GitHub backend stub for gate-keeper (MVP placeholder).
+
+The full implementation comes in a later issue. This stub is registered so
+that `--backend github` is a valid choice rather than a usage error. All rules
+return Status.UNAVAILABLE until the real implementation lands.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from gate_keeper.models import Backend, Diagnostic, Evidence, Rule, Status
+
+name = "github"
+
+
+def check(rule: Rule, target: str | Path) -> Diagnostic:
+    """Return UNAVAILABLE; the GitHub backend is not yet implemented."""
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=Backend.GITHUB,
+        status=Status.UNAVAILABLE,
+        severity=rule.severity,
+        message="GitHub backend is not yet implemented; skipping rule.",
+        evidence=[
+            Evidence(
+                kind="backend_stub",
+                data={"backend": "github", "rule_kind": rule.kind.value},
+            )
+        ],
+    )

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -1,0 +1,31 @@
+"""LLM-rubric backend stub for gate-keeper (MVP placeholder).
+
+Provider-specific implementation is out of scope for the MVP. This stub is
+registered so that `--backend llm-rubric` is a valid choice. All rules return
+Status.UNAVAILABLE (fail-closed) until a provider is configured.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from gate_keeper.models import Backend, Diagnostic, Evidence, Rule, Status
+
+name = "llm-rubric"
+
+
+def check(rule: Rule, target: str | Path) -> Diagnostic:
+    """Return UNAVAILABLE; no LLM provider is configured for the MVP."""
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=Backend.LLM_RUBRIC,
+        status=Status.UNAVAILABLE,
+        severity=rule.severity,
+        message="LLM rubric backend is not configured; skipping rule.",
+        evidence=[
+            Evidence(
+                kind="backend_stub",
+                data={"backend": "llm-rubric", "rule_kind": rule.kind.value},
+            )
+        ],
+    )

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -70,6 +70,9 @@ def _cmd_compile(args: argparse.Namespace) -> int:
     except OSError as exc:
         print(f"error: {args.document}: {exc.strerror}", file=sys.stderr)
         return EXIT_USAGE
+    except UnicodeDecodeError as exc:
+        print(f"error: {args.document}: not valid UTF-8 ({exc.reason})", file=sys.stderr)
+        return EXIT_USAGE
 
     ruleset = parser.parse(str(path), content)
     ruleset = classifier.classify(ruleset)
@@ -101,6 +104,9 @@ def _cmd_validate(args: argparse.Namespace) -> int:
         content = doc_path.read_text(encoding="utf-8")
     except OSError as exc:
         print(f"error: {args.rules}: {exc.strerror}", file=sys.stderr)
+        return EXIT_USAGE
+    except UnicodeDecodeError as exc:
+        print(f"error: {args.rules}: not valid UTF-8 ({exc.reason})", file=sys.stderr)
         return EXIT_USAGE
 
     ruleset = parser.parse(str(doc_path), content)

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -7,6 +7,9 @@ import sys
 from gate_keeper import __version__
 from gate_keeper.diagnostics import EXIT_OK, EXIT_USAGE
 
+# Backend choices exposed by the registry (always includes auto).
+_BACKEND_CHOICES = ["auto", "filesystem", "github", "llm-rubric"]
+
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -37,9 +40,15 @@ def build_parser() -> argparse.ArgumentParser:
     validate_parser.add_argument("--target", required=True, help="artifact or PR to validate")
     validate_parser.add_argument(
         "--backend",
-        choices=["auto", "filesystem", "github", "llm"],
+        choices=_BACKEND_CHOICES,
         default="auto",
-        help="validation backend to use",
+        help="validation backend to use (default: auto)",
+    )
+    validate_parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="output format (default: text)",
     )
 
     return parser
@@ -69,6 +78,48 @@ def _cmd_compile(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def _cmd_validate(args: argparse.Namespace) -> int:
+    from pathlib import Path
+
+    from gate_keeper import classifier, parser, validator
+    from gate_keeper.backends import is_registered
+    from gate_keeper.diagnostics import compute_exit_code, render_json, render_text
+
+    # Validate backend choice defensively (argparse choices= should catch most).
+    backend = args.backend
+    if backend != "auto" and not is_registered(backend):
+        print(f"error: unknown backend {backend!r}", file=sys.stderr)
+        return EXIT_USAGE
+
+    # Read and compile the rule document.
+    doc_path = Path(args.rules)
+    if not doc_path.exists():
+        print(f"error: {args.rules}: No such file or directory", file=sys.stderr)
+        return EXIT_USAGE
+
+    try:
+        content = doc_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"error: {args.rules}: {exc.strerror}", file=sys.stderr)
+        return EXIT_USAGE
+
+    ruleset = parser.parse(str(doc_path), content)
+    ruleset = classifier.classify(ruleset)
+
+    # Run validation.
+    report = validator.validate(ruleset, args.target, backend=backend)
+
+    # Render output.
+    if args.format == "json":
+        print(render_json(report.diagnostics))
+    else:
+        rendered = render_text(report.diagnostics)
+        if rendered:
+            print(rendered)
+
+    return compute_exit_code(report.diagnostics)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -79,6 +130,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "compile":
         return _cmd_compile(args)
+
+    if args.command == "validate":
+        return _cmd_validate(args)
 
     parser.error(f"{args.command!r} is planned but not implemented in the scaffold")
     return 2

--- a/src/gate_keeper/validator.py
+++ b/src/gate_keeper/validator.py
@@ -37,12 +37,26 @@ from gate_keeper.models import (
 )
 
 
-def _error_diagnostic(rule: Rule, exc: Exception) -> Diagnostic:
-    """Wrap an unexpected backend exception in an ERROR diagnostic."""
+def _backend_for(name: str) -> Backend:
+    """Map a registered backend name to its IR ``Backend`` enum.
+
+    Registered names mirror enum values exactly; this raises ``ValueError`` only
+    if a caller registers a name outside the enum, which is a programmer error.
+    """
+    return Backend(name)
+
+
+def _error_diagnostic(rule: Rule, exc: Exception, backend: Backend) -> Diagnostic:
+    """Wrap an unexpected backend exception in an ERROR diagnostic.
+
+    The ``backend`` argument is the implementation that actually raised, so the
+    diagnostic attributes the failure correctly even when several backends are
+    registered.
+    """
     return Diagnostic(
         rule_id=rule.id,
         source=rule.source,
-        backend=Backend.FILESYSTEM,  # best-effort; real backend unknown at this point
+        backend=backend,
         status=Status.ERROR,
         severity=rule.severity,
         message=f"internal error during validation: {exc}",
@@ -55,18 +69,14 @@ def _error_diagnostic(rule: Rule, exc: Exception) -> Diagnostic:
     )
 
 
-def _resolve_check_fn(rule: Rule, backend_name: str):
-    """Return the check callable for *rule* given the chosen *backend_name*.
+def _resolve_backend_name(rule: Rule, backend_name: str) -> str:
+    """Return the registered backend name to use for *rule*.
 
     When ``backend_name`` is ``"auto"`` we use the rule's ``backend_hint``.
-    Returns ``None`` when the name is not registered (should not happen after
-    CLI validation, but handled defensively).
     """
     if backend_name == "auto":
-        name = rule.backend_hint.value  # e.g. "filesystem", "github", "llm-rubric"
-    else:
-        name = backend_name
-    return _registry.get(name)
+        return rule.backend_hint.value
+    return backend_name
 
 
 def validate(
@@ -98,23 +108,31 @@ def validate(
 
     diagnostics: list[Diagnostic] = []
     for rule in ruleset.rules:
-        check_fn = _resolve_check_fn(rule, backend)
+        resolved_name = _resolve_backend_name(rule, backend)
+        check_fn = _registry.get(resolved_name)
         if check_fn is None:
-            # Defensive: backend_hint points to an unregistered name.
+            # Defensive: name resolved from backend_hint is not registered.
+            # Attribute the diagnostic to the IR Backend that *should* have
+            # handled it when the name maps to one; otherwise fall back to
+            # filesystem (the local-only backend) so output stays renderable.
+            try:
+                attributed = _backend_for(resolved_name)
+            except ValueError:
+                attributed = Backend.FILESYSTEM
             diag = Diagnostic(
                 rule_id=rule.id,
                 source=rule.source,
-                backend=Backend.FILESYSTEM,
+                backend=attributed,
                 status=Status.UNAVAILABLE,
                 severity=rule.severity,
                 message=(
-                    f"no backend registered for {rule.backend_hint.value!r}; "
+                    f"no backend registered for {resolved_name!r}; "
                     "cannot validate rule"
                 ),
                 evidence=[
                     Evidence(
                         kind="registry_miss",
-                        data={"backend_hint": rule.backend_hint.value},
+                        data={"backend_hint": resolved_name},
                     )
                 ],
             )
@@ -122,7 +140,7 @@ def validate(
             try:
                 diag = check_fn(rule, target)
             except Exception as exc:  # noqa: BLE001
-                diag = _error_diagnostic(rule, exc)
+                diag = _error_diagnostic(rule, exc, _backend_for(resolved_name))
         diagnostics.append(diag)
 
     return DiagnosticReport(diagnostics=diagnostics)

--- a/src/gate_keeper/validator.py
+++ b/src/gate_keeper/validator.py
@@ -1,0 +1,131 @@
+"""Validation orchestrator for gate-keeper.
+
+``validate`` is the single runtime entry point that connects a compiled
+``RuleSet`` to the registered backends and produces a ``DiagnosticReport``.
+
+Dispatch policy
+---------------
+- ``backend == "auto"``: each rule is dispatched to the backend named by its
+  ``backend_hint`` field (the IR ``Backend`` enum value, e.g. ``"filesystem"``).
+- Any other registered name: every rule is sent to that backend; the backend is
+  expected to return ``UNSUPPORTED`` diagnostics for rule kinds it cannot handle.
+- Unknown name: raises ``ValueError`` (callers should validate before calling).
+
+Error policy
+------------
+The validator never raises.  Unexpected exceptions from a backend call are
+caught here and converted into ``Status.ERROR`` diagnostics so the pipeline
+always produces a report.
+
+Rule ordering
+-------------
+Diagnostics are emitted in the same order as ``ruleset.rules``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from gate_keeper import backends as _registry
+from gate_keeper.models import (
+    Backend,
+    Diagnostic,
+    DiagnosticReport,
+    Evidence,
+    Rule,
+    RuleSet,
+    Status,
+)
+
+
+def _error_diagnostic(rule: Rule, exc: Exception) -> Diagnostic:
+    """Wrap an unexpected backend exception in an ERROR diagnostic."""
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=Backend.FILESYSTEM,  # best-effort; real backend unknown at this point
+        status=Status.ERROR,
+        severity=rule.severity,
+        message=f"internal error during validation: {exc}",
+        evidence=[
+            Evidence(
+                kind="exception",
+                data={"type": type(exc).__name__, "message": str(exc)},
+            )
+        ],
+    )
+
+
+def _resolve_check_fn(rule: Rule, backend_name: str):
+    """Return the check callable for *rule* given the chosen *backend_name*.
+
+    When ``backend_name`` is ``"auto"`` we use the rule's ``backend_hint``.
+    Returns ``None`` when the name is not registered (should not happen after
+    CLI validation, but handled defensively).
+    """
+    if backend_name == "auto":
+        name = rule.backend_hint.value  # e.g. "filesystem", "github", "llm-rubric"
+    else:
+        name = backend_name
+    return _registry.get(name)
+
+
+def validate(
+    ruleset: RuleSet,
+    target: str | Path,
+    backend: str = "auto",
+) -> DiagnosticReport:
+    """Validate *ruleset* against *target* using *backend*.
+
+    Parameters
+    ----------
+    ruleset:
+        Compiled ``RuleSet`` (output of parse + classify).
+    target:
+        Local path or GitHub PR reference passed through to the backend.
+    backend:
+        ``"auto"`` dispatches each rule by its ``backend_hint``; any other
+        registered name sends all rules to that single backend.
+
+    Returns
+    -------
+    DiagnosticReport
+        One ``Diagnostic`` per rule, in source order.  Never raises.
+    """
+    if backend != "auto" and not _registry.is_registered(backend):
+        raise ValueError(
+            f"unknown backend {backend!r}; registered names: {_registry.BACKEND_NAMES}"
+        )
+
+    diagnostics: list[Diagnostic] = []
+    for rule in ruleset.rules:
+        check_fn = _resolve_check_fn(rule, backend)
+        if check_fn is None:
+            # Defensive: backend_hint points to an unregistered name.
+            diag = Diagnostic(
+                rule_id=rule.id,
+                source=rule.source,
+                backend=Backend.FILESYSTEM,
+                status=Status.UNAVAILABLE,
+                severity=rule.severity,
+                message=(
+                    f"no backend registered for {rule.backend_hint.value!r}; "
+                    "cannot validate rule"
+                ),
+                evidence=[
+                    Evidence(
+                        kind="registry_miss",
+                        data={"backend_hint": rule.backend_hint.value},
+                    )
+                ],
+            )
+        else:
+            try:
+                diag = check_fn(rule, target)
+            except Exception as exc:  # noqa: BLE001
+                diag = _error_diagnostic(rule, exc)
+        diagnostics.append(diag)
+
+    return DiagnosticReport(diagnostics=diagnostics)
+
+
+__all__ = ["validate"]

--- a/tests/fixtures/validate/rules-file-exists.md
+++ b/tests/fixtures/validate/rules-file-exists.md
@@ -1,0 +1,7 @@
+# Validate CLI Test Rules
+
+Minimal filesystem rules used by test_cli_validate.py.
+
+## File Checks
+
+- `README.md` must exist.

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -53,3 +53,14 @@ def test_compile_output_has_mixed_backends(capsys):
     backends = {rule["backend_hint"] for rule in data["rules"]}
     assert "filesystem" in backends
     assert "github" in backends
+
+
+def test_compile_non_utf8_input_exits_2(tmp_path, capsys):
+    """A document that exists but is not valid UTF-8 must surface as a usage error."""
+    bad = tmp_path / "binary.md"
+    bad.write_bytes(b"\xff\xfe not utf-8 \x80\x81")
+    rc = main(["compile", str(bad), "--format", "json"])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "error:" in captured.err
+    assert "UTF-8" in captured.err

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -1,0 +1,241 @@
+"""Tests for gate-keeper validate command."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gate_keeper.cli import main
+from gate_keeper.diagnostics import EXIT_FAIL, EXIT_OK, EXIT_USAGE
+
+REPO_ROOT = Path(__file__).parent.parent
+EXAMPLE_DOC = REPO_ROOT / "docs" / "example-rules.md"
+LOCAL_FIXTURES = Path(__file__).parent / "fixtures" / "local"
+PASS_DIR = LOCAL_FIXTURES / "pass"
+FAIL_DIR = LOCAL_FIXTURES / "fail"
+PASS_README = PASS_DIR / "README.md"
+# A minimal rules doc that produces exactly one file_exists rule.
+SIMPLE_RULES = Path(__file__).parent / "fixtures" / "validate" / "rules-file-exists.md"
+
+
+# ---------------------------------------------------------------------------
+# Basic invocation
+# ---------------------------------------------------------------------------
+
+
+class TestBasicInvocation:
+    def test_validate_existing_file_exits_zero(self, capsys):
+        """Simple file-exists rule against an existing file exits 0."""
+        rc = main([
+            "validate", str(SIMPLE_RULES),
+            "--target", str(PASS_README),
+            "--backend", "filesystem",
+            "--format", "text",
+        ])
+        assert rc == EXIT_OK
+
+    def test_validate_missing_document_exits_2(self, capsys):
+        rc = main([
+            "validate", "/nonexistent/rules.md",
+            "--target", str(PASS_DIR),
+            "--backend", "auto",
+        ])
+        assert rc == EXIT_USAGE
+        captured = capsys.readouterr()
+        assert "error:" in captured.err
+
+    def test_validate_text_format_produces_output(self, capsys):
+        rc = main([
+            "validate", str(SIMPLE_RULES),
+            "--target", str(PASS_README),
+            "--backend", "filesystem",
+            "--format", "text",
+        ])
+        captured = capsys.readouterr()
+        assert rc == EXIT_OK
+        # text format includes backend/status in square brackets
+        assert "[filesystem/" in captured.out
+
+    def test_validate_json_format_produces_valid_json(self, capsys):
+        rc = main([
+            "validate", str(SIMPLE_RULES),
+            "--target", str(PASS_README),
+            "--backend", "filesystem",
+            "--format", "json",
+        ])
+        assert rc == EXIT_OK
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "diagnostics" in data
+        assert isinstance(data["diagnostics"], list)
+        assert len(data["diagnostics"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Backend choices
+# ---------------------------------------------------------------------------
+
+
+class TestBackendChoices:
+    def test_auto_backend_accepted(self, capsys):
+        """auto backend routes the file_exists rule to filesystem → PASS."""
+        rc = main([
+            "validate", str(SIMPLE_RULES),
+            "--target", str(PASS_README),
+            "--backend", "auto",
+        ])
+        assert rc == EXIT_OK
+
+    def test_filesystem_backend_accepted(self, capsys):
+        rc = main([
+            "validate", str(SIMPLE_RULES),
+            "--target", str(PASS_README),
+            "--backend", "filesystem",
+        ])
+        assert rc == EXIT_OK
+
+    def test_github_backend_accepted_but_unavailable(self, capsys):
+        """github backend is registered; file_exists → UNSUPPORTED → exit 1."""
+        rc = main([
+            "validate", str(SIMPLE_RULES),
+            "--target", str(PASS_README),
+            "--backend", "github",
+        ])
+        # github stub returns UNAVAILABLE for all rules → exit 1
+        assert rc == EXIT_FAIL
+
+    def test_llm_rubric_backend_accepted_but_unavailable(self, capsys):
+        """llm-rubric backend is registered; all rules → UNAVAILABLE → exit 1."""
+        rc = main([
+            "validate", str(SIMPLE_RULES),
+            "--target", str(PASS_README),
+            "--backend", "llm-rubric",
+        ])
+        assert rc == EXIT_FAIL
+
+    def test_unknown_backend_rejected_by_argparse(self, capsys):
+        """argparse rejects unknown backend names before main() runs."""
+        with pytest.raises(SystemExit) as exc_info:
+            main([
+                "validate", str(SIMPLE_RULES),
+                "--target", str(PASS_README),
+                "--backend", "totally-fake",
+            ])
+        assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# Exit codes
+# ---------------------------------------------------------------------------
+
+
+class TestExitCodes:
+    def test_file_exists_pass_exits_0(self, capsys):
+        """File exists → PASS → exit 0."""
+        rc = main([
+            "validate", str(SIMPLE_RULES),
+            "--target", str(PASS_README),
+            "--backend", "filesystem",
+        ])
+        assert rc == EXIT_OK
+
+    def test_file_exists_missing_exits_1(self, capsys):
+        """File missing → FAIL → exit 1."""
+        missing = FAIL_DIR / "README.md"
+        rc = main([
+            "validate", str(SIMPLE_RULES),
+            "--target", str(missing),
+            "--backend", "filesystem",
+        ])
+        assert rc == EXIT_FAIL
+
+
+# ---------------------------------------------------------------------------
+# Example rules document smoke test (acceptance criterion AC-6)
+# ---------------------------------------------------------------------------
+
+
+class TestExampleRulesSmoke:
+    def test_example_rules_auto_pass_fixture_does_not_raise(self, capsys):
+        """AC-6: runs without exception; emits diagnostics; returns a numeric exit code."""
+        rc = main([
+            "validate", str(EXAMPLE_DOC),
+            "--target", str(PASS_DIR),
+            "--backend", "auto",
+        ])
+        # filesystem rules pass; github/llm-rubric stubs are UNAVAILABLE → exit 1
+        assert rc in (EXIT_OK, EXIT_FAIL)
+        captured = capsys.readouterr()
+        # Should produce diagnostic output on stdout (at least one line)
+        assert captured.out.strip()
+
+    def test_example_rules_json_format_valid_report(self, capsys):
+        rc = main([
+            "validate", str(EXAMPLE_DOC),
+            "--target", str(PASS_DIR),
+            "--backend", "auto",
+            "--format", "json",
+        ])
+        assert rc in (EXIT_OK, EXIT_FAIL)
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "diagnostics" in data
+        # Every diagnostic must carry required fields
+        for diag in data["diagnostics"]:
+            assert "rule_id" in diag
+            assert "status" in diag
+            assert "backend" in diag
+            assert "severity" in diag
+            assert "message" in diag
+            assert "evidence" in diag
+
+    def test_example_rules_has_github_unavailable_diagnostics(self, capsys):
+        """GitHub rules in example-rules.md produce UNAVAILABLE (fail-closed)."""
+        main([
+            "validate", str(EXAMPLE_DOC),
+            "--target", str(PASS_DIR),
+            "--backend", "auto",
+            "--format", "json",
+        ])
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        statuses = {d["status"] for d in data["diagnostics"]}
+        # github stubs return unavailable → fail-closed
+        assert "unavailable" in statuses
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic field contract
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticFields:
+    def test_all_diagnostics_have_required_fields_in_json(self, capsys):
+        main([
+            "validate", str(SIMPLE_RULES),
+            "--target", str(PASS_README),
+            "--backend", "filesystem",
+            "--format", "json",
+        ])
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        for diag in data["diagnostics"]:
+            assert "rule_id" in diag
+            assert "source" in diag
+            assert "backend" in diag
+            assert "status" in diag
+            assert "severity" in diag
+            assert "message" in diag
+            assert "evidence" in diag
+
+    def test_text_format_includes_backend_and_status(self, capsys):
+        main([
+            "validate", str(SIMPLE_RULES),
+            "--target", str(PASS_README),
+            "--backend", "filesystem",
+            "--format", "text",
+        ])
+        captured = capsys.readouterr()
+        # text format: [backend/status] in every line
+        assert "[filesystem/" in captured.out

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -45,6 +45,19 @@ class TestBasicInvocation:
         captured = capsys.readouterr()
         assert "error:" in captured.err
 
+    def test_validate_non_utf8_document_exits_2(self, tmp_path, capsys):
+        bad = tmp_path / "binary.md"
+        bad.write_bytes(b"\xff\xfe not utf-8 \x80\x81")
+        rc = main([
+            "validate", str(bad),
+            "--target", str(PASS_DIR),
+            "--backend", "auto",
+        ])
+        assert rc == EXIT_USAGE
+        captured = capsys.readouterr()
+        assert "error:" in captured.err
+        assert "UTF-8" in captured.err
+
     def test_validate_text_format_produces_output(self, capsys):
         rc = main([
             "validate", str(SIMPLE_RULES),

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,226 @@
+"""Unit tests for gate_keeper.validator — the validation orchestrator.
+
+All backend interactions use lightweight stubs registered via the registry so
+no filesystem I/O or network access is required.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from gate_keeper import backends as registry
+from gate_keeper.models import (
+    Backend,
+    Confidence,
+    Diagnostic,
+    DiagnosticReport,
+    Evidence,
+    Rule,
+    RuleKind,
+    Severity,
+    SourceLocation,
+    Status,
+)
+from gate_keeper.validator import validate
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _rule(
+    rule_id: str = "test-rule",
+    kind: RuleKind = RuleKind.FILE_EXISTS,
+    backend_hint: Backend = Backend.FILESYSTEM,
+) -> Rule:
+    return Rule(
+        id=rule_id,
+        title="Test rule",
+        source=SourceLocation(path="test.md", line=1),
+        text="test rule text",
+        kind=kind,
+        severity=Severity.ERROR,
+        backend_hint=backend_hint,
+        confidence=Confidence.HIGH,
+        params={},
+    )
+
+
+def _make_ruleset(*rules: Rule):
+    from gate_keeper.models import RuleSet
+    return RuleSet(rules=list(rules))
+
+
+def _stub_diag(rule: Rule, status: Status, backend: Backend) -> Diagnostic:
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=backend,
+        status=status,
+        severity=rule.severity,
+        message=f"stub: {status.value}",
+        evidence=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auto-dispatch tests
+# ---------------------------------------------------------------------------
+
+
+class TestAutoDispatch:
+    """In 'auto' mode each rule is routed by its backend_hint."""
+
+    def test_filesystem_rule_dispatched_to_filesystem(self, tmp_path):
+        rule = _rule(kind=RuleKind.FILE_EXISTS, backend_hint=Backend.FILESYSTEM)
+        # The real filesystem backend is used; tmp_path exists → PASS.
+        report = validate(_make_ruleset(rule), tmp_path, backend="auto")
+        assert len(report.diagnostics) == 1
+        assert report.diagnostics[0].backend is Backend.FILESYSTEM
+        assert report.diagnostics[0].status is Status.PASS
+
+    def test_github_rule_dispatched_to_github_stub(self, tmp_path):
+        rule = _rule(kind=RuleKind.GITHUB_PR_OPEN, backend_hint=Backend.GITHUB)
+        report = validate(_make_ruleset(rule), tmp_path, backend="auto")
+        assert len(report.diagnostics) == 1
+        diag = report.diagnostics[0]
+        assert diag.backend is Backend.GITHUB
+        assert diag.status is Status.UNAVAILABLE
+
+    def test_llm_rule_dispatched_to_llm_stub(self, tmp_path):
+        rule = _rule(kind=RuleKind.SEMANTIC_RUBRIC, backend_hint=Backend.LLM_RUBRIC)
+        report = validate(_make_ruleset(rule), tmp_path, backend="auto")
+        assert len(report.diagnostics) == 1
+        diag = report.diagnostics[0]
+        assert diag.backend is Backend.LLM_RUBRIC
+        assert diag.status is Status.UNAVAILABLE
+
+    def test_order_preserved_with_mixed_backends(self, tmp_path):
+        r1 = _rule("r1", RuleKind.FILE_EXISTS, Backend.FILESYSTEM)
+        r2 = _rule("r2", RuleKind.GITHUB_PR_OPEN, Backend.GITHUB)
+        r3 = _rule("r3", RuleKind.SEMANTIC_RUBRIC, Backend.LLM_RUBRIC)
+        report = validate(_make_ruleset(r1, r2, r3), tmp_path, backend="auto")
+        ids = [d.rule_id for d in report.diagnostics]
+        assert ids == ["r1", "r2", "r3"]
+
+
+# ---------------------------------------------------------------------------
+# Explicit backend tests
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitBackend:
+    """Named backend sends all rules through that single backend."""
+
+    def test_filesystem_explicit_passes_filesystem_rule(self, tmp_path):
+        rule = _rule(kind=RuleKind.FILE_EXISTS, backend_hint=Backend.FILESYSTEM)
+        report = validate(_make_ruleset(rule), tmp_path, backend="filesystem")
+        assert report.diagnostics[0].status is Status.PASS
+        assert report.diagnostics[0].backend is Backend.FILESYSTEM
+
+    def test_filesystem_explicit_unsupported_for_github_rule(self, tmp_path):
+        rule = _rule(kind=RuleKind.GITHUB_PR_OPEN, backend_hint=Backend.GITHUB)
+        report = validate(_make_ruleset(rule), tmp_path, backend="filesystem")
+        diag = report.diagnostics[0]
+        # filesystem backend returns UNSUPPORTED for github rules
+        assert diag.status is Status.UNSUPPORTED
+        assert diag.backend is Backend.FILESYSTEM
+
+    def test_github_explicit_all_rules_use_github(self, tmp_path):
+        r1 = _rule("r1", RuleKind.FILE_EXISTS, Backend.FILESYSTEM)
+        r2 = _rule("r2", RuleKind.GITHUB_PR_OPEN, Backend.GITHUB)
+        report = validate(_make_ruleset(r1, r2), tmp_path, backend="github")
+        for diag in report.diagnostics:
+            assert diag.backend is Backend.GITHUB
+
+    def test_llm_rubric_explicit_all_rules_unavailable(self, tmp_path):
+        r1 = _rule("r1", RuleKind.FILE_EXISTS, Backend.FILESYSTEM)
+        r2 = _rule("r2", RuleKind.SEMANTIC_RUBRIC, Backend.LLM_RUBRIC)
+        report = validate(_make_ruleset(r1, r2), tmp_path, backend="llm-rubric")
+        for diag in report.diagnostics:
+            assert diag.status is Status.UNAVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# Unknown backend raises ValueError
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownBackend:
+    def test_unknown_backend_raises_value_error(self, tmp_path):
+        rule = _rule()
+        with pytest.raises(ValueError, match="unknown backend"):
+            validate(_make_ruleset(rule), tmp_path, backend="nonexistent-backend")
+
+
+# ---------------------------------------------------------------------------
+# Error wrapping — exceptions from backend become ERROR diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestErrorWrapping:
+    """Unexpected exceptions from a backend call become Status.ERROR diagnostics."""
+
+    def test_backend_exception_becomes_error_diagnostic(self, tmp_path, monkeypatch):
+        rule = _rule(kind=RuleKind.FILE_EXISTS, backend_hint=Backend.FILESYSTEM)
+
+        def _raise(r, t):
+            raise RuntimeError("simulated crash")
+
+        monkeypatch.setitem(registry._REGISTRY, "filesystem", _raise)
+        report = validate(_make_ruleset(rule), tmp_path, backend="filesystem")
+        diag = report.diagnostics[0]
+        assert diag.status is Status.ERROR
+        assert "simulated crash" in diag.message
+        assert any(e.kind == "exception" for e in diag.evidence)
+
+    def test_error_diagnostic_round_trips(self, tmp_path, monkeypatch):
+        rule = _rule(kind=RuleKind.FILE_EXISTS, backend_hint=Backend.FILESYSTEM)
+
+        def _raise(r, t):
+            raise ValueError("boom")
+
+        monkeypatch.setitem(registry._REGISTRY, "filesystem", _raise)
+        report = validate(_make_ruleset(rule), tmp_path, backend="filesystem")
+        diag = report.diagnostics[0]
+        rebuilt = Diagnostic.from_dict(diag.to_dict())
+        assert rebuilt.status is Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# Empty ruleset
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyRuleset:
+    def test_empty_ruleset_returns_empty_report(self, tmp_path):
+        report = validate(_make_ruleset(), tmp_path, backend="auto")
+        assert isinstance(report, DiagnosticReport)
+        assert report.diagnostics == []
+
+
+# ---------------------------------------------------------------------------
+# Return type contract
+# ---------------------------------------------------------------------------
+
+
+class TestReturnContract:
+    def test_returns_diagnostic_report(self, tmp_path):
+        rule = _rule()
+        report = validate(_make_ruleset(rule), tmp_path)
+        assert isinstance(report, DiagnosticReport)
+
+    def test_one_diagnostic_per_rule(self, tmp_path):
+        rules = [_rule(f"r{i}") for i in range(5)]
+        report = validate(_make_ruleset(*rules), tmp_path)
+        assert len(report.diagnostics) == 5
+
+    def test_diagnostics_carry_rule_ids(self, tmp_path):
+        r1 = _rule("alpha")
+        r2 = _rule("beta")
+        report = validate(_make_ruleset(r1, r2), tmp_path)
+        ids = [d.rule_id for d in report.diagnostics]
+        assert ids == ["alpha", "beta"]


### PR DESCRIPTION
Closes #8

## Summary
Adds the runtime path that connects compiled rules to validation backends.

- New `src/gate_keeper/validator.py` with `validate(ruleset, target, backend="auto")`. Auto routes each rule by its `backend_hint`; named modes route every rule through one backend (filesystem returns `unsupported` for non-filesystem rule kinds).
- New backend interface (`src/gate_keeper/backends/base.py`) and a name-keyed registry in `src/gate_keeper/backends/__init__.py`. Three backends are registered for MVP: `filesystem` (real), `github` (stub returning `unavailable`), `llm-rubric` (stub returning `unavailable`). Stubs keep `--backend github` a known choice rather than a usage error while later issues fill them in.
- `validate` CLI subcommand wired up: parse → classify → validate → render → exit code via `compute_exit_code`. `--format {text,json}` mirrors `compile`.
- Validator never raises. Backend exceptions become `Status.ERROR` diagnostics that carry the backend that actually raised. Registry misses become `Status.UNAVAILABLE`.
- Rule order from the source document is preserved in the diagnostic report.

## Validation
- `uv run pytest` → **262 passed** (229 pre-existing + 33 new across `test_validator.py`, `test_cli_validate.py`, and the non-UTF-8 cases on both CLI subcommands).
- Smoke: `uv run gate-keeper validate docs/example-rules.md --target tests/fixtures/local/pass --backend auto` → exits 1, with filesystem rules passing and github stub rules emitting `unavailable` (expected, fail-closed).
- `uv run gate-keeper validate ... --backend filesystem` against the same target → exits 0 (filesystem-only routing skips github stub rules as `unsupported`).

## Codex review
Run: `codex review --base main` against the worktree. Findings posted as a PR comment. Both fixed in commit `0f6be08`:
- [P2] `UnicodeDecodeError` on rule document read now surfaces as `EXIT_USAGE` on both `compile` and `validate`.
- [P3] ERROR / registry-miss diagnostics now carry the backend that actually owned the failure instead of always pointing at filesystem.

## Notes / followups
- `github` and `llm-rubric` are stubs by design here. Real implementations land in #9-#14 (github) and #15 (llm rubric).

🤖 Generated with [Claude Code](https://claude.com/claude-code)