### PR TITLE
feat(github): PR target resolver (#9)

### DIFF
--- a/src/gate_keeper/backends/_target.py
+++ b/src/gate_keeper/backends/_target.py
@@ -228,17 +228,23 @@ def resolve_target(rule: Rule, target: str) -> tuple[PrTarget | None, Diagnostic
     if err is not None:
         return None, gh_json_diag(rule, "pr-view", err)
 
-    # Validate required fields
+    # Validate required fields. We check both presence AND that the value is of
+    # the expected type so a malformed response (e.g. ``number: null``) is
+    # surfaced as a Diagnostic rather than raising during int coercion.
     if "url" not in data:
         return None, gh_missing_field_diag(rule, "pr-view", "url")
     if "number" not in data:
+        return None, gh_missing_field_diag(rule, "pr-view", "number")
+    if not isinstance(data["url"], str) or not data["url"]:
+        return None, gh_missing_field_diag(rule, "pr-view", "url")
+    if not isinstance(data["number"], int) or isinstance(data["number"], bool):
         return None, gh_missing_field_diag(rule, "pr-view", "number")
 
     # Build refreshed PrTarget using gh-canonical values
     refreshed = PrTarget(
         owner=t.owner,
         repo=t.repo,
-        number=int(data["number"]),
+        number=data["number"],
         url=data["url"],
     )
     return refreshed, None

--- a/src/gate_keeper/backends/_target.py
+++ b/src/gate_keeper/backends/_target.py
@@ -1,0 +1,251 @@
+"""GitHub PR target resolver for gate-keeper.
+
+Provides:
+- PrTarget         — frozen dataclass carrying owner, repo, number, and URL.
+- parse_target()   — pure-string parser; no I/O.
+- resolve_target() — live resolver that shells out through run_gh() to confirm
+                     that the PR exists and returns a gh-canonical PrTarget.
+
+Consumers (#10-#13) should call resolve_target() at the start of each
+per-rule check and short-circuit with the returned Diagnostic on failure.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from gate_keeper.backends._gh import (
+    classify_gh_failure,
+    failure_diag,
+    gh_json_diag,
+    gh_missing_field_diag,
+    parse_json,
+    run_gh,
+)
+from gate_keeper.models import Backend, Diagnostic, Evidence, Rule, Status
+
+# ---------------------------------------------------------------------------
+# Compiled regexes for the two supported target formats.
+#
+# 1. HTTPS PR URL — optional http (upgraded to https canonical), optional
+#    www., optional trailing slash, optional query/fragment.
+#    Choice: http:// is accepted here and silently upgraded to https in the
+#    canonical URL.  This is intentional — GH redirects http→https anyway and
+#    refusing it would surprise callers with copy-pasted URLs.
+# ---------------------------------------------------------------------------
+
+_URL_RE = re.compile(
+    r"^https?://(?:www\.)?github\.com"
+    r"/([^/\s]+)"      # owner
+    r"/([^/\s]+)"      # repo
+    r"/pull/(\d+)"     # PR number
+    r"/?(?:[?#].*)?"   # optional trailing slash, query, fragment
+    r"$",
+    re.IGNORECASE,
+)
+
+# 2. OWNER/REPO#NUMBER shorthand
+_SHORTHAND_RE = re.compile(
+    r"^([A-Za-z0-9._-]+)/([A-Za-z0-9._-]+)#(\d+)$"
+)
+
+
+# ---------------------------------------------------------------------------
+# PrTarget
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PrTarget:
+    """Resolved, validated GitHub pull request coordinates."""
+
+    owner: str
+    repo: str
+    number: int
+    url: str
+
+
+# ---------------------------------------------------------------------------
+# parse_target — pure string parsing, no I/O
+# ---------------------------------------------------------------------------
+
+
+def parse_target(target: str) -> tuple[PrTarget | None, str | None]:
+    """Parse *target* into a PrTarget without performing any I/O.
+
+    Returns ``(PrTarget, None)`` on success, ``(None, reason)`` on failure.
+
+    Accepted formats
+    ----------------
+    - HTTPS PR URL: ``https://github.com/OWNER/REPO/pull/NUMBER``
+      (also tolerates ``http://``, ``www.``, trailing slash, query string,
+      and fragment; the canonical URL stored on PrTarget is the https form
+      with no trailing slash, query, or fragment).
+    - Shorthand: ``OWNER/REPO#NUMBER``
+
+    Validation
+    ----------
+    - Owner and repo must be non-empty after stripping whitespace.
+    - PR number must be a positive integer (> 0).
+    - URL must point at ``/pull/``, not ``/issues/`` or any other path.
+    - Host must be github.com (not gitlab.com, etc.).
+    """
+    stripped = target.strip()
+    if not stripped:
+        return None, f"target {target!r} is not a recognized PR URL or OWNER/REPO#N shorthand"
+
+    # --- Try URL form first ---
+    m = _URL_RE.match(stripped)
+    if m:
+        owner, repo, num_str = m.group(1), m.group(2), m.group(3)
+
+        # Reject whitespace-only captures (the regex already ensures non-empty
+        # via [^/\s]+, but be explicit for clarity).
+        if not owner.strip() or not repo.strip():
+            return None, f"target {target!r} has an empty owner or repo segment"
+
+        number = int(num_str)
+        if number <= 0:
+            return None, f"target {target!r} has PR number {number}; must be a positive integer"
+
+        # Build canonical https URL (strip query, fragment, trailing slash).
+        canonical_url = f"https://github.com/{owner}/{repo}/pull/{number}"
+        return PrTarget(owner=owner, repo=repo, number=number, url=canonical_url), None
+
+    # --- Try shorthand form ---
+    m = _SHORTHAND_RE.match(stripped)
+    if m:
+        owner, repo, num_str = m.group(1), m.group(2), m.group(3)
+
+        # Owner/repo already validated non-empty by the character class [A-Za-z0-9._-]+.
+        number = int(num_str)
+        if number <= 0:
+            return None, f"target {target!r} has PR number {number}; must be a positive integer"
+
+        canonical_url = f"https://github.com/{owner}/{repo}/pull/{number}"
+        return PrTarget(owner=owner, repo=repo, number=number, url=canonical_url), None
+
+    # --- No match ---
+    return None, f"target {target!r} is not a recognized PR URL or OWNER/REPO#N shorthand"
+
+
+# ---------------------------------------------------------------------------
+# _not_found_stderr — detect PR/repo-not-found from gh stderr
+# ---------------------------------------------------------------------------
+
+_NOT_FOUND_PATTERNS = (
+    "could not resolve to a repository",
+    "could not resolve to a node",
+    "no pull requests found",
+    "not found",
+)
+
+
+def _looks_like_not_found(stderr: str) -> bool:
+    lower = stderr.lower()
+    return any(pat in lower for pat in _NOT_FOUND_PATTERNS)
+
+
+# ---------------------------------------------------------------------------
+# resolve_target — live resolver
+# ---------------------------------------------------------------------------
+
+
+def resolve_target(rule: Rule, target: str) -> tuple[PrTarget | None, Diagnostic | None]:
+    """Resolve *target* to a confirmed PrTarget by calling ``gh pr view``.
+
+    Step 1 — parse_target (pure string; no I/O).
+    Step 2 — call ``gh pr view <NUMBER> -R OWNER/REPO --json number,url`` to
+              confirm the PR exists and obtain the gh-canonical URL.
+
+    Returns ``(PrTarget, None)`` on success, ``(None, Diagnostic)`` on any
+    failure.  The caller must propagate the Diagnostic to the check result.
+    """
+    # Step 1: parse
+    t, reason = parse_target(target)
+    if t is None:
+        diag = Diagnostic(
+            rule_id=rule.id,
+            source=rule.source,
+            backend=Backend.GITHUB,
+            status=Status.UNAVAILABLE,
+            severity=rule.severity,
+            message=f"Cannot resolve GitHub target: {reason}",
+            evidence=[
+                Evidence(
+                    kind="target_parse_error",
+                    data={"target": target, "reason": reason},
+                )
+            ],
+        )
+        return None, diag
+
+    # Step 2: verify with gh
+    argv = ["pr", "view", str(t.number), "-R", f"{t.owner}/{t.repo}", "--json", "number,url"]
+    result = run_gh(argv)
+
+    if result.binary_missing:
+        return None, failure_diag(rule, "pr-view", result)
+
+    if not result.ok:
+        category = classify_gh_failure(result)
+        if category == "auth":
+            return None, failure_diag(rule, "pr-view", result)
+
+        if _looks_like_not_found(result.stderr):
+            stderr_excerpt = result.stderr[:300]
+            if len(result.stderr) > 300:
+                stderr_excerpt += "…"
+            diag = Diagnostic(
+                rule_id=rule.id,
+                source=rule.source,
+                backend=Backend.GITHUB,
+                status=Status.UNAVAILABLE,
+                severity=rule.severity,
+                message=(
+                    f"GitHub PR {t.owner}/{t.repo}#{t.number} could not be found "
+                    f"or repository does not exist."
+                ),
+                evidence=[
+                    Evidence(
+                        kind="gh_pr_not_found",
+                        data={
+                            "op": "pr-view",
+                            "owner": t.owner,
+                            "repo": t.repo,
+                            "number": t.number,
+                            "stderr_excerpt": stderr_excerpt,
+                        },
+                    )
+                ],
+            )
+            return None, diag
+
+        return None, failure_diag(rule, "pr-view", result)
+
+    # Parse JSON response
+    data, err = parse_json(result.stdout)
+    if err is not None:
+        return None, gh_json_diag(rule, "pr-view", err)
+
+    # Validate required fields
+    if "url" not in data:
+        return None, gh_missing_field_diag(rule, "pr-view", "url")
+    if "number" not in data:
+        return None, gh_missing_field_diag(rule, "pr-view", "number")
+
+    # Build refreshed PrTarget using gh-canonical values
+    refreshed = PrTarget(
+        owner=t.owner,
+        repo=t.repo,
+        number=int(data["number"]),
+        url=data["url"],
+    )
+    return refreshed, None
+
+
+__all__ = [
+    "PrTarget",
+    "parse_target",
+    "resolve_target",
+]

--- a/src/gate_keeper/backends/github.py
+++ b/src/gate_keeper/backends/github.py
@@ -35,22 +35,43 @@ name = "github"
 
 
 def check(rule: Rule, target: str | Path) -> Diagnostic:
-    """Return UNAVAILABLE; per-rule GitHub checks land in issues #9-#13.
+    """Resolve the target, then report UNAVAILABLE for the rule kind.
 
-    The message follows the same shape as future auth/network failures so
-    callers can recognise the pattern without special-casing the stub.
+    Per-rule GitHub checks land in issues #10-#13. Until then this entry point
+    still goes through ``resolve_target`` so any target-level failure (bad
+    target shape, missing ``gh``, auth failure, repo/PR not found, malformed
+    response) surfaces with the right diagnostic shape and the resolver is
+    exercised end-to-end via the registered backend path.
+
+    On successful resolution the diagnostic still reports UNAVAILABLE — this
+    is fail-closed by design until the per-rule logic exists.
     """
+    target_str = str(target)
+    pr, diag = resolve_target(rule, target_str)
+    if diag is not None:
+        return diag
+
     return Diagnostic(
         rule_id=rule.id,
         source=rule.source,
         backend=Backend.GITHUB,
         status=Status.UNAVAILABLE,
         severity=rule.severity,
-        message=f"github backend rule kind {rule.kind.value!r} not yet implemented (#9-#13)",
+        message=(
+            f"target resolved to {pr.owner}/{pr.repo}#{pr.number}; "
+            f"rule kind {rule.kind.value!r} not yet implemented (#10-#13)"
+        ),
         evidence=[
             Evidence(
                 kind="backend_stub",
-                data={"backend": "github", "rule_kind": rule.kind.value},
+                data={
+                    "backend": "github",
+                    "rule_kind": rule.kind.value,
+                    "owner": pr.owner,
+                    "repo": pr.repo,
+                    "number": pr.number,
+                    "url": pr.url,
+                },
             )
         ],
     )

--- a/src/gate_keeper/backends/github.py
+++ b/src/gate_keeper/backends/github.py
@@ -25,6 +25,10 @@ from gate_keeper.backends._gh import (  # noqa: F401  (re-export)
     parse_json,
     run_gh,
 )
+from gate_keeper.backends._target import (  # noqa: F401  (re-export)
+    PrTarget,
+    resolve_target,
+)
 from gate_keeper.models import Backend, Diagnostic, Evidence, Rule, Status
 
 name = "github"

--- a/tests/test_github_backend_stub.py
+++ b/tests/test_github_backend_stub.py
@@ -48,10 +48,31 @@ class TestGithubBackendStub:
         diag = gh_backend.check(rule, tmp_path)
         assert diag.backend is Backend.GITHUB
 
-    def test_check_message_names_rule_kind(self, tmp_path):
+    def test_check_message_names_rule_kind_when_target_resolves(self, monkeypatch):
+        """When the target resolves, the diag still names the rule kind."""
+        from gate_keeper.backends import _gh, _target
+
+        def _fake_run_gh(args, **kwargs):
+            return _gh.GhResult(
+                ok=True,
+                stdout='{"number": 42, "url": "https://github.com/owner/repo/pull/42"}',
+                stderr="",
+                returncode=0,
+                cmd=("gh", *args),
+            )
+
+        monkeypatch.setattr(_target, "run_gh", _fake_run_gh)
+        rule = _github_rule(RuleKind.GITHUB_NOT_DRAFT)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert "github_not_draft" in diag.message
+
+    def test_check_invalid_target_surfaces_target_parse_error(self, tmp_path):
+        """A non-PR target now surfaces a parse-error diagnostic via the resolver."""
         rule = _github_rule(RuleKind.GITHUB_NOT_DRAFT)
         diag = gh_backend.check(rule, tmp_path)
-        assert "github_not_draft" in diag.message
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "target_parse_error"
 
     @pytest.mark.parametrize(
         "kind",
@@ -66,6 +87,8 @@ class TestGithubBackendStub:
         ],
     )
     def test_all_github_kinds_return_unavailable(self, tmp_path, kind):
+        # tmp_path is not a valid PR target; the resolver fails closed and
+        # the diagnostic is UNAVAILABLE/github (the parse-error path).
         rule = _github_rule(kind)
         diag = gh_backend.check(rule, tmp_path)
         assert diag.status is Status.UNAVAILABLE

--- a/tests/test_target_resolver.py
+++ b/tests/test_target_resolver.py
@@ -1,0 +1,503 @@
+"""Tests for the GitHub PR target resolver (gate_keeper.backends._target).
+
+Covers:
+- parse_target: valid and invalid input formats
+- resolve_target: full path with monkeypatched run_gh
+- Command construction: exact argv captured
+- Round-trip schema compliance for all produced Diagnostic shapes
+"""
+from __future__ import annotations
+
+import pytest
+
+from gate_keeper.backends._target import PrTarget, parse_target, resolve_target
+from gate_keeper.backends._gh import GhResult
+from gate_keeper.models import (
+    Backend,
+    Confidence,
+    Diagnostic,
+    Rule,
+    RuleKind,
+    Severity,
+    SourceLocation,
+    Status,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _rule(rule_id: str = "test-rule") -> Rule:
+    return Rule(
+        id=rule_id,
+        title="Test GitHub rule",
+        source=SourceLocation(path="rules.md", line=1),
+        text="some rule text",
+        kind=RuleKind.GITHUB_PR_OPEN,
+        severity=Severity.ERROR,
+        backend_hint=Backend.GITHUB,
+        confidence=Confidence.HIGH,
+        params={},
+    )
+
+
+def _ok_gh_result(number: int = 123, owner: str = "octocat", repo: str = "hello") -> GhResult:
+    return GhResult(
+        ok=True,
+        stdout=f'{{"number":{number},"url":"https://github.com/{owner}/{repo}/pull/{number}"}}',
+        stderr="",
+        returncode=0,
+        cmd=("gh", "pr", "view", str(number), "-R", f"{owner}/{repo}", "--json", "number,url"),
+    )
+
+
+def _missing_binary_result() -> GhResult:
+    return GhResult(
+        ok=False,
+        stdout="",
+        stderr="gh binary not found",
+        returncode=127,
+        cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
+        binary_missing=True,
+    )
+
+
+def _auth_failure_result() -> GhResult:
+    return GhResult(
+        ok=False,
+        stdout="",
+        stderr="To get started, please run: gh auth login",
+        returncode=1,
+        cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
+    )
+
+
+def _pr_not_found_result() -> GhResult:
+    return GhResult(
+        ok=False,
+        stdout="",
+        stderr="GraphQL: Could not resolve to a Repository with the name 'octo/missing'",
+        returncode=1,
+        cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# parse_target — valid inputs
+# ---------------------------------------------------------------------------
+
+
+class TestParseTargetValid:
+    def test_full_https_url(self):
+        t, err = parse_target("https://github.com/octocat/hello/pull/123")
+        assert err is None
+        assert t is not None
+        assert t.owner == "octocat"
+        assert t.repo == "hello"
+        assert t.number == 123
+        assert t.url == "https://github.com/octocat/hello/pull/123"
+
+    def test_url_with_trailing_slash_and_query_and_fragment(self):
+        t, err = parse_target("https://github.com/octocat/hello/pull/123/?notify=true#discussion")
+        assert err is None
+        assert t is not None
+        assert t.number == 123
+        # Canonical URL has no trailing slash, query, or fragment
+        assert t.url == "https://github.com/octocat/hello/pull/123"
+        assert "?" not in t.url
+        assert "#" not in t.url
+
+    def test_http_url_upgraded_to_https_canonical(self):
+        # http:// is accepted and silently upgraded to https in canonical URL
+        t, err = parse_target("http://github.com/octocat/hello/pull/456")
+        assert err is None
+        assert t is not None
+        assert t.number == 456
+        assert t.url.startswith("https://")
+
+    def test_url_with_www_prefix(self):
+        t, err = parse_target("https://www.github.com/octocat/hello/pull/789")
+        assert err is None
+        assert t is not None
+        assert t.number == 789
+
+    def test_shorthand(self):
+        t, err = parse_target("octocat/hello#123")
+        assert err is None
+        assert t is not None
+        assert t.owner == "octocat"
+        assert t.repo == "hello"
+        assert t.number == 123
+        assert t.url == "https://github.com/octocat/hello/pull/123"
+
+    def test_shorthand_with_dots_and_dashes(self):
+        t, err = parse_target("my.org/my-repo.js#42")
+        assert err is None
+        assert t is not None
+        assert t.owner == "my.org"
+        assert t.repo == "my-repo.js"
+        assert t.number == 42
+
+    def test_shorthand_large_pr_number(self):
+        t, err = parse_target("octocat/hello#99999")
+        assert err is None
+        assert t is not None
+        assert t.number == 99999
+
+    def test_owner_and_repo_preserved_exactly_as_captured(self):
+        # No case folding
+        t, err = parse_target("OctoCAT/Hello-World#1")
+        assert err is None
+        assert t is not None
+        assert t.owner == "OctoCAT"
+        assert t.repo == "Hello-World"
+
+
+# ---------------------------------------------------------------------------
+# parse_target — invalid inputs
+# ---------------------------------------------------------------------------
+
+
+class TestParseTargetInvalid:
+    def test_empty_string(self):
+        t, err = parse_target("")
+        assert t is None
+        assert err is not None
+
+    def test_whitespace_only(self):
+        t, err = parse_target("   ")
+        assert t is None
+        assert err is not None
+
+    def test_shorthand_missing_hash(self):
+        t, err = parse_target("octocat/hello/123")
+        assert t is None
+        assert err is not None
+
+    def test_shorthand_non_numeric_number(self):
+        t, err = parse_target("octocat/hello#abc")
+        assert t is None
+        assert err is not None
+
+    def test_shorthand_zero_pr_number(self):
+        t, err = parse_target("octocat/hello#0")
+        assert t is None
+        assert err is not None
+        assert "positive" in err.lower() or "0" in err
+
+    def test_shorthand_owner_with_slash(self):
+        # "org/sub/repo#1" has two slashes — does not match OWNER/REPO#N
+        t, err = parse_target("org/sub/repo#1")
+        assert t is None
+        assert err is not None
+
+    def test_url_pointing_at_issues_path(self):
+        t, err = parse_target("https://github.com/octocat/hello/issues/123")
+        assert t is None
+        assert err is not None
+
+    def test_url_on_non_github_host(self):
+        t, err = parse_target("https://gitlab.com/octocat/hello/pull/123")
+        assert t is None
+        assert err is not None
+
+    def test_bare_number(self):
+        t, err = parse_target("123")
+        assert t is None
+        assert err is not None
+
+    def test_plain_repo_slug(self):
+        t, err = parse_target("octocat/hello")
+        assert t is None
+        assert err is not None
+
+    def test_error_message_mentions_target(self):
+        bad = "not-a-target"
+        t, err = parse_target(bad)
+        assert t is None
+        assert err is not None
+        assert bad in err
+
+
+# ---------------------------------------------------------------------------
+# resolve_target — success path
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTargetSuccess:
+    def test_success_returns_pr_target_no_diagnostic(self, monkeypatch):
+        monkeypatch.setattr(
+            "gate_keeper.backends._target.run_gh",
+            lambda args: _ok_gh_result(),
+        )
+        pr, diag = resolve_target(_rule(), "octocat/hello#123")
+        assert diag is None
+        assert pr is not None
+        assert pr.owner == "octocat"
+        assert pr.repo == "hello"
+        assert pr.number == 123
+        assert pr.url == "https://github.com/octocat/hello/pull/123"
+
+    def test_success_uses_gh_canonical_url(self, monkeypatch):
+        # gh returns a slightly different canonical URL (e.g. without fragment)
+        canonical = "https://github.com/octocat/hello/pull/123"
+        gh_result = GhResult(
+            ok=True,
+            stdout=f'{{"number":123,"url":"{canonical}"}}',
+            stderr="",
+            returncode=0,
+            cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
+        )
+        monkeypatch.setattr("gate_keeper.backends._target.run_gh", lambda args: gh_result)
+        # Supply a URL target with fragment — the returned PrTarget.url should
+        # be gh's canonical, not the input.
+        pr, diag = resolve_target(_rule(), "https://github.com/octocat/hello/pull/123?tab=files")
+        assert diag is None
+        assert pr is not None
+        assert pr.url == canonical
+
+
+# ---------------------------------------------------------------------------
+# resolve_target — failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTargetFailures:
+    def test_missing_binary_returns_gh_missing_diag(self, monkeypatch):
+        monkeypatch.setattr(
+            "gate_keeper.backends._target.run_gh",
+            lambda args: _missing_binary_result(),
+        )
+        pr, diag = resolve_target(_rule(), "octocat/hello#123")
+        assert pr is None
+        assert diag is not None
+        assert diag.evidence[0].kind == "gh_missing"
+
+    def test_auth_failure_returns_gh_auth_diag(self, monkeypatch):
+        monkeypatch.setattr(
+            "gate_keeper.backends._target.run_gh",
+            lambda args: _auth_failure_result(),
+        )
+        pr, diag = resolve_target(_rule(), "octocat/hello#123")
+        assert pr is None
+        assert diag is not None
+        assert diag.evidence[0].kind == "gh_auth_failure"
+
+    def test_pr_not_found_returns_gh_pr_not_found_diag(self, monkeypatch):
+        monkeypatch.setattr(
+            "gate_keeper.backends._target.run_gh",
+            lambda args: _pr_not_found_result(),
+        )
+        pr, diag = resolve_target(_rule(), "octocat/hello#123")
+        assert pr is None
+        assert diag is not None
+        assert diag.evidence[0].kind == "gh_pr_not_found"
+        ev_data = diag.evidence[0].data
+        assert ev_data["op"] == "pr-view"
+        assert ev_data["owner"] == "octocat"
+        assert ev_data["repo"] == "hello"
+        assert ev_data["number"] == 123
+        assert "Could not resolve" in ev_data["stderr_excerpt"] or "not found" in ev_data["stderr_excerpt"].lower()
+
+    def test_pr_not_found_stderr_excerpt_included(self, monkeypatch):
+        stderr_msg = "GraphQL: Could not resolve to a Repository with the name 'octo/missing'"
+        result = GhResult(
+            ok=False, stdout="", stderr=stderr_msg, returncode=1,
+            cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
+        )
+        monkeypatch.setattr("gate_keeper.backends._target.run_gh", lambda args: result)
+        pr, diag = resolve_target(_rule(), "octocat/hello#123")
+        assert pr is None
+        assert diag is not None
+        assert diag.evidence[0].data["stderr_excerpt"] == stderr_msg
+
+    def test_malformed_json_returns_gh_json_error_diag(self, monkeypatch):
+        result = GhResult(
+            ok=True, stdout="{not json}", stderr="", returncode=0,
+            cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
+        )
+        monkeypatch.setattr("gate_keeper.backends._target.run_gh", lambda args: result)
+        pr, diag = resolve_target(_rule(), "octocat/hello#123")
+        assert pr is None
+        assert diag is not None
+        assert diag.evidence[0].kind == "gh_json_error"
+
+    def test_missing_url_field_returns_gh_missing_field_diag(self, monkeypatch):
+        # url absent, number present
+        result = GhResult(
+            ok=True, stdout='{"number":123}', stderr="", returncode=0,
+            cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
+        )
+        monkeypatch.setattr("gate_keeper.backends._target.run_gh", lambda args: result)
+        pr, diag = resolve_target(_rule(), "octocat/hello#123")
+        assert pr is None
+        assert diag is not None
+        assert diag.evidence[0].kind == "gh_missing_field"
+        assert diag.evidence[0].data["field"] == "url"
+
+    def test_invalid_target_string_returns_target_parse_error_diag(self, monkeypatch):
+        # run_gh should never be called for an invalid target
+        called = []
+        monkeypatch.setattr(
+            "gate_keeper.backends._target.run_gh",
+            lambda args: called.append(args) or _ok_gh_result(),
+        )
+        pr, diag = resolve_target(_rule(), "not-a-valid-target")
+        assert pr is None
+        assert diag is not None
+        assert diag.evidence[0].kind == "target_parse_error"
+        assert diag.evidence[0].data["target"] == "not-a-valid-target"
+        # run_gh must not have been called
+        assert called == []
+
+    def test_generic_gh_failure_returns_gh_failure_diag(self, monkeypatch):
+        result = GhResult(
+            ok=False, stdout="", stderr="some unexpected server error", returncode=1,
+            cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
+        )
+        monkeypatch.setattr("gate_keeper.backends._target.run_gh", lambda args: result)
+        pr, diag = resolve_target(_rule(), "octocat/hello#123")
+        assert pr is None
+        assert diag is not None
+        assert diag.evidence[0].kind == "gh_failure"
+
+
+# ---------------------------------------------------------------------------
+# Command construction — assert exact argv
+# ---------------------------------------------------------------------------
+
+
+class TestCommandConstruction:
+    def test_exact_argv_for_shorthand_target(self, monkeypatch):
+        captured_args = []
+
+        def fake_run_gh(args):
+            captured_args.append(list(args))
+            return _ok_gh_result()
+
+        monkeypatch.setattr("gate_keeper.backends._target.run_gh", fake_run_gh)
+        resolve_target(_rule(), "octocat/hello#123")
+
+        assert len(captured_args) == 1
+        assert captured_args[0] == ["pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"]
+
+    def test_exact_argv_for_url_target(self, monkeypatch):
+        captured_args = []
+
+        def fake_run_gh(args):
+            captured_args.append(list(args))
+            return _ok_gh_result(number=456, owner="org", repo="project")
+
+        monkeypatch.setattr("gate_keeper.backends._target.run_gh", fake_run_gh)
+        resolve_target(_rule(), "https://github.com/org/project/pull/456")
+
+        assert len(captured_args) == 1
+        assert captured_args[0] == ["pr", "view", "456", "-R", "org/project", "--json", "number,url"]
+
+    def test_run_gh_not_called_for_invalid_target(self, monkeypatch):
+        called = []
+        monkeypatch.setattr(
+            "gate_keeper.backends._target.run_gh",
+            lambda args: called.append(args) or _ok_gh_result(),
+        )
+        resolve_target(_rule(), "invalid-target-no-slash-hash")
+        assert called == []
+
+
+# ---------------------------------------------------------------------------
+# Round-trip schema compliance
+# ---------------------------------------------------------------------------
+
+
+class TestDiagRoundTrip:
+    def _round_trip(self, diag: Diagnostic) -> Diagnostic:
+        return Diagnostic.from_dict(diag.to_dict())
+
+    def test_target_parse_error_round_trips(self, monkeypatch):
+        monkeypatch.setattr(
+            "gate_keeper.backends._target.run_gh",
+            lambda args: _ok_gh_result(),
+        )
+        _, diag = resolve_target(_rule(), "not-valid")
+        assert diag is not None
+        rebuilt = self._round_trip(diag)
+        assert rebuilt.evidence[0].kind == "target_parse_error"
+
+    def test_gh_missing_round_trips(self, monkeypatch):
+        monkeypatch.setattr(
+            "gate_keeper.backends._target.run_gh",
+            lambda args: _missing_binary_result(),
+        )
+        _, diag = resolve_target(_rule(), "octocat/hello#123")
+        assert diag is not None
+        rebuilt = self._round_trip(diag)
+        assert rebuilt.evidence[0].kind == "gh_missing"
+
+    def test_gh_auth_failure_round_trips(self, monkeypatch):
+        monkeypatch.setattr(
+            "gate_keeper.backends._target.run_gh",
+            lambda args: _auth_failure_result(),
+        )
+        _, diag = resolve_target(_rule(), "octocat/hello#123")
+        assert diag is not None
+        rebuilt = self._round_trip(diag)
+        assert rebuilt.evidence[0].kind == "gh_auth_failure"
+
+    def test_gh_pr_not_found_round_trips(self, monkeypatch):
+        monkeypatch.setattr(
+            "gate_keeper.backends._target.run_gh",
+            lambda args: _pr_not_found_result(),
+        )
+        _, diag = resolve_target(_rule(), "octocat/hello#123")
+        assert diag is not None
+        rebuilt = self._round_trip(diag)
+        assert rebuilt.evidence[0].kind == "gh_pr_not_found"
+
+    def test_gh_json_error_round_trips(self, monkeypatch):
+        result = GhResult(
+            ok=True, stdout="{not json}", stderr="", returncode=0,
+            cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
+        )
+        monkeypatch.setattr("gate_keeper.backends._target.run_gh", lambda args: result)
+        _, diag = resolve_target(_rule(), "octocat/hello#123")
+        assert diag is not None
+        rebuilt = self._round_trip(diag)
+        assert rebuilt.evidence[0].kind == "gh_json_error"
+
+    def test_gh_missing_field_round_trips(self, monkeypatch):
+        result = GhResult(
+            ok=True, stdout='{"number":123}', stderr="", returncode=0,
+            cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
+        )
+        monkeypatch.setattr("gate_keeper.backends._target.run_gh", lambda args: result)
+        _, diag = resolve_target(_rule(), "octocat/hello#123")
+        assert diag is not None
+        rebuilt = self._round_trip(diag)
+        assert rebuilt.evidence[0].kind == "gh_missing_field"
+
+    def test_gh_failure_round_trips(self, monkeypatch):
+        result = GhResult(
+            ok=False, stdout="", stderr="some unexpected error", returncode=1,
+            cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
+        )
+        monkeypatch.setattr("gate_keeper.backends._target.run_gh", lambda args: result)
+        _, diag = resolve_target(_rule(), "octocat/hello#123")
+        assert diag is not None
+        rebuilt = self._round_trip(diag)
+        assert rebuilt.evidence[0].kind == "gh_failure"
+
+
+# ---------------------------------------------------------------------------
+# Re-export from gate_keeper.backends.github
+# ---------------------------------------------------------------------------
+
+
+class TestReExports:
+    def test_resolve_target_re_exported(self):
+        from gate_keeper.backends.github import resolve_target as rt
+        assert rt is resolve_target
+
+    def test_pr_target_re_exported(self):
+        from gate_keeper.backends.github import PrTarget as PT
+        assert PT is PrTarget


### PR DESCRIPTION
Closes #9

## Summary
Adds the resolver that turns user-supplied targets into structured `PrTarget` records before the per-rule github checks (#10-#13) need them.

- `src/gate_keeper/backends/_target.py`:
  - `PrTarget` (frozen dataclass): `owner`, `repo`, `number: int`, `url: str`.
  - `parse_target(target)` — pure-string parser. Accepts `https://github.com/OWNER/REPO/pull/N` (tolerating `http://`, `www.`, trailing slash, query strings, fragments — all normalized to a canonical https URL) and `OWNER/REPO#N` shorthand. Returns `(PrTarget, None)` or `(None, reason)`.
  - `resolve_target(rule, target)` — composes `parse_target` with `gh pr view N -R OWNER/REPO --json number,url` via `run_gh`. Returns `(PrTarget, None)` on success with the URL refreshed to gh's canonical form; on any failure returns `(None, Diagnostic)` with the appropriate evidence kind: `target_parse_error`, `gh_missing`, `gh_auth_failure`, `gh_pr_not_found`, `gh_json_error`, `gh_missing_field`, or `gh_failure`.
- `src/gate_keeper/backends/github.py`: `check()` now calls `resolve_target` first. On success it still returns UNAVAILABLE pointing at the rule kind (per-rule logic lands in #10-#13), but with the resolved owner/repo/number/url in evidence. On any resolution failure it returns the resolver's diagnostic. Re-exports `PrTarget` and `resolve_target`.

Per-rule logic (#10-#13) will branch on `rule.kind` AFTER resolution and call additional `gh` operations through the same adapter.

## Validation
- `uv run pytest` → **367 passed** (325 → +42 new in `tests/test_target_resolver.py` plus updated stub tests).
- Smoke: `gate-keeper validate docs/example-rules.md --target tests/fixtures/local/pass --backend auto` → exit 1; github rules now surface a `target_parse_error` diagnostic (the local path is not a PR target), which is the expected fail-closed shape.
- Smoke (with monkeypatched `run_gh`): a successful resolution against `owner/repo#42` produces an UNAVAILABLE diagnostic that names the rule kind plus the resolved PR coordinates.

## Codex review
Run: `codex review --base main`. Findings posted as a PR comment. Both fixed in commit `9c0adce`:
- [P1] `resolve_target` was added but never called from `check()`, so the resolver had no user-visible effect. `check()` now invokes it.
- [P2] `int(data["number"])` could raise on malformed responses (`number: null`). Both `number` and `url` are now type-checked before coercion; bad shapes surface as `gh_missing_field`.

## Notes / followups
- `http://` PR URLs are silently upgraded to `https://` in the canonical URL (documented in code).
- Resolving the *current checkout* PR is intentionally out of scope per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)