### PR TITLE
feat(github): status check rollup validation (#11)

### DIFF
--- a/docs/rule-ir.md
+++ b/docs/rule-ir.md
@@ -101,6 +101,7 @@ shape beyond those two top-level keys.
 | `kind` | `params` key | Default | Notes |
 | ------ | ------------ | ------- | ----- |
 | `github_labels_absent` | `labels` | `["blocked","do-not-merge","needs-decision"]` | List of blocking label names (case-insensitive). Absent key uses default list; explicit `[]` means no blocking labels → always PASS. |
+| `github_checks_success` | _(none)_ | — | Evaluates every entry in `statusCheckRollup` as required; only `SUCCESS` state/conclusion passes. Branch protection remains the authoritative control plane. |
 
 ## Validation policy
 

--- a/src/gate_keeper/backends/github.py
+++ b/src/gate_keeper/backends/github.py
@@ -281,6 +281,36 @@ def _check_tasks_complete(rule: Rule, pr: PrTarget, data: dict) -> Diagnostic:
 # ---------------------------------------------------------------------------
 
 
+def _normalize_rollup(raw: object) -> list | None:
+    """Return a flat list of rollup entries, or ``None`` if shape is unrecognized.
+
+    ``gh pr view --json statusCheckRollup`` flattens the GraphQL
+    ``StatusCheckRollup`` object to a list of entries (one per
+    ``CheckRun``/``StatusContext``). Future gh versions or alternate access
+    paths could conceivably return the nested object shape, e.g.::
+
+        {"contexts": {"nodes": [...]}}
+
+    or simply ``{"nodes": [...]}``. Be tolerant: accept the flat list (current
+    behaviour), and fall back to either nested-nodes shape so the rule still
+    evaluates instead of failing closed on a pure shape change.
+    """
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, dict):
+        # Try ``contexts.nodes`` first (the documented GraphQL relay shape),
+        # then a top-level ``nodes`` fallback.
+        contexts = raw.get("contexts")
+        if isinstance(contexts, dict):
+            nodes = contexts.get("nodes")
+            if isinstance(nodes, list):
+                return nodes
+        nodes = raw.get("nodes")
+        if isinstance(nodes, list):
+            return nodes
+    return None
+
+
 def _classify_check_entry(entry: dict) -> tuple[str, str, bool]:
     """Classify a single statusCheckRollup entry into (name, label, ok).
 
@@ -343,8 +373,9 @@ def _check_checks_success(rule: Rule, pr: PrTarget, data: dict) -> Diagnostic:
     if "statusCheckRollup" not in data:
         return gh_missing_field_diag(rule, "pr-view", "statusCheckRollup")
 
-    rollup = data["statusCheckRollup"]
-    if not isinstance(rollup, list):
+    rollup_raw = data["statusCheckRollup"]
+    rollup = _normalize_rollup(rollup_raw)
+    if rollup is None:
         return gh_missing_field_diag(rule, "pr-view", "statusCheckRollup")
 
     successful: list[str] = []

--- a/src/gate_keeper/backends/github.py
+++ b/src/gate_keeper/backends/github.py
@@ -1,8 +1,8 @@
 """GitHub backend for gate-keeper.
 
