### PR TITLE
feat(github): PR state, draft, label, and tasklist checks (#10)

### DIFF
--- a/docs/rule-ir.md
+++ b/docs/rule-ir.md
@@ -96,6 +96,12 @@ shape beyond those two top-level keys.
 ### `Confidence`
 `high`, `medium`, `low`
 
+## Per-kind params
+
+| `kind` | `params` key | Default | Notes |
+| ------ | ------------ | ------- | ----- |
+| `github_labels_absent` | `labels` | `["blocked","do-not-merge","needs-decision"]` | List of blocking label names (case-insensitive). Absent key uses default list; explicit `[]` means no blocking labels → always PASS. |
+
 ## Validation policy
 
 `from_dict` parsers in `src/gate_keeper/models.py` are strict and fail-closed:

--- a/src/gate_keeper/_md.py
+++ b/src/gate_keeper/_md.py
@@ -16,36 +16,66 @@ TASK_CHECKED_RE = re.compile(r"^[ \t]*[-*+]\s+\[[xX]\]", re.MULTILINE)
 TASK_UNCHECKED_RE = re.compile(r"^[ \t]*[-*+]\s+\[ \]", re.MULTILINE)
 
 # ---------------------------------------------------------------------------
-# Fenced-block detection
+# Fenced-block detection (CommonMark §4.5)
 # ---------------------------------------------------------------------------
+#
+# An opening fence is a line indented at most 3 spaces consisting of 3+ matching
+# fence characters (` or ~), followed by an optional info string and trailing
+# whitespace. Backtick fences MUST NOT contain backticks in their info string;
+# tilde fences may contain anything. The closing fence must use the same
+# character, be at least as long as the opening, indented at most 3 spaces, and
+# be followed only by whitespace.
 
-FENCE_START_RE = re.compile(r"^[ \t]*(`{3,}|~{3,})")
+FENCE_START_RE = re.compile(
+    r"^ {0,3}"                       # at most 3 leading spaces
+    r"(?P<marker>`{3,}|~{3,})"       # the fence run
+    r"(?P<info>[^`\n]*)?"            # info string (no backticks for backtick fences;
+                                     # tilde fences are slightly more permissive but
+                                     # this is good enough for MVP)
+    r"\s*$"                          # only whitespace allowed after info string
+)
 
 
 def strip_fenced_blocks(text: str) -> str:
     """Return *text* with fenced code block contents removed (fence lines included).
 
-    Opening fence: a line whose stripped form starts with three or more backticks
-    or tildes.  The closing fence must use the same fence character and be at least
-    as long as the opening fence.  Nested or mismatched fences are left as-is.
-    An unterminated fence consumes the rest of the document.
+    Follows CommonMark §4.5 closely enough for MVP usage:
+      * opening fence indented ≤3 spaces, 3+ matching ``\\`/~`` characters;
+      * info string allowed but, for backtick fences, must not contain backticks;
+      * closing fence: same character, at least as long, ≤3-space indent, only
+        whitespace after the marker;
+      * an unterminated fence consumes the rest of the document.
+
+    Lines that look like fences but violate any of these rules (e.g. ``    \\`\\`\\`py``
+    indented with 4+ spaces, or `\\`\\`\\`\\` followed by free-form trailing text on a
+    backtick fence) are left in place and treated as ordinary content.
     """
     out: list[str] = []
     in_fence = False
     fence_char = ""
     fence_len = 0
     for line in text.splitlines(keepends=True):
-        m = FENCE_START_RE.match(line)
+        # Strip a single trailing newline before matching so the regex's trailing
+        # ``\s*$`` anchor works regardless of EOL.
+        stripped = line.rstrip("\r\n")
+        m = FENCE_START_RE.match(stripped)
         if m:
-            marker = m.group(1)
+            marker = m.group("marker")
+            info = m.group("info") or ""
             if not in_fence:
+                # Opening fence: backtick fences disallow backticks in info string.
+                if marker[0] == "`" and "`" in info:
+                    out.append(line)
+                    continue
                 in_fence = True
                 fence_char = marker[0]
                 fence_len = len(marker)
-            elif marker[0] == fence_char and len(marker) >= fence_len:
+            elif marker[0] == fence_char and len(marker) >= fence_len and not info.strip():
+                # Closing fence: same char, ≥ length, no info string.
                 in_fence = False
                 fence_char = ""
                 fence_len = 0
+            # else: mismatched marker inside an open fence — drop it as content
         elif not in_fence:
             out.append(line)
     return "".join(out)

--- a/src/gate_keeper/_md.py
+++ b/src/gate_keeper/_md.py
@@ -1,0 +1,59 @@
+"""Shared Markdown helpers for gate-keeper backends.
+
+Provides regex patterns and utilities for detecting Markdown task checkboxes
+and stripping fenced code blocks. Both the filesystem and github backends
+import from here to avoid duplication.
+"""
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# Task-box regexes
+# ---------------------------------------------------------------------------
+
+TASK_CHECKED_RE = re.compile(r"^[ \t]*[-*+]\s+\[[xX]\]", re.MULTILINE)
+TASK_UNCHECKED_RE = re.compile(r"^[ \t]*[-*+]\s+\[ \]", re.MULTILINE)
+
+# ---------------------------------------------------------------------------
+# Fenced-block detection
+# ---------------------------------------------------------------------------
+
+FENCE_START_RE = re.compile(r"^[ \t]*(`{3,}|~{3,})")
+
+
+def strip_fenced_blocks(text: str) -> str:
+    """Return *text* with fenced code block contents removed (fence lines included).
+
+    Opening fence: a line whose stripped form starts with three or more backticks
+    or tildes.  The closing fence must use the same fence character and be at least
+    as long as the opening fence.  Nested or mismatched fences are left as-is.
+    An unterminated fence consumes the rest of the document.
+    """
+    out: list[str] = []
+    in_fence = False
+    fence_char = ""
+    fence_len = 0
+    for line in text.splitlines(keepends=True):
+        m = FENCE_START_RE.match(line)
+        if m:
+            marker = m.group(1)
+            if not in_fence:
+                in_fence = True
+                fence_char = marker[0]
+                fence_len = len(marker)
+            elif marker[0] == fence_char and len(marker) >= fence_len:
+                in_fence = False
+                fence_char = ""
+                fence_len = 0
+        elif not in_fence:
+            out.append(line)
+    return "".join(out)
+
+
+__all__ = [
+    "TASK_CHECKED_RE",
+    "TASK_UNCHECKED_RE",
+    "FENCE_START_RE",
+    "strip_fenced_blocks",
+]

--- a/src/gate_keeper/backends/filesystem.py
+++ b/src/gate_keeper/backends/filesystem.py
@@ -11,6 +11,12 @@ from pathlib import Path
 
 name = "filesystem"
 
+from gate_keeper._md import (
+    FENCE_START_RE as _FENCE_START_RE,
+    TASK_CHECKED_RE as _TASK_CHECKED_RE,
+    TASK_UNCHECKED_RE as _TASK_UNCHECKED_RE,
+    strip_fenced_blocks as _strip_fenced_blocks_impl,
+)
 from gate_keeper.models import (
     Backend,
     Diagnostic,
@@ -30,10 +36,6 @@ _FILESYSTEM_KINDS = frozenset(
         RuleKind.MARKDOWN_TASKS_COMPLETE,
     }
 )
-
-_TASK_CHECKED_RE = re.compile(r"^[ \t]*[-*+]\s+\[[xX]\]", re.MULTILINE)
-_TASK_UNCHECKED_RE = re.compile(r"^[ \t]*[-*+]\s+\[ \]", re.MULTILINE)
-_FENCE_START_RE = re.compile(r"^[ \t]*(`{3,}|~{3,})")
 
 
 def _diag(rule: Rule, status: Status, message: str, evidence: list[Evidence]) -> Diagnostic:
@@ -198,26 +200,12 @@ def _text_forbidden(rule: Rule, target: Path) -> Diagnostic:
 
 
 def _strip_fenced_blocks(text: str) -> str:
-    """Return *text* with fenced code block contents removed (fence lines included)."""
-    out: list[str] = []
-    in_fence = False
-    fence_char = ""
-    fence_len = 0
-    for line in text.splitlines(keepends=True):
-        m = _FENCE_START_RE.match(line)
-        if m:
-            marker = m.group(1)
-            if not in_fence:
-                in_fence = True
-                fence_char = marker[0]
-                fence_len = len(marker)
-            elif marker[0] == fence_char and len(marker) >= fence_len:
-                in_fence = False
-                fence_char = ""
-                fence_len = 0
-        elif not in_fence:
-            out.append(line)
-    return "".join(out)
+    """Return *text* with fenced code block contents removed (fence lines included).
+
+    Delegates to ``gate_keeper._md.strip_fenced_blocks``; kept here for backward
+    compatibility with any internal callers in this module.
+    """
+    return _strip_fenced_blocks_impl(text)
 
 
 def _markdown_tasks_complete(rule: Rule, target: Path) -> Diagnostic:

--- a/src/gate_keeper/backends/github.py
+++ b/src/gate_keeper/backends/github.py
@@ -166,14 +166,41 @@ def _check_labels_absent(rule: Rule, pr: PrTarget, data: dict) -> Diagnostic:
         if isinstance(item, dict) and "name" in item and isinstance(item["name"], str):
             pr_label_names.append(item["name"])
 
-    # Determine configured blocking labels.
+    # Determine configured blocking labels. ``params.labels`` MUST be either
+    # absent (use defaults) or a list of strings. Anything else (a bare string,
+    # a list with non-string items, etc.) fails closed as UNAVAILABLE — the IR
+    # is the contract; tolerating drift here would silently change rule
+    # semantics.
     params_labels = rule.params.get("labels")
     if params_labels is None:
-        # Key absent → use defaults.
         blocking: list[str] = list(_DEFAULT_BLOCKING_LABELS)
-    else:
-        # Key present; use as-is (including empty list which means no blocking).
+    elif (
+        isinstance(params_labels, list)
+        and all(isinstance(item, str) for item in params_labels)
+    ):
         blocking = list(params_labels)
+    else:
+        return Diagnostic(
+            rule_id=rule.id,
+            source=rule.source,
+            backend=Backend.GITHUB,
+            status=Status.UNAVAILABLE,
+            severity=rule.severity,
+            message=(
+                f"rule.params.labels for {rule.id!r} must be a list of strings; "
+                f"got {type(params_labels).__name__}"
+            ),
+            evidence=[
+                Evidence(
+                    kind="rule_params_invalid",
+                    data={
+                        "param": "labels",
+                        "expected": "list[str]",
+                        "actual_type": type(params_labels).__name__,
+                    },
+                )
+            ],
+        )
 
     # Case-insensitive intersection.
     blocking_lower = {b.lower() for b in blocking}
@@ -217,7 +244,11 @@ def _check_tasks_complete(rule: Rule, pr: PrTarget, data: dict) -> Diagnostic:
     if "body" not in data or data["body"] is None:
         return gh_missing_field_diag(rule, "pr-view", "body")
 
-    body: str = data["body"]
+    body = data["body"]
+    if not isinstance(body, str):
+        # Type mismatch; fail closed instead of letting strip_fenced_blocks raise.
+        return gh_missing_field_diag(rule, "pr-view", "body")
+
     scannable = strip_fenced_blocks(body)
     checked = len(TASK_CHECKED_RE.findall(scannable))
     unchecked = len(TASK_UNCHECKED_RE.findall(scannable))

--- a/src/gate_keeper/backends/github.py
+++ b/src/gate_keeper/backends/github.py
@@ -1,17 +1,23 @@
 """GitHub backend for gate-keeper.
 
-Per-rule checks land in issues #9-#13. This module provides the registered
-``check()`` entry point and re-exports the public adapter API from ``_gh``
-so downstream callers only need to import ``gate_keeper.backends.github``.
+Implements deterministic PR state, draft, label, and tasklist checks
+using the ``gh`` CLI (issue #10).  Issues #11-#13 (status checks, threads,
+approvals) are still UNAVAILABLE stubs; they land in separate PRs.
 
-All rule kinds currently return ``Status.UNAVAILABLE`` via the shared
-diagnostic builders in ``_gh``, so the message shape is consistent with
-what future per-rule checks will produce on auth/network failure.
+All rule kinds here share a single ``gh pr view`` call per ``check()``
+invocation; the result is parsed once and dispatched to the appropriate
+handler.  Any failure before dispatch (missing gh, auth, JSON, missing
+field) propagates as UNAVAILABLE — all paths fail closed.
 """
 from __future__ import annotations
 
 from pathlib import Path
 
+from gate_keeper._md import (
+    TASK_CHECKED_RE,
+    TASK_UNCHECKED_RE,
+    strip_fenced_blocks,
+)
 from gate_keeper.backends._gh import (  # noqa: F401  (re-export)
     GhResult,
     classify_gh_failure,
@@ -29,49 +35,276 @@ from gate_keeper.backends._target import (  # noqa: F401  (re-export)
     PrTarget,
     resolve_target,
 )
-from gate_keeper.models import Backend, Diagnostic, Evidence, Rule, Status
+from gate_keeper.models import Backend, Diagnostic, Evidence, Rule, RuleKind, Status
 
 name = "github"
 
+# ---------------------------------------------------------------------------
+# Default blocking labels for github_labels_absent
+# ---------------------------------------------------------------------------
+
+_DEFAULT_BLOCKING_LABELS: list[str] = ["blocked", "do-not-merge", "needs-decision"]
+
+# ---------------------------------------------------------------------------
+# Shared diagnostic builder
+# ---------------------------------------------------------------------------
+
+
+def _diag(rule: Rule, status: Status, message: str, evidence: list[Evidence]) -> Diagnostic:
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=Backend.GITHUB,
+        status=status,
+        severity=rule.severity,
+        message=message,
+        evidence=evidence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _fetch_pr_view — single gh pr view call shared by all four handlers
+# ---------------------------------------------------------------------------
+
+_PR_VIEW_FIELDS = "state,isDraft,labels,body"
+
+
+def _fetch_pr_view(pr: PrTarget, rule: Rule) -> tuple[dict | None, Diagnostic | None]:
+    """Call ``gh pr view`` and return (parsed_dict, None) or (None, error_diag).
+
+    One call per check() invocation; the result is shared across all handlers.
+    """
+    argv = [
+        "pr", "view", str(pr.number),
+        "-R", f"{pr.owner}/{pr.repo}",
+        "--json", _PR_VIEW_FIELDS,
+    ]
+    result = run_gh(argv)
+    if not result.ok:
+        return None, failure_diag(rule, "pr-view", result)
+
+    data, err = parse_json(result.stdout)
+    if err is not None:
+        return None, gh_json_diag(rule, "pr-view", err)
+
+    if not isinstance(data, dict):
+        return None, gh_json_diag(rule, "pr-view", "expected a JSON object at top level")
+
+    return data, None
+
+
+# ---------------------------------------------------------------------------
+# Per-kind handlers
+# ---------------------------------------------------------------------------
+
+def _pr_coords(pr: PrTarget) -> dict:
+    """Return the shared coordinate fields appended to every evidence payload."""
+    return {"owner": pr.owner, "repo": pr.repo, "number": pr.number, "url": pr.url}
+
+
+def _check_pr_open(rule: Rule, pr: PrTarget, data: dict) -> Diagnostic:
+    """Pass when ``state == "OPEN"``; fail otherwise.
+
+    Evidence kind: ``pr_state``.
+    """
+    if "state" not in data:
+        return gh_missing_field_diag(rule, "pr-view", "state")
+
+    state = data["state"]
+    evidence = [Evidence(kind="pr_state", data={"state": state, **_pr_coords(pr)})]
+
+    if state == "OPEN":
+        return _diag(rule, Status.PASS, f"PR {pr.owner}/{pr.repo}#{pr.number} is open.", evidence)
+    return _diag(rule, Status.FAIL, f"PR {pr.owner}/{pr.repo}#{pr.number} is not open (state: {state!r}).", evidence)
+
+
+def _check_not_draft(rule: Rule, pr: PrTarget, data: dict) -> Diagnostic:
+    """Pass when ``isDraft`` is ``False``; fail when ``True``.
+
+    Missing or non-bool value fails closed (UNAVAILABLE).
+    Evidence kind: ``pr_draft``.
+    """
+    if "isDraft" not in data:
+        return gh_missing_field_diag(rule, "pr-view", "isDraft")
+
+    is_draft = data["isDraft"]
+    if not isinstance(is_draft, bool):
+        return gh_missing_field_diag(rule, "pr-view", "isDraft")
+
+    evidence = [Evidence(kind="pr_draft", data={"is_draft": is_draft, **_pr_coords(pr)})]
+
+    if not is_draft:
+        return _diag(rule, Status.PASS, f"PR {pr.owner}/{pr.repo}#{pr.number} is not a draft.", evidence)
+    return _diag(rule, Status.FAIL, f"PR {pr.owner}/{pr.repo}#{pr.number} is a draft.", evidence)
+
+
+def _check_labels_absent(rule: Rule, pr: PrTarget, data: dict) -> Diagnostic:
+    """Pass when none of the configured blocking labels appear on the PR.
+
+    Blocking labels are configured via ``rule.params["labels"]`` (a list of
+    strings).  If the key is absent or the list is empty the default blocking
+    list is used: ``["blocked", "do-not-merge", "needs-decision"]``.  An
+    explicit empty list in params means "no blocking labels configured" → PASS
+    for any PR (the caller opted out of blocking label enforcement).
+
+    Wait — re-reading the spec: "empty list = caller explicitly said no
+    blocking labels → PASS".  So: missing key → use defaults; empty list →
+    no blocking labels → PASS always.
+
+    Evidence kind: ``pr_labels``.
+    """
+    if "labels" not in data:
+        return gh_missing_field_diag(rule, "pr-view", "labels")
+
+    raw_labels = data["labels"]
+    if not isinstance(raw_labels, list):
+        return gh_missing_field_diag(rule, "pr-view", "labels")
+
+    # Extract label names; each element should be a dict with a "name" key.
+    pr_label_names: list[str] = []
+    for item in raw_labels:
+        if isinstance(item, dict) and "name" in item and isinstance(item["name"], str):
+            pr_label_names.append(item["name"])
+
+    # Determine configured blocking labels.
+    params_labels = rule.params.get("labels")
+    if params_labels is None:
+        # Key absent → use defaults.
+        blocking: list[str] = list(_DEFAULT_BLOCKING_LABELS)
+    else:
+        # Key present; use as-is (including empty list which means no blocking).
+        blocking = list(params_labels)
+
+    # Case-insensitive intersection.
+    blocking_lower = {b.lower() for b in blocking}
+    matched = [name for name in pr_label_names if name.lower() in blocking_lower]
+
+    evidence = [
+        Evidence(
+            kind="pr_labels",
+            data={
+                "pr_labels": pr_label_names,
+                "blocking": blocking,
+                "matched": matched,
+                **_pr_coords(pr),
+            },
+        )
+    ]
+
+    if not matched:
+        return _diag(
+            rule,
+            Status.PASS,
+            f"PR {pr.owner}/{pr.repo}#{pr.number} has no blocking labels.",
+            evidence,
+        )
+    return _diag(
+        rule,
+        Status.FAIL,
+        f"PR {pr.owner}/{pr.repo}#{pr.number} has blocking label(s): {matched!r}.",
+        evidence,
+    )
+
+
+def _check_tasks_complete(rule: Rule, pr: PrTarget, data: dict) -> Diagnostic:
+    """Pass when the PR body has zero unchecked task boxes.
+
+    A ``null`` body fails closed (UNAVAILABLE — treated as missing field).
+    An empty string body has 0 tasks → PASS (vacuous truth).
+    Task boxes inside fenced code blocks are ignored.
+    Evidence kind: ``pr_tasks``.
+    """
+    if "body" not in data or data["body"] is None:
+        return gh_missing_field_diag(rule, "pr-view", "body")
+
+    body: str = data["body"]
+    scannable = strip_fenced_blocks(body)
+    checked = len(TASK_CHECKED_RE.findall(scannable))
+    unchecked = len(TASK_UNCHECKED_RE.findall(scannable))
+    total = checked + unchecked
+
+    evidence = [
+        Evidence(
+            kind="pr_tasks",
+            data={"checked": checked, "unchecked": unchecked, "total": total, **_pr_coords(pr)},
+        )
+    ]
+
+    if unchecked == 0:
+        return _diag(
+            rule,
+            Status.PASS,
+            f"PR {pr.owner}/{pr.repo}#{pr.number} has all {total} task(s) checked.",
+            evidence,
+        )
+    return _diag(
+        rule,
+        Status.FAIL,
+        f"PR {pr.owner}/{pr.repo}#{pr.number} has {unchecked} unchecked task(s) of {total}.",
+        evidence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch table
+# ---------------------------------------------------------------------------
+
+_HANDLED = {
+    RuleKind.GITHUB_PR_OPEN: _check_pr_open,
+    RuleKind.GITHUB_NOT_DRAFT: _check_not_draft,
+    RuleKind.GITHUB_LABELS_ABSENT: _check_labels_absent,
+    RuleKind.GITHUB_TASKS_COMPLETE: _check_tasks_complete,
+}
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
 
 def check(rule: Rule, target: str | Path) -> Diagnostic:
-    """Resolve the target, then report UNAVAILABLE for the rule kind.
+    """Resolve the target, fetch PR view data, then dispatch by rule kind.
 
-    Per-rule GitHub checks land in issues #10-#13. Until then this entry point
-    still goes through ``resolve_target`` so any target-level failure (bad
-    target shape, missing ``gh``, auth failure, repo/PR not found, malformed
-    response) surfaces with the right diagnostic shape and the resolver is
-    exercised end-to-end via the registered backend path.
-
-    On successful resolution the diagnostic still reports UNAVAILABLE — this
-    is fail-closed by design until the per-rule logic exists.
+    Resolution failures (bad target, missing gh, auth error, PR not found)
+    surface as UNAVAILABLE immediately.  A single ``gh pr view`` call is made
+    for the four implemented kinds; unimplemented kinds (#11-#13) receive an
+    UNAVAILABLE stub after resolution.
     """
     target_str = str(target)
     pr, diag = resolve_target(rule, target_str)
     if diag is not None:
         return diag
 
-    return Diagnostic(
-        rule_id=rule.id,
-        source=rule.source,
-        backend=Backend.GITHUB,
-        status=Status.UNAVAILABLE,
-        severity=rule.severity,
-        message=(
-            f"target resolved to {pr.owner}/{pr.repo}#{pr.number}; "
-            f"rule kind {rule.kind.value!r} not yet implemented (#10-#13)"
-        ),
-        evidence=[
-            Evidence(
-                kind="backend_stub",
-                data={
-                    "backend": "github",
-                    "rule_kind": rule.kind.value,
-                    "owner": pr.owner,
-                    "repo": pr.repo,
-                    "number": pr.number,
-                    "url": pr.url,
-                },
-            )
-        ],
-    )
+    handler = _HANDLED.get(rule.kind)
+    if handler is None:
+        # Rule kind not yet implemented — issues #11-#13.
+        return Diagnostic(
+            rule_id=rule.id,
+            source=rule.source,
+            backend=Backend.GITHUB,
+            status=Status.UNAVAILABLE,
+            severity=rule.severity,
+            message=(
+                f"target resolved to {pr.owner}/{pr.repo}#{pr.number}; "
+                f"rule kind {rule.kind.value!r} not yet implemented (#11-#13)"
+            ),
+            evidence=[
+                Evidence(
+                    kind="backend_stub",
+                    data={
+                        "backend": "github",
+                        "rule_kind": rule.kind.value,
+                        "owner": pr.owner,
+                        "repo": pr.repo,
+                        "number": pr.number,
+                        "url": pr.url,
+                    },
+                )
+            ],
+        )
+
+    # Fetch the PR view data (one call for all four handlers).
+    data, fetch_diag = _fetch_pr_view(pr, rule)
+    if fetch_diag is not None:
+        return fetch_diag
+
+    return handler(rule, pr, data)

--- a/tests/test_github_backend_stub.py
+++ b/tests/test_github_backend_stub.py
@@ -49,7 +49,11 @@ class TestGithubBackendStub:
         assert diag.backend is Backend.GITHUB
 
     def test_check_message_names_rule_kind_when_target_resolves(self, monkeypatch):
-        """When the target resolves, the diag still names the rule kind."""
+        """When the target resolves, a stub kind still names the rule kind in its message.
+
+        GITHUB_THREADS_RESOLVED is not yet implemented (#12), so it returns
+        UNAVAILABLE with the rule kind in the message even after resolution.
+        """
         from gate_keeper.backends import _gh, _target
 
         def _fake_run_gh(args, **kwargs):
@@ -62,10 +66,10 @@ class TestGithubBackendStub:
             )
 
         monkeypatch.setattr(_target, "run_gh", _fake_run_gh)
-        rule = _github_rule(RuleKind.GITHUB_NOT_DRAFT)
+        rule = _github_rule(RuleKind.GITHUB_THREADS_RESOLVED)
         diag = gh_backend.check(rule, "owner/repo#42")
         assert diag.status is Status.UNAVAILABLE
-        assert "github_not_draft" in diag.message
+        assert "github_threads_resolved" in diag.message
 
     def test_check_invalid_target_surfaces_target_parse_error(self, tmp_path):
         """A non-PR target now surfaces a parse-error diagnostic via the resolver."""

--- a/tests/test_github_pr_state.py
+++ b/tests/test_github_pr_state.py
@@ -1,0 +1,542 @@
+"""Tests for the four PR-state handlers added in issue #10.
+
+Each test monkeypatches both:
+- ``gate_keeper.backends._target.run_gh`` — for resolve_target (returns PR number/url)
+- ``gate_keeper.backends.github.run_gh``  — for _fetch_pr_view (returns state/isDraft/labels/body)
+
+A helper ``_make_run_gh`` produces a fake ``run_gh`` that cycles through a list
+of pre-configured ``GhResult`` objects in order, so the two calls (resolve +
+fetch) can return different payloads.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from gate_keeper.backends import _gh, _target
+from gate_keeper.backends import github as gh_backend
+from gate_keeper.diagnostics import EXIT_FAIL, EXIT_OK, compute_exit_code
+from gate_keeper.models import (
+    Backend,
+    Confidence,
+    Rule,
+    RuleKind,
+    RuleSet,
+    Severity,
+    SourceLocation,
+    Status,
+)
+from gate_keeper.validator import validate
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_RESOLVE_OK = json.dumps({"number": 42, "url": "https://github.com/owner/repo/pull/42"})
+
+
+def _ok(stdout: str, args: tuple[str, ...] = ()) -> _gh.GhResult:
+    return _gh.GhResult(ok=True, stdout=stdout, stderr="", returncode=0, cmd=("gh", *args))
+
+
+def _fail_missing() -> _gh.GhResult:
+    return _gh.GhResult(
+        ok=False,
+        stdout="",
+        stderr="gh binary not found",
+        returncode=127,
+        cmd=("gh",),
+        binary_missing=True,
+    )
+
+
+def _make_github_rule(kind: RuleKind, params: dict | None = None) -> Rule:
+    return Rule(
+        id="test-rule",
+        title="Test GitHub rule",
+        source=SourceLocation(path="rules.md", line=1),
+        text="Test rule text",
+        kind=kind,
+        severity=Severity.ERROR,
+        backend_hint=Backend.GITHUB,
+        confidence=Confidence.HIGH,
+        params=params or {},
+    )
+
+
+def _make_run_gh_sequence(results: list[_gh.GhResult]):
+    """Return a fake run_gh that pops results from the list in order."""
+    queue = list(results)
+
+    def _fake(args, **kwargs):
+        if queue:
+            return queue.pop(0)
+        raise AssertionError(f"run_gh called more times than expected; args={args!r}")
+
+    return _fake
+
+
+def _patch_both(monkeypatch, resolve_result: _gh.GhResult, fetch_result: _gh.GhResult):
+    """Monkeypatch both target resolver and github backend run_gh."""
+    monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([resolve_result]))
+    monkeypatch.setattr(gh_backend, "run_gh", _make_run_gh_sequence([fetch_result]))
+
+
+def _pr_view_json(**fields) -> str:
+    """Build a JSON string for a gh pr view response."""
+    return json.dumps(fields)
+
+
+# ---------------------------------------------------------------------------
+# PR Open
+# ---------------------------------------------------------------------------
+
+class TestCheckPrOpen:
+    def test_open_state_passes(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="OPEN", isDraft=False, labels=[], body="")),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_PR_OPEN)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.PASS
+        assert diag.evidence[0].kind == "pr_state"
+        assert diag.evidence[0].data["state"] == "OPEN"
+
+    def test_closed_state_fails(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="CLOSED", isDraft=False, labels=[], body="")),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_PR_OPEN)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        assert diag.evidence[0].data["state"] == "CLOSED"
+
+    def test_merged_state_fails(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="MERGED", isDraft=False, labels=[], body="")),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_PR_OPEN)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        assert diag.evidence[0].data["state"] == "MERGED"
+
+    def test_missing_state_field_unavailable(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(isDraft=False, labels=[], body="")),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_PR_OPEN)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_missing_field"
+        assert diag.evidence[0].data["field"] == "state"
+
+
+# ---------------------------------------------------------------------------
+# Not Draft
+# ---------------------------------------------------------------------------
+
+class TestCheckNotDraft:
+    def test_not_draft_passes(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="OPEN", isDraft=False, labels=[], body="")),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_NOT_DRAFT)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.PASS
+        assert diag.evidence[0].kind == "pr_draft"
+        assert diag.evidence[0].data["is_draft"] is False
+
+    def test_is_draft_fails(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="OPEN", isDraft=True, labels=[], body="")),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_NOT_DRAFT)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        assert diag.evidence[0].data["is_draft"] is True
+
+    def test_missing_is_draft_field_unavailable(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="OPEN", labels=[], body="")),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_NOT_DRAFT)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_missing_field"
+        assert diag.evidence[0].data["field"] == "isDraft"
+
+    def test_non_bool_is_draft_unavailable(self, monkeypatch):
+        """isDraft must be a bool; a string value fails closed."""
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="OPEN", isDraft="yes", labels=[], body="")),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_NOT_DRAFT)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_missing_field"
+
+
+# ---------------------------------------------------------------------------
+# Labels Absent
+# ---------------------------------------------------------------------------
+
+class TestCheckLabelsAbsent:
+    def test_missing_labels_field_unavailable(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="OPEN", isDraft=False, body="")),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_LABELS_ABSENT)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_missing_field"
+        assert diag.evidence[0].data["field"] == "labels"
+
+    def test_empty_labels_passes_with_defaults(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="OPEN", isDraft=False, labels=[], body="")),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_LABELS_ABSENT)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.PASS
+        assert diag.evidence[0].kind == "pr_labels"
+        assert diag.evidence[0].data["matched"] == []
+
+    def test_blocking_label_do_not_merge_fails(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(
+                state="OPEN", isDraft=False,
+                labels=[{"name": "do-not-merge"}],
+                body="",
+            )),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_LABELS_ABSENT)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        assert "do-not-merge" in diag.evidence[0].data["matched"]
+
+    def test_blocking_label_case_insensitive(self, monkeypatch):
+        """Label matching is case-insensitive."""
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(
+                state="OPEN", isDraft=False,
+                labels=[{"name": "DO-NOT-MERGE"}],
+                body="",
+            )),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_LABELS_ABSENT)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        assert "DO-NOT-MERGE" in diag.evidence[0].data["matched"]
+
+    def test_mixed_labels_one_blocking(self, monkeypatch):
+        """Only the blocking label appears in matched; feature label is ignored."""
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(
+                state="OPEN", isDraft=False,
+                labels=[{"name": "blocked"}, {"name": "feature"}],
+                body="",
+            )),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_LABELS_ABSENT)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        assert diag.evidence[0].data["matched"] == ["blocked"]
+
+    def test_custom_blocking_label_fails(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(
+                state="OPEN", isDraft=False,
+                labels=[{"name": "custom-block"}],
+                body="",
+            )),
+        )
+        rule = _make_github_rule(
+            RuleKind.GITHUB_LABELS_ABSENT,
+            params={"labels": ["custom-block"]},
+        )
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        assert "custom-block" in diag.evidence[0].data["matched"]
+
+    def test_explicit_empty_params_labels_means_no_blocking_pass(self, monkeypatch):
+        """An explicit empty list in params.labels means no blocking labels → always PASS."""
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(
+                state="OPEN", isDraft=False,
+                labels=[{"name": "do-not-merge"}],
+                body="",
+            )),
+        )
+        rule = _make_github_rule(
+            RuleKind.GITHUB_LABELS_ABSENT,
+            params={"labels": []},
+        )
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.PASS
+        assert diag.evidence[0].data["matched"] == []
+
+    def test_missing_params_labels_key_uses_defaults(self, monkeypatch):
+        """When params has no 'labels' key at all, the default blocking list is used."""
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(
+                state="OPEN", isDraft=False,
+                labels=[{"name": "needs-decision"}],
+                body="",
+            )),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_LABELS_ABSENT)  # no params
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        assert "needs-decision" in diag.evidence[0].data["matched"]
+        assert "needs-decision" in diag.evidence[0].data["blocking"]
+
+
+# ---------------------------------------------------------------------------
+# Tasks Complete
+# ---------------------------------------------------------------------------
+
+class TestCheckTasksComplete:
+    def test_null_body_unavailable(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="OPEN", isDraft=False, labels=[], body=None)),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_TASKS_COMPLETE)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_missing_field"
+        assert diag.evidence[0].data["field"] == "body"
+
+    def test_missing_body_field_unavailable(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="OPEN", isDraft=False, labels=[])),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_TASKS_COMPLETE)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_missing_field"
+
+    def test_empty_body_passes(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="OPEN", isDraft=False, labels=[], body="")),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_TASKS_COMPLETE)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.PASS
+        ev = diag.evidence[0]
+        assert ev.data["unchecked"] == 0
+        assert ev.data["total"] == 0
+
+    def test_one_unchecked_item_fails(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="OPEN", isDraft=False, labels=[], body="- [ ] item")),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_TASKS_COMPLETE)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        ev = diag.evidence[0]
+        assert ev.data["unchecked"] == 1
+        assert ev.data["checked"] == 0
+
+    def test_mixed_tasks_fail_when_unchecked(self, monkeypatch):
+        body = "- [x] done\n- [ ] todo\n"
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="OPEN", isDraft=False, labels=[], body=body)),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_TASKS_COMPLETE)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        ev = diag.evidence[0]
+        assert ev.data["unchecked"] == 1
+        assert ev.data["checked"] == 1
+        assert ev.data["total"] == 2
+
+    def test_all_checked_passes(self, monkeypatch):
+        body = "- [x] done\n- [X] also done\n"
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="OPEN", isDraft=False, labels=[], body=body)),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_TASKS_COMPLETE)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.PASS
+        ev = diag.evidence[0]
+        assert ev.data["unchecked"] == 0
+        assert ev.data["checked"] == 2
+
+    def test_fenced_code_task_ignored(self, monkeypatch):
+        """Task boxes inside fenced code blocks are ignored."""
+        body = "Real content\n```\n- [ ] inside fence\n```\n"
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="OPEN", isDraft=False, labels=[], body=body)),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_TASKS_COMPLETE)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.PASS
+        ev = diag.evidence[0]
+        assert ev.data["unchecked"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Evidence structure
+# ---------------------------------------------------------------------------
+
+class TestEvidenceStructure:
+    """Verify that evidence payloads contain the expected coordinate fields."""
+
+    def _resolve_and_fetch(self, monkeypatch, pr_view_payload: dict):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(json.dumps(pr_view_payload)),
+        )
+
+    def _coords_present(self, data: dict):
+        assert data["owner"] == "owner"
+        assert data["repo"] == "repo"
+        assert data["number"] == 42
+        assert data["url"] == "https://github.com/owner/repo/pull/42"
+
+    def test_pr_open_evidence_coords(self, monkeypatch):
+        self._resolve_and_fetch(monkeypatch, {"state": "OPEN", "isDraft": False, "labels": [], "body": ""})
+        diag = gh_backend.check(_make_github_rule(RuleKind.GITHUB_PR_OPEN), "owner/repo#42")
+        self._coords_present(diag.evidence[0].data)
+
+    def test_not_draft_evidence_coords(self, monkeypatch):
+        self._resolve_and_fetch(monkeypatch, {"state": "OPEN", "isDraft": False, "labels": [], "body": ""})
+        diag = gh_backend.check(_make_github_rule(RuleKind.GITHUB_NOT_DRAFT), "owner/repo#42")
+        self._coords_present(diag.evidence[0].data)
+
+    def test_labels_absent_evidence_coords(self, monkeypatch):
+        self._resolve_and_fetch(monkeypatch, {"state": "OPEN", "isDraft": False, "labels": [], "body": ""})
+        diag = gh_backend.check(_make_github_rule(RuleKind.GITHUB_LABELS_ABSENT), "owner/repo#42")
+        self._coords_present(diag.evidence[0].data)
+
+    def test_tasks_complete_evidence_coords(self, monkeypatch):
+        self._resolve_and_fetch(monkeypatch, {"state": "OPEN", "isDraft": False, "labels": [], "body": ""})
+        diag = gh_backend.check(_make_github_rule(RuleKind.GITHUB_TASKS_COMPLETE), "owner/repo#42")
+        self._coords_present(diag.evidence[0].data)
+
+
+# ---------------------------------------------------------------------------
+# Fetch failures (gh error, auth, JSON) propagate before dispatch
+# ---------------------------------------------------------------------------
+
+class TestFetchFailures:
+    def test_gh_missing_binary_returns_unavailable(self, monkeypatch):
+        """If gh is missing at resolve time, we get UNAVAILABLE immediately."""
+        monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([_fail_missing()]))
+        rule = _make_github_rule(RuleKind.GITHUB_PR_OPEN)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+
+    def test_fetch_failure_returns_unavailable(self, monkeypatch):
+        """If the pr-view fetch call fails, handler never runs."""
+        fail_result = _gh.GhResult(
+            ok=False,
+            stdout="",
+            stderr="rate limit exceeded",
+            returncode=1,
+            cmd=("gh",),
+        )
+        monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([_ok(_RESOLVE_OK)]))
+        monkeypatch.setattr(gh_backend, "run_gh", _make_run_gh_sequence([fail_result]))
+        rule = _make_github_rule(RuleKind.GITHUB_PR_OPEN)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+
+    def test_fetch_json_error_returns_unavailable(self, monkeypatch):
+        monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([_ok(_RESOLVE_OK)]))
+        bad_json = _gh.GhResult(
+            ok=True, stdout="not-json", stderr="", returncode=0, cmd=("gh",)
+        )
+        monkeypatch.setattr(gh_backend, "run_gh", _make_run_gh_sequence([bad_json]))
+        rule = _make_github_rule(RuleKind.GITHUB_PR_OPEN)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_json_error"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via validator
+# ---------------------------------------------------------------------------
+
+class TestEndToEndValidator:
+    def test_pr_open_rule_passes_via_validator(self, monkeypatch):
+        """Full validate() call with a GITHUB_PR_OPEN rule returns PASS and exit 0."""
+        resolve_result = _ok(_RESOLVE_OK)
+        fetch_result = _ok(_pr_view_json(state="OPEN", isDraft=False, labels=[], body=""))
+
+        monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([resolve_result]))
+        monkeypatch.setattr(gh_backend, "run_gh", _make_run_gh_sequence([fetch_result]))
+
+        rule = _make_github_rule(RuleKind.GITHUB_PR_OPEN)
+        ruleset = RuleSet(rules=[rule])
+        report = validate(ruleset, "owner/repo#42", backend="auto")
+
+        assert len(report.diagnostics) == 1
+        diag = report.diagnostics[0]
+        assert diag.status is Status.PASS
+        assert compute_exit_code(report.diagnostics) == EXIT_OK
+
+    def test_closed_pr_fails_via_validator(self, monkeypatch):
+        resolve_result = _ok(_RESOLVE_OK)
+        fetch_result = _ok(_pr_view_json(state="CLOSED", isDraft=False, labels=[], body=""))
+
+        monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([resolve_result]))
+        monkeypatch.setattr(gh_backend, "run_gh", _make_run_gh_sequence([fetch_result]))
+
+        rule = _make_github_rule(RuleKind.GITHUB_PR_OPEN)
+        ruleset = RuleSet(rules=[rule])
+        report = validate(ruleset, "owner/repo#42", backend="auto")
+
+        assert len(report.diagnostics) == 1
+        assert report.diagnostics[0].status is Status.FAIL
+        assert compute_exit_code(report.diagnostics) == EXIT_FAIL

--- a/tests/test_github_pr_state.py
+++ b/tests/test_github_pr_state.py
@@ -308,6 +308,37 @@ class TestCheckLabelsAbsent:
         assert diag.status is Status.PASS
         assert diag.evidence[0].data["matched"] == []
 
+    def test_invalid_params_labels_type_unavailable(self, monkeypatch):
+        """params.labels with a non-list value fails closed (UNAVAILABLE)."""
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="OPEN", isDraft=False, labels=[], body="")),
+        )
+        rule = _make_github_rule(
+            RuleKind.GITHUB_LABELS_ABSENT,
+            params={"labels": "do-not-merge"},  # bare string is wrong shape
+        )
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "rule_params_invalid"
+        assert diag.evidence[0].data["param"] == "labels"
+
+    def test_invalid_params_labels_non_string_items_unavailable(self, monkeypatch):
+        """params.labels with non-string items fails closed."""
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_json(state="OPEN", isDraft=False, labels=[], body="")),
+        )
+        rule = _make_github_rule(
+            RuleKind.GITHUB_LABELS_ABSENT,
+            params={"labels": ["ok", 42]},
+        )
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "rule_params_invalid"
+
     def test_missing_params_labels_key_uses_defaults(self, monkeypatch):
         """When params has no 'labels' key at all, the default blocking list is used."""
         _patch_both(
@@ -353,6 +384,28 @@ class TestCheckTasksComplete:
         diag = gh_backend.check(rule, "owner/repo#42")
         assert diag.status is Status.UNAVAILABLE
         assert diag.evidence[0].kind == "gh_missing_field"
+
+    def test_non_string_body_fails_closed(self, monkeypatch):
+        """A non-string body (e.g. malformed gh response) must NOT crash; UNAVAILABLE."""
+        # Build the JSON payload by hand because _pr_view_json filters None.
+        import json
+
+        bad_payload = json.dumps({
+            "state": "OPEN",
+            "isDraft": False,
+            "labels": [],
+            "body": 42,  # numeric, not a string
+        })
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(bad_payload),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_TASKS_COMPLETE)
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_missing_field"
+        assert diag.evidence[0].data["field"] == "body"
 
     def test_empty_body_passes(self, monkeypatch):
         _patch_both(

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -1,0 +1,137 @@
+"""Unit tests for gate_keeper._md — shared Markdown helpers.
+
+Focused tests for strip_fenced_blocks and the task-box regexes.
+The task-box patterns are also exercised indirectly via
+test_filesystem_backend.py::TestMarkdownTasksComplete.
+"""
+from __future__ import annotations
+
+import pytest
+
+from gate_keeper._md import (
+    TASK_CHECKED_RE,
+    TASK_UNCHECKED_RE,
+    strip_fenced_blocks,
+)
+
+
+class TestStripFencedBlocks:
+    def test_plain_text_unchanged(self):
+        text = "Hello\nWorld\n"
+        assert strip_fenced_blocks(text) == text
+
+    def test_backtick_fence_removed(self):
+        text = "before\n```\n- [ ] inside fence\n```\nafter\n"
+        result = strip_fenced_blocks(text)
+        assert "inside fence" not in result
+        assert "before" in result
+        assert "after" in result
+
+    def test_tilde_fence_removed(self):
+        text = "before\n~~~\n- [ ] inside tilde\n~~~\nafter\n"
+        result = strip_fenced_blocks(text)
+        assert "inside tilde" not in result
+        assert "before" in result
+        assert "after" in result
+
+    def test_longer_fence_closes_shorter_fence(self):
+        """A longer fence (4 ticks) closes a shorter fence (3 ticks) per CommonMark.
+
+        The closing rule requires at least as many characters as the opening.
+        So ```` closes ```, leaving "still inside" visible outside the fence.
+        """
+        # Open with ``` (3 ticks), encounter ```` (4 ticks) which closes it.
+        text = "```\ninner\n````\nstill inside\n```\nafter\n"
+        result = strip_fenced_blocks(text)
+        # "inner" is inside the first fence (closed by ````), so it's stripped.
+        assert "inner" not in result
+        # "still inside" is outside the (now-closed) first fence.
+        assert "still inside" in result
+        # "after" is outside a second (3-tick) fence that re-opens and is unterminated.
+        # Actually: after ```` closes the fence, then ``` opens a new fence (unterminated).
+        # So "after" is inside the unterminated second fence and gets stripped.
+        assert "after" not in result
+
+    def test_shorter_fence_does_not_close_longer_fence(self):
+        """A shorter fence (3 ticks) does NOT close a longer fence (4 ticks)."""
+        # Open with ```` (4 ticks); encounter ``` (3 ticks) — does not close.
+        text = "````\ninner\n```\nstill inside\n````\nafter\n"
+        result = strip_fenced_blocks(text)
+        assert "inner" not in result
+        assert "still inside" not in result
+        assert "after" in result
+
+    def test_unterminated_fence_consumes_rest(self):
+        """An unterminated fence strips everything to end of document."""
+        text = "visible\n```\nhidden line\nanother hidden\n"
+        result = strip_fenced_blocks(text)
+        assert "visible" in result
+        assert "hidden" not in result
+
+    def test_empty_string(self):
+        assert strip_fenced_blocks("") == ""
+
+    def test_task_boxes_outside_fence_preserved(self):
+        """Task-box lines outside a fence survive strip_fenced_blocks."""
+        text = "- [ ] todo\n- [x] done\n"
+        result = strip_fenced_blocks(text)
+        assert "- [ ] todo" in result
+        assert "- [x] done" in result
+
+    def test_mixed_task_boxes_inside_and_outside(self):
+        """Task boxes inside a fence are ignored; outside ones survive."""
+        text = (
+            "- [ ] outside unchecked\n"
+            "```\n"
+            "- [ ] inside unchecked\n"
+            "- [x] inside checked\n"
+            "```\n"
+            "- [x] outside checked\n"
+        )
+        result = strip_fenced_blocks(text)
+        unchecked = TASK_UNCHECKED_RE.findall(result)
+        checked = TASK_CHECKED_RE.findall(result)
+        assert len(unchecked) == 1
+        assert len(checked) == 1
+
+    def test_four_backtick_fence(self):
+        """Fences with four or more backticks work correctly."""
+        text = "outside\n````\nhidden\n````\nback outside\n"
+        result = strip_fenced_blocks(text)
+        assert "hidden" not in result
+        assert "outside" in result
+        assert "back outside" in result
+
+    def test_indented_fence(self):
+        """Indented fences (with leading spaces/tabs) are recognized."""
+        text = "text\n  ```\nhidden\n  ```\nvisible\n"
+        result = strip_fenced_blocks(text)
+        assert "hidden" not in result
+        assert "visible" in result
+
+
+class TestTaskBoxRegexes:
+    @pytest.mark.parametrize("line", [
+        "- [ ] item",
+        "* [ ] item",
+        "+ [ ] item",
+        "  - [ ] indented",
+        "\t- [ ] tab-indented",
+    ])
+    def test_unchecked_matches(self, line):
+        assert TASK_UNCHECKED_RE.search(line) is not None
+
+    @pytest.mark.parametrize("line", [
+        "- [x] done",
+        "- [X] done",
+        "* [x] done",
+        "  - [X] indented",
+    ])
+    def test_checked_matches(self, line):
+        assert TASK_CHECKED_RE.search(line) is not None
+
+    def test_unchecked_does_not_match_checked(self):
+        assert TASK_UNCHECKED_RE.search("- [x] done") is None
+
+    def test_checked_does_not_match_unchecked(self):
+        assert TASK_CHECKED_RE.search("- [ ] todo") is None

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -135,3 +135,36 @@ class TestTaskBoxRegexes:
 
     def test_checked_does_not_match_unchecked(self):
         assert TASK_CHECKED_RE.search("- [ ] todo") is None
+
+
+class TestStripFencedBlocksCommonMark:
+    """Regression tests for stricter CommonMark fence handling."""
+
+    def test_indented_more_than_3_spaces_is_not_a_fence(self):
+        """A line with 4+ leading spaces is code-block-by-indentation, not a fence."""
+        text = "before\n    ```python\n- [ ] outside any fence\n    ```\nafter\n"
+        result = strip_fenced_blocks(text)
+        # Because ``    \`\`\`python`` is NOT a fence, the task box that follows
+        # remains visible.
+        assert "outside any fence" in result
+
+    def test_backtick_fence_with_backtick_in_info_string_rejected(self):
+        """A backtick fence whose info string contains a backtick is not an opening fence."""
+        # ```` ```py` ```` is not a valid opening fence per CommonMark.
+        text = "before\n```py`bad\n- [ ] still outside\n```\nafter\n"
+        result = strip_fenced_blocks(text)
+        assert "still outside" in result
+
+    def test_three_space_indent_is_still_a_fence(self):
+        """0–3 spaces of indentation is allowed for a fence."""
+        text = "before\n   ```\n- [ ] inside\n   ```\nafter\n"
+        result = strip_fenced_blocks(text)
+        assert "inside" not in result
+
+    def test_closing_fence_with_trailing_text_is_not_a_close(self):
+        """A line `\\`\\`\\`stuff` while inside a fence is not a closing fence."""
+        text = "before\n```\nfirst\n```not-closing\nstill inside\n```\nafter\n"
+        result = strip_fenced_blocks(text)
+        assert "first" not in result
+        assert "still inside" not in result
+        assert "after" in result


### PR DESCRIPTION
Closes #10

## Summary
First batch of deterministic GitHub PR checks.

- `src/gate_keeper/_md.py` (new): shared `TASK_CHECKED_RE` / `TASK_UNCHECKED_RE` / `FENCE_START_RE` / `strip_fenced_blocks` lifted out of the filesystem backend so the github backend can reuse them. Filesystem backend now imports from here.
- `src/gate_keeper/backends/github.py`:
  - `_fetch_pr_view(pr, rule)` makes a single `gh pr view <n> -R owner/repo --json state,isDraft,labels,body` call per `check()` invocation, parses, and returns either the dict or a fail-closed Diagnostic.
  - `_check_pr_open` — PASS if `state == "OPEN"`; FAIL otherwise. Missing field → UNAVAILABLE.
  - `_check_not_draft` — PASS if `isDraft is False`. Non-bool / missing → UNAVAILABLE.
  - `_check_labels_absent` — PASS when no PR label intersects the configured blocking set (case-insensitive). `rule.params.labels` is a list of strings; absent → defaults `["blocked","do-not-merge","needs-decision"]`; explicit `[]` means "no blocking labels at all" → always PASS. Malformed (non-list or non-string items) fails closed as `rule_params_invalid`.
  - `_check_tasks_complete` — PASS when the PR body has zero unchecked task boxes outside fenced code. `body=null` or non-string → UNAVAILABLE. Empty body → PASS (vacuous).
  - `_HANDLED` dispatch table; unknown github kinds (#11-#13) still return UNAVAILABLE after target resolution.
- `docs/rule-ir.md` — adds a per-kind params note for `github_labels_absent`.

## Validation
- `uv run pytest` → **428 passed** (367 → +61 new across `tests/test_md.py`, `tests/test_github_pr_state.py`, plus updates to `test_github_backend_stub.py`).
- Smoke: `uv run gate-keeper validate docs/example-rules.md --target tests/fixtures/local/pass --backend auto` → exit 1 (expected; github rule kinds emit `target_parse_error` UNAVAILABLE on a local-path target).

## Codex review
Run: `codex review --base main`. Findings posted as a PR comment. All three fixed in commit `ee7677c`:
- [P2] `strip_fenced_blocks` was too permissive (any indent, any trailing info on closing fence). Now matches CommonMark §4.5: ≤3-space indent, same-char closing fence ≥ open length, no info on close, backtick fences reject backticks in info.
- [P2] `_check_labels_absent` could iterate a bare string char-by-char or crash on non-string items in `params.labels`. Now type-validates list[str] up front and fails closed via `rule_params_invalid` evidence.
- [P2] `_check_tasks_complete` would crash if `body` was non-string. Now returns UNAVAILABLE/`gh_missing_field` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)