-Implements deterministic PR state, draft, label, and tasklist checks
-using the ``gh`` CLI (issue #10).  Issues #11-#13 (status checks, threads,
-approvals) are still UNAVAILABLE stubs; they land in separate PRs.
+Implements deterministic PR state, draft, label, tasklist, and status-check
+rollup validation using the ``gh`` CLI (issues #10–#11).  Issues #12–#13
+(threads, approvals) are still UNAVAILABLE stubs; they land in separate PRs.
 
 All rule kinds here share a single ``gh pr view`` call per ``check()``
 invocation; the result is parsed once and dispatched to the appropriate
@@ -66,7 +66,7 @@ def _diag(rule: Rule, status: Status, message: str, evidence: list[Evidence]) ->
 # _fetch_pr_view — single gh pr view call shared by all four handlers
 # ---------------------------------------------------------------------------
 
-_PR_VIEW_FIELDS = "state,isDraft,labels,body"
+_PR_VIEW_FIELDS = "state,isDraft,labels,body,statusCheckRollup"
 
 
 def _fetch_pr_view(pr: PrTarget, rule: Rule) -> tuple[dict | None, Diagnostic | None]:
@@ -277,6 +277,123 @@ def _check_tasks_complete(rule: Rule, pr: PrTarget, data: dict) -> Diagnostic:
 
 
 # ---------------------------------------------------------------------------
+# Status check rollup handler (issue #11)
+# ---------------------------------------------------------------------------
+
+
+def _classify_check_entry(entry: dict) -> tuple[str, str, bool]:
+    """Classify a single statusCheckRollup entry into (name, label, ok).
+
+    Two shapes are supported:
+
+    - ``StatusContext`` (legacy commit statuses): passes only when
+      ``state == "SUCCESS"``.
+    - ``CheckRun`` (GitHub Actions / Checks API): passes only when
+      ``status == "COMPLETED"`` **and** ``conclusion == "SUCCESS"``.
+
+    Entries with an unrecognised ``__typename``, or with missing fields that
+    prevent classification, yield ``label = "UNKNOWN"`` and ``ok = False``.
+    The name falls back to ``"<unnamed>"`` when neither ``name`` nor
+    ``context`` is present.
+    """
+    if not isinstance(entry, dict):
+        return "<unnamed>", "UNKNOWN", False
+
+    name = entry.get("name") or entry.get("context") or "<unnamed>"
+
+    typename = entry.get("__typename", "")
+
+    if typename == "StatusContext":
+        state = entry.get("state")
+        if not isinstance(state, str):
+            return name, "UNKNOWN", False
+        ok = state == "SUCCESS"
+        return name, state, ok
+
+    if typename == "CheckRun":
+        status = entry.get("status")
+        conclusion = entry.get("conclusion")
+        if not isinstance(status, str):
+            return name, "UNKNOWN", False
+        if status != "COMPLETED":
+            # Still in progress, queued, etc.
+            label = status if status else "UNKNOWN"
+            return name, label, False
+        # status == COMPLETED — conclusion is authoritative.
+        if not isinstance(conclusion, str):
+            return name, "MISSING_CONCLUSION", False
+        ok = conclusion == "SUCCESS"
+        return name, conclusion, ok
+
+    # Unknown __typename or missing it entirely.
+    return name, "UNKNOWN", False
+
+
+def _check_checks_success(rule: Rule, pr: PrTarget, data: dict) -> Diagnostic:
+    """Pass when every entry in ``statusCheckRollup`` resolves to success.
+
+    Evidence kind: ``checks_rollup``.
+
+    - ``statusCheckRollup`` absent → UNAVAILABLE (gh_missing_field).
+    - Empty rollup list → PASS (vacuous — zero checks defined; noted in message).
+    - Any non-successful entry → FAIL; non-successful names listed in evidence.
+    - Branch protection remains the authoritative control plane; this check
+      is advisory evidence only.
+    """
+    if "statusCheckRollup" not in data:
+        return gh_missing_field_diag(rule, "pr-view", "statusCheckRollup")
+
+    rollup = data["statusCheckRollup"]
+    if not isinstance(rollup, list):
+        return gh_missing_field_diag(rule, "pr-view", "statusCheckRollup")
+
+    successful: list[str] = []
+    non_successful: list[dict] = []
+
+    for entry in rollup:
+        entry_name, label, ok = _classify_check_entry(entry)
+        if ok:
+            successful.append(entry_name)
+        else:
+            non_successful.append({"name": entry_name, "state": label})
+
+    total = len(rollup)
+    n_success = len(successful)
+    summary = f"{n_success}/{total} checks passed"
+
+    evidence = [
+        Evidence(
+            kind="checks_rollup",
+            data={
+                "total": total,
+                "successful": successful,
+                "non_successful": non_successful,
+                "summary": summary,
+                **_pr_coords(pr),
+            },
+        )
+    ]
+
+    if not non_successful:
+        if total == 0:
+            msg = f"PR {pr.owner}/{pr.repo}#{pr.number}: 0 checks defined; vacuous pass."
+        else:
+            msg = f"PR {pr.owner}/{pr.repo}#{pr.number}: {summary}."
+        return _diag(rule, Status.PASS, msg, evidence)
+
+    non_names = [e["name"] for e in non_successful]
+    return _diag(
+        rule,
+        Status.FAIL,
+        (
+            f"PR {pr.owner}/{pr.repo}#{pr.number}: {summary}; "
+            f"non-successful checks: {non_names!r}."
+        ),
+        evidence,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Dispatch table
 # ---------------------------------------------------------------------------
 
@@ -285,6 +402,7 @@ _HANDLED = {
     RuleKind.GITHUB_NOT_DRAFT: _check_not_draft,
     RuleKind.GITHUB_LABELS_ABSENT: _check_labels_absent,
     RuleKind.GITHUB_TASKS_COMPLETE: _check_tasks_complete,
+    RuleKind.GITHUB_CHECKS_SUCCESS: _check_checks_success,
 }
 
 # ---------------------------------------------------------------------------
@@ -297,7 +415,7 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
 
     Resolution failures (bad target, missing gh, auth error, PR not found)
     surface as UNAVAILABLE immediately.  A single ``gh pr view`` call is made
-    for the four implemented kinds; unimplemented kinds (#11-#13) receive an
+    for the five implemented kinds; unimplemented kinds (#12-#13) receive an
     UNAVAILABLE stub after resolution.
     """
     target_str = str(target)
@@ -307,7 +425,7 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
 
     handler = _HANDLED.get(rule.kind)
     if handler is None:
-        # Rule kind not yet implemented — issues #11-#13.
+        # Rule kind not yet implemented — issues #12-#13.
         return Diagnostic(
             rule_id=rule.id,
             source=rule.source,
@@ -316,7 +434,7 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
             severity=rule.severity,
             message=(
                 f"target resolved to {pr.owner}/{pr.repo}#{pr.number}; "
-                f"rule kind {rule.kind.value!r} not yet implemented (#11-#13)"
+                f"rule kind {rule.kind.value!r} not yet implemented (#12-#13)"
             ),
             evidence=[
                 Evidence(

--- a/tests/test_github_checks_success.py
+++ b/tests/test_github_checks_success.py
@@ -1,0 +1,547 @@
+"""Tests for the status check rollup handler (issue #11).
+
+Uses the same _patch_both / _ok / _RESOLVE_OK helpers as
+tests/test_github_pr_state.py.  A local _pr_view_checks_json helper
+builds a gh pr view payload that includes statusCheckRollup.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from gate_keeper.backends import _gh, _target
+from gate_keeper.backends import github as gh_backend
+from gate_keeper.backends.github import _classify_check_entry
+from gate_keeper.diagnostics import EXIT_FAIL, EXIT_OK, compute_exit_code
+from gate_keeper.models import (
+    Backend,
+    Confidence,
+    Diagnostic,
+    Rule,
+    RuleKind,
+    RuleSet,
+    Severity,
+    SourceLocation,
+    Status,
+)
+from gate_keeper.validator import validate
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (mirrors test_github_pr_state.py)
+# ---------------------------------------------------------------------------
+
+_RESOLVE_OK = json.dumps({"number": 42, "url": "https://github.com/owner/repo/pull/42"})
+
+
+def _ok(stdout: str, args: tuple[str, ...] = ()) -> _gh.GhResult:
+    return _gh.GhResult(ok=True, stdout=stdout, stderr="", returncode=0, cmd=("gh", *args))
+
+
+def _make_github_rule(kind: RuleKind, params: dict | None = None) -> Rule:
+    return Rule(
+        id="test-rule",
+        title="Test GitHub rule",
+        source=SourceLocation(path="rules.md", line=1),
+        text="Test rule text",
+        kind=kind,
+        severity=Severity.ERROR,
+        backend_hint=Backend.GITHUB,
+        confidence=Confidence.HIGH,
+        params=params or {},
+    )
+
+
+def _make_run_gh_sequence(results: list[_gh.GhResult]):
+    queue = list(results)
+
+    def _fake(args, **kwargs):
+        if queue:
+            return queue.pop(0)
+        raise AssertionError(f"run_gh called more times than expected; args={args!r}")
+
+    return _fake
+
+
+def _patch_both(monkeypatch, resolve_result: _gh.GhResult, fetch_result: _gh.GhResult):
+    monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([resolve_result]))
+    monkeypatch.setattr(gh_backend, "run_gh", _make_run_gh_sequence([fetch_result]))
+
+
+def _pr_view_checks_json(rollup: Any = None, *, include_rollup: bool = True) -> str:
+    """Build a gh pr view JSON string.
+
+    Pass ``include_rollup=False`` to omit the field entirely (simulates missing
+    field).  Otherwise ``rollup`` is the value for ``statusCheckRollup``.
+    """
+    payload: dict[str, Any] = {
+        "state": "OPEN",
+        "isDraft": False,
+        "labels": [],
+        "body": "",
+    }
+    if include_rollup:
+        payload["statusCheckRollup"] = rollup
+    return json.dumps(payload)
+
+
+def _check_rule(monkeypatch, rollup: Any = None, *, include_rollup: bool = True) -> Diagnostic:
+    _patch_both(
+        monkeypatch,
+        _ok(_RESOLVE_OK),
+        _ok(_pr_view_checks_json(rollup, include_rollup=include_rollup)),
+    )
+    rule = _make_github_rule(RuleKind.GITHUB_CHECKS_SUCCESS)
+    return gh_backend.check(rule, "owner/repo#42")
+
+
+# ---------------------------------------------------------------------------
+# Unit: _classify_check_entry
+# ---------------------------------------------------------------------------
+
+class TestClassifyCheckEntry:
+    def test_status_context_success(self):
+        entry = {"__typename": "StatusContext", "context": "ci/build", "state": "SUCCESS"}
+        name, label, ok = _classify_check_entry(entry)
+        assert name == "ci/build"
+        assert label == "SUCCESS"
+        assert ok is True
+
+    def test_status_context_failure(self):
+        entry = {"__typename": "StatusContext", "context": "ci/build", "state": "FAILURE"}
+        name, label, ok = _classify_check_entry(entry)
+        assert name == "ci/build"
+        assert label == "FAILURE"
+        assert ok is False
+
+    def test_status_context_error(self):
+        entry = {"__typename": "StatusContext", "context": "ci/lint", "state": "ERROR"}
+        name, label, ok = _classify_check_entry(entry)
+        assert ok is False
+        assert label == "ERROR"
+
+    def test_status_context_pending(self):
+        entry = {"__typename": "StatusContext", "context": "ci/test", "state": "PENDING"}
+        _, label, ok = _classify_check_entry(entry)
+        assert ok is False
+        assert label == "PENDING"
+
+    def test_status_context_missing_state(self):
+        entry = {"__typename": "StatusContext", "context": "ci/build"}
+        name, label, ok = _classify_check_entry(entry)
+        assert ok is False
+        assert label == "UNKNOWN"
+
+    def test_checkrun_completed_success(self):
+        entry = {
+            "__typename": "CheckRun",
+            "name": "lint",
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS",
+        }
+        name, label, ok = _classify_check_entry(entry)
+        assert name == "lint"
+        assert label == "SUCCESS"
+        assert ok is True
+
+    def test_checkrun_completed_neutral(self):
+        entry = {
+            "__typename": "CheckRun",
+            "name": "lint",
+            "status": "COMPLETED",
+            "conclusion": "NEUTRAL",
+        }
+        name, label, ok = _classify_check_entry(entry)
+        assert ok is False
+        assert label == "NEUTRAL"
+
+    def test_checkrun_completed_cancelled(self):
+        entry = {
+            "__typename": "CheckRun",
+            "name": "build",
+            "status": "COMPLETED",
+            "conclusion": "CANCELLED",
+        }
+        _, label, ok = _classify_check_entry(entry)
+        assert ok is False
+        assert label == "CANCELLED"
+
+    def test_checkrun_queued(self):
+        entry = {"__typename": "CheckRun", "name": "build", "status": "QUEUED"}
+        name, label, ok = _classify_check_entry(entry)
+        assert ok is False
+        assert label == "QUEUED"
+
+    def test_checkrun_in_progress(self):
+        entry = {
+            "__typename": "CheckRun",
+            "name": "tests",
+            "status": "IN_PROGRESS",
+        }
+        _, label, ok = _classify_check_entry(entry)
+        assert ok is False
+        assert label == "IN_PROGRESS"
+
+    def test_checkrun_completed_missing_conclusion(self):
+        entry = {"__typename": "CheckRun", "name": "build", "status": "COMPLETED"}
+        _, label, ok = _classify_check_entry(entry)
+        assert ok is False
+        assert label == "MISSING_CONCLUSION"
+
+    def test_unknown_typename(self):
+        entry = {"__typename": "SomeFutureType", "name": "x"}
+        name, label, ok = _classify_check_entry(entry)
+        assert ok is False
+        assert label == "UNKNOWN"
+
+    def test_no_typename(self):
+        entry = {"name": "mystery"}
+        name, label, ok = _classify_check_entry(entry)
+        assert ok is False
+        assert label == "UNKNOWN"
+
+    def test_no_name_or_context_falls_back_to_unnamed(self):
+        entry = {"__typename": "CheckRun", "status": "QUEUED"}
+        name, label, ok = _classify_check_entry(entry)
+        assert name == "<unnamed>"
+        assert ok is False
+
+    def test_uses_name_over_context(self):
+        entry = {
+            "__typename": "CheckRun",
+            "name": "explicit-name",
+            "context": "ignored-context",
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS",
+        }
+        name, _, _ = _classify_check_entry(entry)
+        assert name == "explicit-name"
+
+    def test_non_dict_entry(self):
+        name, label, ok = _classify_check_entry("not-a-dict")  # type: ignore[arg-type]
+        assert name == "<unnamed>"
+        assert label == "UNKNOWN"
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Handler: missing / malformed rollup field
+# ---------------------------------------------------------------------------
+
+class TestMissingRollup:
+    def test_missing_statuscheckrollup_field_unavailable(self, monkeypatch):
+        diag = _check_rule(monkeypatch, include_rollup=False)
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_missing_field"
+        assert diag.evidence[0].data["field"] == "statusCheckRollup"
+
+    def test_non_list_rollup_unavailable(self, monkeypatch):
+        """A non-list value for statusCheckRollup fails closed."""
+        diag = _check_rule(monkeypatch, rollup="not-a-list")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_missing_field"
+
+
+# ---------------------------------------------------------------------------
+# Handler: empty rollup → vacuous PASS
+# ---------------------------------------------------------------------------
+
+class TestEmptyRollup:
+    def test_empty_rollup_passes(self, monkeypatch):
+        diag = _check_rule(monkeypatch, rollup=[])
+        assert diag.status is Status.PASS
+        ev = diag.evidence[0]
+        assert ev.kind == "checks_rollup"
+        assert ev.data["total"] == 0
+        assert ev.data["successful"] == []
+        assert ev.data["non_successful"] == []
+        assert "0 checks defined" in diag.message
+
+    def test_empty_rollup_evidence_coords(self, monkeypatch):
+        diag = _check_rule(monkeypatch, rollup=[])
+        d = diag.evidence[0].data
+        assert d["owner"] == "owner"
+        assert d["repo"] == "repo"
+        assert d["number"] == 42
+        assert d["url"] == "https://github.com/owner/repo/pull/42"
+
+
+# ---------------------------------------------------------------------------
+# Handler: single SUCCESS entries
+# ---------------------------------------------------------------------------
+
+class TestSingleSuccessEntries:
+    def test_single_checkrun_success_passes(self, monkeypatch):
+        rollup = [
+            {
+                "__typename": "CheckRun",
+                "name": "lint",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            }
+        ]
+        diag = _check_rule(monkeypatch, rollup=rollup)
+        assert diag.status is Status.PASS
+        ev = diag.evidence[0]
+        assert ev.data["total"] == 1
+        assert ev.data["successful"] == ["lint"]
+        assert ev.data["non_successful"] == []
+
+    def test_single_statuscontext_success_passes(self, monkeypatch):
+        """StatusContext uses 'context' as name."""
+        rollup = [
+            {
+                "__typename": "StatusContext",
+                "context": "ci/build",
+                "state": "SUCCESS",
+            }
+        ]
+        diag = _check_rule(monkeypatch, rollup=rollup)
+        assert diag.status is Status.PASS
+        ev = diag.evidence[0]
+        assert ev.data["successful"] == ["ci/build"]
+
+    def test_mix_checkrun_and_statuscontext_success(self, monkeypatch):
+        """Both kinds of entries can coexist."""
+        rollup = [
+            {
+                "__typename": "CheckRun",
+                "name": "lint",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            },
+            {
+                "__typename": "StatusContext",
+                "context": "ci/build",
+                "state": "SUCCESS",
+            },
+        ]
+        diag = _check_rule(monkeypatch, rollup=rollup)
+        assert diag.status is Status.PASS
+        ev = diag.evidence[0]
+        assert ev.data["total"] == 2
+        assert set(ev.data["successful"]) == {"lint", "ci/build"}
+        assert ev.data["non_successful"] == []
+
+
+# ---------------------------------------------------------------------------
+# Handler: failures / non-successful checks
+# ---------------------------------------------------------------------------
+
+class TestNonSuccessfulChecks:
+    def test_one_failure_fails(self, monkeypatch):
+        rollup = [
+            {
+                "__typename": "CheckRun",
+                "name": "tests",
+                "status": "COMPLETED",
+                "conclusion": "FAILURE",
+            }
+        ]
+        diag = _check_rule(monkeypatch, rollup=rollup)
+        assert diag.status is Status.FAIL
+        ev = diag.evidence[0]
+        assert ev.data["non_successful"] == [{"name": "tests", "state": "FAILURE"}]
+        assert ev.data["successful"] == []
+
+    def test_pending_fails(self, monkeypatch):
+        """StatusContext with state PENDING fails."""
+        rollup = [
+            {"__typename": "StatusContext", "context": "ci/test", "state": "PENDING"}
+        ]
+        diag = _check_rule(monkeypatch, rollup=rollup)
+        assert diag.status is Status.FAIL
+        ev = diag.evidence[0]
+        assert ev.data["non_successful"][0]["name"] == "ci/test"
+        assert ev.data["non_successful"][0]["state"] == "PENDING"
+
+    def test_in_progress_fails(self, monkeypatch):
+        rollup = [
+            {
+                "__typename": "CheckRun",
+                "name": "build",
+                "status": "IN_PROGRESS",
+            }
+        ]
+        diag = _check_rule(monkeypatch, rollup=rollup)
+        assert diag.status is Status.FAIL
+
+    def test_checkrun_neutral_conclusion_fails(self, monkeypatch):
+        rollup = [
+            {
+                "__typename": "CheckRun",
+                "name": "style",
+                "status": "COMPLETED",
+                "conclusion": "NEUTRAL",
+            }
+        ]
+        diag = _check_rule(monkeypatch, rollup=rollup)
+        assert diag.status is Status.FAIL
+        ev = diag.evidence[0]
+        assert ev.data["non_successful"][0]["state"] == "NEUTRAL"
+
+    def test_checkrun_cancelled_conclusion_fails(self, monkeypatch):
+        rollup = [
+            {
+                "__typename": "CheckRun",
+                "name": "deploy",
+                "status": "COMPLETED",
+                "conclusion": "CANCELLED",
+            }
+        ]
+        diag = _check_rule(monkeypatch, rollup=rollup)
+        assert diag.status is Status.FAIL
+
+    def test_checkrun_queued_fails(self, monkeypatch):
+        rollup = [{"__typename": "CheckRun", "name": "waiting", "status": "QUEUED"}]
+        diag = _check_rule(monkeypatch, rollup=rollup)
+        assert diag.status is Status.FAIL
+        ev = diag.evidence[0]
+        assert ev.data["non_successful"][0]["state"] == "QUEUED"
+
+    def test_statuscontext_error_fails(self, monkeypatch):
+        rollup = [
+            {"__typename": "StatusContext", "context": "ci/deploy", "state": "ERROR"}
+        ]
+        diag = _check_rule(monkeypatch, rollup=rollup)
+        assert diag.status is Status.FAIL
+
+    def test_unknown_typename_fails(self, monkeypatch):
+        rollup = [{"__typename": "FutureType", "name": "mystery"}]
+        diag = _check_rule(monkeypatch, rollup=rollup)
+        assert diag.status is Status.FAIL
+        ev = diag.evidence[0]
+        assert ev.data["non_successful"][0]["state"] == "UNKNOWN"
+
+    def test_missing_fields_unknown_and_unnamed(self, monkeypatch):
+        """Entries missing name/context and type fields → '<unnamed>' + UNKNOWN."""
+        rollup = [{}]
+        diag = _check_rule(monkeypatch, rollup=rollup)
+        assert diag.status is Status.FAIL
+        ev = diag.evidence[0]
+        assert ev.data["non_successful"] == [{"name": "<unnamed>", "state": "UNKNOWN"}]
+
+    def test_multi_fail_one_success_and_one_failure(self, monkeypatch):
+        """Mixed rollup: successful and non-successful are categorised correctly."""
+        rollup = [
+            {
+                "__typename": "CheckRun",
+                "name": "lint",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            },
+            {
+                "__typename": "StatusContext",
+                "context": "ci/integration",
+                "state": "FAILURE",
+            },
+        ]
+        diag = _check_rule(monkeypatch, rollup=rollup)
+        assert diag.status is Status.FAIL
+        ev = diag.evidence[0]
+        assert ev.data["successful"] == ["lint"]
+        assert ev.data["non_successful"] == [
+            {"name": "ci/integration", "state": "FAILURE"}
+        ]
+        assert ev.data["total"] == 2
+        assert ev.data["summary"] == "1/2 checks passed"
+
+
+# ---------------------------------------------------------------------------
+# Evidence: round-trip through to_dict / from_dict
+# ---------------------------------------------------------------------------
+
+class TestDiagRoundTrip:
+    def _round_trip(self, diag: Diagnostic) -> Diagnostic:
+        return Diagnostic.from_dict(diag.to_dict())
+
+    def test_pass_round_trips(self, monkeypatch):
+        rollup = [
+            {
+                "__typename": "CheckRun",
+                "name": "lint",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            }
+        ]
+        diag = _check_rule(monkeypatch, rollup=rollup)
+        rt = self._round_trip(diag)
+        assert rt.status is Status.PASS
+        assert rt.evidence[0].kind == "checks_rollup"
+
+    def test_fail_round_trips(self, monkeypatch):
+        rollup = [
+            {
+                "__typename": "CheckRun",
+                "name": "tests",
+                "status": "COMPLETED",
+                "conclusion": "FAILURE",
+            }
+        ]
+        diag = _check_rule(monkeypatch, rollup=rollup)
+        rt = self._round_trip(diag)
+        assert rt.status is Status.FAIL
+
+    def test_unavailable_round_trips(self, monkeypatch):
+        diag = _check_rule(monkeypatch, include_rollup=False)
+        rt = self._round_trip(diag)
+        assert rt.status is Status.UNAVAILABLE
+
+    def test_empty_rollup_round_trips(self, monkeypatch):
+        diag = _check_rule(monkeypatch, rollup=[])
+        rt = self._round_trip(diag)
+        assert rt.status is Status.PASS
+        assert rt.evidence[0].data["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via validate()
+# ---------------------------------------------------------------------------
+
+class TestEndToEndValidator:
+    def test_all_success_passes_exit_0(self, monkeypatch):
+        rollup = [
+            {
+                "__typename": "CheckRun",
+                "name": "lint",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            },
+            {
+                "__typename": "StatusContext",
+                "context": "ci/build",
+                "state": "SUCCESS",
+            },
+        ]
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_checks_json(rollup)),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_CHECKS_SUCCESS)
+        report = validate(RuleSet(rules=[rule]), "owner/repo#42", backend="auto")
+        assert len(report.diagnostics) == 1
+        assert report.diagnostics[0].status is Status.PASS
+        assert compute_exit_code(report.diagnostics) == EXIT_OK
+
+    def test_one_failure_exit_1(self, monkeypatch):
+        rollup = [
+            {
+                "__typename": "CheckRun",
+                "name": "tests",
+                "status": "COMPLETED",
+                "conclusion": "FAILURE",
+            }
+        ]
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_pr_view_checks_json(rollup)),
+        )
+        rule = _make_github_rule(RuleKind.GITHUB_CHECKS_SUCCESS)
+        report = validate(RuleSet(rules=[rule]), "owner/repo#42", backend="auto")
+        assert len(report.diagnostics) == 1
+        assert report.diagnostics[0].status is Status.FAIL
+        assert compute_exit_code(report.diagnostics) == EXIT_FAIL

--- a/tests/test_github_checks_success.py
+++ b/tests/test_github_checks_success.py
@@ -238,10 +238,49 @@ class TestMissingRollup:
         assert diag.evidence[0].data["field"] == "statusCheckRollup"
 
     def test_non_list_rollup_unavailable(self, monkeypatch):
-        """A non-list value for statusCheckRollup fails closed."""
+        """A non-list, non-recognized-dict value for statusCheckRollup fails closed."""
         diag = _check_rule(monkeypatch, rollup="not-a-list")
         assert diag.status is Status.UNAVAILABLE
         assert diag.evidence[0].kind == "gh_missing_field"
+
+    def test_unrecognized_dict_rollup_unavailable(self, monkeypatch):
+        """A dict without contexts.nodes or nodes also fails closed."""
+        diag = _check_rule(monkeypatch, rollup={"unexpected": "shape"})
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_missing_field"
+
+
+class TestRollupShapeFlexibility:
+    """gh's --json statusCheckRollup currently flattens to a list, but be
+    tolerant of the GraphQL StatusCheckRollup object shape so a future gh
+    upgrade or alternate access path doesn't silently break the rule."""
+
+    _ENTRY = {
+        "__typename": "CheckRun",
+        "name": "lint",
+        "status": "COMPLETED",
+        "conclusion": "SUCCESS",
+    }
+
+    def test_dict_rollup_with_contexts_nodes_is_evaluated(self, monkeypatch):
+        diag = _check_rule(
+            monkeypatch,
+            rollup={"contexts": {"nodes": [self._ENTRY]}},
+        )
+        assert diag.status is Status.PASS
+        ev = diag.evidence[0]
+        assert ev.data["total"] == 1
+        assert ev.data["successful"] == ["lint"]
+
+    def test_dict_rollup_with_top_level_nodes_is_evaluated(self, monkeypatch):
+        diag = _check_rule(
+            monkeypatch,
+            rollup={"nodes": [self._ENTRY]},
+        )
+        assert diag.status is Status.PASS
+        ev = diag.evidence[0]
+        assert ev.data["total"] == 1
+        assert ev.data["successful"] == ["lint"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #11

## Summary
Implements `github_checks_success`: every entry in the PR's `statusCheckRollup` must be successful for the rule to pass. Branch protection remains the authoritative control plane; this rule only produces evidence.

- `_classify_check_entry(entry)` is a pure helper that normalizes a rollup entry into `(name, label, ok)`. Two shapes: `StatusContext` passes only on `state == "SUCCESS"`; `CheckRun` passes only when `status == "COMPLETED"` AND `conclusion == "SUCCESS"`. Anything else (PENDING, IN_PROGRESS, QUEUED, NEUTRAL, CANCELLED, SKIPPED, TIMED_OUT, MISSING_CONCLUSION, UNKNOWN, …) → not-ok.
- `_normalize_rollup` accepts the flat list shape (what `gh pr view --json statusCheckRollup` returns today, verified live) AND the GraphQL-object shape `{contexts: {nodes: [...]}}` or `{nodes: [...]}` for forward compatibility.
- `_check_checks_success` returns:
  - UNAVAILABLE / `gh_missing_field` when the rollup field is absent or shape is unrecognized.
  - PASS with `total=0` and a "0 checks defined" message when the rollup is empty (vacuous).
  - PASS when every entry is ok; FAIL with `non_successful = [{name, state}, ...]` and a `summary = "{n_ok}/{total} checks passed"` otherwise.
- `_fetch_pr_view` widens the `--json` view to include `statusCheckRollup` (single gh call serves all five handlers).
- `_HANDLED` table now includes `GITHUB_CHECKS_SUCCESS`. Stub message updated to point at #12-#13.

## Validation
- `uv run pytest` → **470 passed** (428 → +42 new in `tests/test_github_checks_success.py`).
- Smoke: `gate-keeper validate docs/example-rules.md --target tests/fixtures/local/pass --backend auto` exits 1 (expected; github rules emit `target_parse_error` against a local-path target).

## Codex review
Run: `codex review --base main`. One finding posted as a PR comment. Fixed in commit `7811b35`:
- [P1] Codex flagged a hard-coded `isinstance(rollup, list)` check that would fail closed on the GraphQL object shape. Verified live that `gh pr view --json statusCheckRollup` currently flattens to a list (see microsoft/vscode #313452), so behavior on real PRs was already correct, but added a `_normalize_rollup` helper that also accepts the nested shape so a future gh change won't silently break us.

## Notes
- Branch protection / required checks remain authoritative. This rule produces advisory evidence only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)