### PR TITLE
feat(github): unresolved review thread check (#12)

### DIFF
--- a/src/gate_keeper/backends/github.py
+++ b/src/gate_keeper/backends/github.py
@@ -1,13 +1,16 @@
 """GitHub backend for gate-keeper.
 
-Implements deterministic PR state, draft, label, tasklist, and status-check
-rollup validation using the ``gh`` CLI (issues #10–#11).  Issues #12–#13
-(threads, approvals) are still UNAVAILABLE stubs; they land in separate PRs.
+Implements deterministic PR state, draft, label, tasklist, status-check
+rollup, and review thread validation using the ``gh`` CLI (issues #10–#12).
+Issue #13 (approvals) is still an UNAVAILABLE stub; it lands in a separate PR.
 
-All rule kinds here share a single ``gh pr view`` call per ``check()``
+Five rule kinds share a single ``gh pr view`` call per ``check()``
 invocation; the result is parsed once and dispatched to the appropriate
-handler.  Any failure before dispatch (missing gh, auth, JSON, missing
-field) propagates as UNAVAILABLE — all paths fail closed.
+handler.  The sixth kind (``github_threads_resolved``) makes its own
+GraphQL call via ``gh api graphql`` and does NOT use ``_fetch_pr_view``.
+
+Any failure before dispatch (missing gh, auth, JSON, missing field)
+propagates as UNAVAILABLE — all paths fail closed.
 """
 from __future__ import annotations
 
@@ -20,6 +23,7 @@ from gate_keeper._md import (
 )
 from gate_keeper.backends._gh import (  # noqa: F401  (re-export)
     GhResult,
+    _redact,
     classify_gh_failure,
     failure_diag,
     gh_auth_diag,
@@ -425,15 +429,259 @@ def _check_checks_success(rule: Rule, pr: PrTarget, data: dict) -> Diagnostic:
 
 
 # ---------------------------------------------------------------------------
-# Dispatch table
+# Review threads GraphQL handler (issue #12)
 # ---------------------------------------------------------------------------
 
-_HANDLED = {
+_THREADS_QUERY = """query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          path
+          line
+          comments(first: 1) { nodes { author { login } body url } }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}"""
+
+_GRAPHQL_ERROR_MSG_LIMIT = 200
+
+
+def _fetch_review_threads(
+    pr: PrTarget, rule: Rule
+) -> tuple[list[dict] | None, dict | None, Diagnostic | None]:
+    """Run the threads GraphQL query.
+
+    Returns exactly one populated branch:
+    - ``(nodes, pageInfo, None)`` on success.
+    - ``(None, None, diag)`` on any failure.
+    """
+    argv = [
+        "api", "graphql",
+        "-f", f"query={_THREADS_QUERY}",
+        "-f", f"owner={pr.owner}",
+        "-f", f"repo={pr.repo}",
+        "-F", f"number={pr.number}",
+    ]
+    result = run_gh(argv)
+
+    if not result.ok:
+        return None, None, failure_diag(rule, "graphql", result)
+
+    data, err = parse_json(result.stdout)
+    if err is not None:
+        return None, None, gh_json_diag(rule, "graphql", err)
+
+    # Top-level GraphQL errors array → UNAVAILABLE
+    if isinstance(data, dict) and "errors" in data:
+        raw_errors = data["errors"]
+        if not isinstance(raw_errors, list):
+            raw_errors = [raw_errors]
+        summaries = []
+        for e in raw_errors:
+            if isinstance(e, dict):
+                msg = str(e.get("message", repr(e)))
+            else:
+                msg = str(e)
+            msg = _redact(msg)
+            if len(msg) > _GRAPHQL_ERROR_MSG_LIMIT:
+                msg = msg[:_GRAPHQL_ERROR_MSG_LIMIT] + "…"
+            summaries.append(msg)
+        diag = _base_gh_diag(
+            rule,
+            Status.UNAVAILABLE,
+            "gh 'graphql' returned GraphQL errors; evaluation is unavailable.",
+            [
+                Evidence(
+                    kind="gh_graphql_error",
+                    data={
+                        "op": "graphql",
+                        "errors": summaries,
+                        "owner": pr.owner,
+                        "repo": pr.repo,
+                        "number": pr.number,
+                    },
+                )
+            ],
+        )
+        return None, None, diag
+
+    # Navigate to reviewThreads
+    if not isinstance(data, dict) or "data" not in data:
+        return None, None, gh_missing_field_diag(rule, "graphql", "data")
+
+    repo_data = data["data"]
+    if not isinstance(repo_data, dict) or "repository" not in repo_data:
+        return None, None, gh_missing_field_diag(rule, "graphql", "data.repository")
+
+    repository = repo_data["repository"]
+    if not isinstance(repository, dict) or "pullRequest" not in repository:
+        return None, None, gh_missing_field_diag(rule, "graphql", "data.repository.pullRequest")
+
+    pull_request = repository["pullRequest"]
+    if not isinstance(pull_request, dict) or "reviewThreads" not in pull_request:
+        return (
+            None,
+            None,
+            gh_missing_field_diag(rule, "graphql", "data.repository.pullRequest.reviewThreads"),
+        )
+
+    review_threads = pull_request["reviewThreads"]
+    if not isinstance(review_threads, dict):
+        return (
+            None,
+            None,
+            gh_missing_field_diag(rule, "graphql", "data.repository.pullRequest.reviewThreads"),
+        )
+
+    nodes = review_threads.get("nodes")
+    page_info = review_threads.get("pageInfo")
+
+    if not isinstance(nodes, list):
+        return (
+            None,
+            None,
+            gh_missing_field_diag(
+                rule, "graphql", "data.repository.pullRequest.reviewThreads.nodes"
+            ),
+        )
+
+    if not isinstance(page_info, dict):
+        return (
+            None,
+            None,
+            gh_missing_field_diag(
+                rule, "graphql", "data.repository.pullRequest.reviewThreads.pageInfo"
+            ),
+        )
+
+    # Pagination guard: hasNextPage true → UNAVAILABLE
+    has_next = page_info.get("hasNextPage")
+    if has_next is True:
+        end_cursor = page_info.get("endCursor")
+        if not isinstance(end_cursor, str):
+            end_cursor = None
+        return None, None, gh_pagination_diag(rule, "graphql", end_cursor=end_cursor)
+
+    return nodes, page_info, None
+
+
+def _base_gh_diag(rule: Rule, status: Status, message: str, evidence: list[Evidence]) -> Diagnostic:
+    """Shared builder for diagnostics that bypass _diag (which sets backend=GITHUB already)."""
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=Backend.GITHUB,
+        status=status,
+        severity=rule.severity,
+        message=message,
+        evidence=evidence,
+    )
+
+
+def _check_threads_resolved(rule: Rule, pr: PrTarget) -> Diagnostic:
+    """Pass when all review threads are resolved; fail if any are unresolved.
+
+    Evidence kind: ``review_threads``.
+    """
+    nodes, _page_info, diag = _fetch_review_threads(pr, rule)
+    if diag is not None:
+        return diag
+
+    unresolved: list[dict] = []
+    for node in nodes:  # type: ignore[union-attr]
+        if not isinstance(node, dict):
+            # Treat non-dict nodes conservatively as unresolved
+            unresolved.append({"path": None, "line": None, "first_comment_author": None, "first_comment_url": None})
+            continue
+
+        is_resolved = node.get("isResolved")
+        # Non-bool → treat as not-resolved (conservative)
+        if not isinstance(is_resolved, bool) or not is_resolved:
+            path = node.get("path")
+            line = node.get("line")
+            if not isinstance(path, str):
+                path = None
+            if not isinstance(line, int) or isinstance(line, bool):
+                line = None
+
+            # Extract first comment metadata
+            first_comment_author = None
+            first_comment_url = None
+            comments = node.get("comments")
+            if isinstance(comments, dict):
+                comment_nodes = comments.get("nodes")
+                if isinstance(comment_nodes, list) and comment_nodes:
+                    first = comment_nodes[0]
+                    if isinstance(first, dict):
+                        author = first.get("author")
+                        if isinstance(author, dict):
+                            login = author.get("login")
+                            if isinstance(login, str):
+                                first_comment_author = login
+                        url = first.get("url")
+                        if isinstance(url, str):
+                            first_comment_url = url
+
+            unresolved.append({
+                "path": path,
+                "line": line,
+                "first_comment_author": first_comment_author,
+                "first_comment_url": first_comment_url,
+            })
+
+    total = len(nodes)  # type: ignore[arg-type]
+    unresolved_count = len(unresolved)
+
+    evidence = [
+        Evidence(
+            kind="review_threads",
+            data={
+                "total": total,
+                "unresolved_count": unresolved_count,
+                "unresolved": unresolved,
+                **_pr_coords(pr),
+            },
+        )
+    ]
+
+    if unresolved_count == 0:
+        return _diag(
+            rule,
+            Status.PASS,
+            f"PR {pr.owner}/{pr.repo}#{pr.number}: all {total} review thread(s) are resolved.",
+            evidence,
+        )
+
+    return _diag(
+        rule,
+        Status.FAIL,
+        f"PR {pr.owner}/{pr.repo}#{pr.number}: {unresolved_count} unresolved review thread(s) of {total}.",
+        evidence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch tables
+# ---------------------------------------------------------------------------
+
+# Handlers that require a prior _fetch_pr_view call (takes rule, pr, data).
+_PR_VIEW_HANDLERS = {
     RuleKind.GITHUB_PR_OPEN: _check_pr_open,
     RuleKind.GITHUB_NOT_DRAFT: _check_not_draft,
     RuleKind.GITHUB_LABELS_ABSENT: _check_labels_absent,
     RuleKind.GITHUB_TASKS_COMPLETE: _check_tasks_complete,
     RuleKind.GITHUB_CHECKS_SUCCESS: _check_checks_success,
+}
+
+# Handlers that make their own gh call directly (takes rule, pr only).
+_DIRECT_HANDLERS = {
+    RuleKind.GITHUB_THREADS_RESOLVED: _check_threads_resolved,
 }
 
 # ---------------------------------------------------------------------------
@@ -442,21 +690,28 @@ _HANDLED = {
 
 
 def check(rule: Rule, target: str | Path) -> Diagnostic:
-    """Resolve the target, fetch PR view data, then dispatch by rule kind.
+    """Resolve the target, then dispatch by rule kind.
 
     Resolution failures (bad target, missing gh, auth error, PR not found)
-    surface as UNAVAILABLE immediately.  A single ``gh pr view`` call is made
-    for the five implemented kinds; unimplemented kinds (#12-#13) receive an
-    UNAVAILABLE stub after resolution.
+    surface as UNAVAILABLE immediately.
+
+    - Five rule kinds share a single ``gh pr view`` call (_PR_VIEW_HANDLERS).
+    - ``github_threads_resolved`` makes its own GraphQL call (_DIRECT_HANDLERS).
+    - Unimplemented kinds (#13) receive an UNAVAILABLE stub after resolution.
     """
     target_str = str(target)
     pr, diag = resolve_target(rule, target_str)
     if diag is not None:
         return diag
 
-    handler = _HANDLED.get(rule.kind)
+    # Direct handlers: make their own gh call, don't need pr-view.
+    direct = _DIRECT_HANDLERS.get(rule.kind)
+    if direct is not None:
+        return direct(rule, pr)
+
+    handler = _PR_VIEW_HANDLERS.get(rule.kind)
     if handler is None:
-        # Rule kind not yet implemented — issues #12-#13.
+        # Rule kind not yet implemented — issue #13.
         return Diagnostic(
             rule_id=rule.id,
             source=rule.source,
@@ -465,7 +720,7 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
             severity=rule.severity,
             message=(
                 f"target resolved to {pr.owner}/{pr.repo}#{pr.number}; "
-                f"rule kind {rule.kind.value!r} not yet implemented (#12-#13)"
+                f"rule kind {rule.kind.value!r} not yet implemented (#13)"
             ),
             evidence=[
                 Evidence(
@@ -482,7 +737,7 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
             ],
         )
 
-    # Fetch the PR view data (one call for all four handlers).
+    # Fetch the PR view data (one call for all five pr-view handlers).
     data, fetch_diag = _fetch_pr_view(pr, rule)
     if fetch_diag is not None:
         return fetch_diag

--- a/src/gate_keeper/backends/github.py
+++ b/src/gate_keeper/backends/github.py
@@ -560,9 +560,12 @@ def _fetch_review_threads(
             ),
         )
 
-    # Pagination guard: hasNextPage true → UNAVAILABLE
+    # Pagination guard: hasNextPage must be an explicit ``False`` to treat the
+    # first page as complete. ``True`` *and* any missing/malformed value
+    # (``None``, a string, absent key) all fail closed as UNAVAILABLE — a
+    # truncated first page must never silently PASS.
     has_next = page_info.get("hasNextPage")
-    if has_next is True:
+    if has_next is not False:
         end_cursor = page_info.get("endCursor")
         if not isinstance(end_cursor, str):
             end_cursor = None

--- a/tests/test_github_backend_stub.py
+++ b/tests/test_github_backend_stub.py
@@ -51,7 +51,7 @@ class TestGithubBackendStub:
     def test_check_message_names_rule_kind_when_target_resolves(self, monkeypatch):
         """When the target resolves, a stub kind still names the rule kind in its message.
 
-        GITHUB_THREADS_RESOLVED is not yet implemented (#12), so it returns
+        GITHUB_NON_AUTHOR_APPROVAL is not yet implemented (#13), so it returns
         UNAVAILABLE with the rule kind in the message even after resolution.
         """
         from gate_keeper.backends import _gh, _target
@@ -66,10 +66,10 @@ class TestGithubBackendStub:
             )
 
         monkeypatch.setattr(_target, "run_gh", _fake_run_gh)
-        rule = _github_rule(RuleKind.GITHUB_THREADS_RESOLVED)
+        rule = _github_rule(RuleKind.GITHUB_NON_AUTHOR_APPROVAL)
         diag = gh_backend.check(rule, "owner/repo#42")
         assert diag.status is Status.UNAVAILABLE
-        assert "github_threads_resolved" in diag.message
+        assert "github_non_author_approval" in diag.message
 
     def test_check_invalid_target_surfaces_target_parse_error(self, tmp_path):
         """A non-PR target now surfaces a parse-error diagnostic via the resolver."""

--- a/tests/test_github_threads.py
+++ b/tests/test_github_threads.py
@@ -1,0 +1,582 @@
+"""Tests for the review-thread handler added in issue #12.
+
+Uses a ``_patch_both``-style helper that monkeypatches:
+- ``gate_keeper.backends._target.run_gh``  — for resolve_target
+- ``gate_keeper.backends.github.run_gh``   — for _fetch_review_threads
+
+For the threads handler the two gh calls happen sequentially:
+  1. resolve_target → ``gh pr view`` (returns number/url)
+  2. _fetch_review_threads → ``gh api graphql``
+
+So _make_run_gh_sequence is used with a two-element queue when both
+calls are exercised.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from gate_keeper.backends import _gh, _target
+from gate_keeper.backends import github as gh_backend
+from gate_keeper.diagnostics import EXIT_FAIL, EXIT_OK, compute_exit_code
+from gate_keeper.models import (
+    Backend,
+    Confidence,
+    Diagnostic,
+    Rule,
+    RuleKind,
+    RuleSet,
+    Severity,
+    SourceLocation,
+    Status,
+)
+from gate_keeper.validator import validate
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_RESOLVE_OK = json.dumps({"number": 42, "url": "https://github.com/owner/repo/pull/42"})
+
+_PR_COORDS = {
+    "owner": "owner",
+    "repo": "repo",
+    "number": 42,
+    "url": "https://github.com/owner/repo/pull/42",
+}
+
+
+def _ok(stdout: str, args: tuple[str, ...] = ()) -> _gh.GhResult:
+    return _gh.GhResult(ok=True, stdout=stdout, stderr="", returncode=0, cmd=("gh", *args))
+
+
+def _fail(stderr: str = "error", returncode: int = 1, binary_missing: bool = False) -> _gh.GhResult:
+    return _gh.GhResult(
+        ok=False,
+        stdout="",
+        stderr=stderr,
+        returncode=returncode,
+        cmd=("gh",),
+        binary_missing=binary_missing,
+    )
+
+
+def _make_github_rule(kind: RuleKind = RuleKind.GITHUB_THREADS_RESOLVED) -> Rule:
+    return Rule(
+        id="test-threads-rule",
+        title="All review threads must be resolved",
+        source=SourceLocation(path="rules.md", line=1),
+        text="All review threads must be resolved before merge.",
+        kind=kind,
+        severity=Severity.ERROR,
+        backend_hint=Backend.GITHUB,
+        confidence=Confidence.HIGH,
+        params={},
+    )
+
+
+def _make_run_gh_sequence(results: list[_gh.GhResult]):
+    """Return a fake run_gh that pops results from the list in order."""
+    queue = list(results)
+
+    def _fake(args, **kwargs):
+        if queue:
+            return queue.pop(0)
+        raise AssertionError(f"run_gh called more times than expected; args={args!r}")
+
+    return _fake
+
+
+def _patch_both(
+    monkeypatch,
+    resolve_result: _gh.GhResult,
+    graphql_result: _gh.GhResult,
+):
+    """Monkeypatch both target resolver and the github backend run_gh."""
+    monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([resolve_result]))
+    monkeypatch.setattr(gh_backend, "run_gh", _make_run_gh_sequence([graphql_result]))
+
+
+def _graphql_response(
+    nodes: list[dict],
+    has_next_page: bool = False,
+    end_cursor: str | None = "Y3Vy",
+) -> str:
+    """Build a well-formed GraphQL response JSON string."""
+    return json.dumps({
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": nodes,
+                        "pageInfo": {
+                            "hasNextPage": has_next_page,
+                            "endCursor": end_cursor,
+                        },
+                    }
+                }
+            }
+        }
+    })
+
+
+def _make_thread(
+    is_resolved: bool,
+    path: str = "src/foo.py",
+    line: int = 42,
+    author: str = "alice",
+    url: str = "https://github.com/owner/repo/pull/42#discussion_r1",
+) -> dict:
+    return {
+        "id": "PRRT_kwDOA1",
+        "isResolved": is_resolved,
+        "path": path,
+        "line": line,
+        "comments": {
+            "nodes": [
+                {
+                    "author": {"login": author},
+                    "body": "Please fix this.",
+                    "url": url,
+                }
+            ]
+        },
+    }
+
+
+def _check(monkeypatch, nodes: list[dict], **kwargs) -> Diagnostic:
+    """Run the threads check with a given set of nodes."""
+    _patch_both(
+        monkeypatch,
+        _ok(_RESOLVE_OK),
+        _ok(_graphql_response(nodes, **kwargs)),
+    )
+    rule = _make_github_rule()
+    return gh_backend.check(rule, "owner/repo#42")
+
+
+# ---------------------------------------------------------------------------
+# Zero nodes → PASS
+# ---------------------------------------------------------------------------
+
+class TestZeroNodes:
+    def test_empty_nodes_passes(self, monkeypatch):
+        diag = _check(monkeypatch, [])
+        assert diag.status is Status.PASS
+        ev = diag.evidence[0]
+        assert ev.kind == "review_threads"
+        assert ev.data["total"] == 0
+        assert ev.data["unresolved_count"] == 0
+        assert ev.data["unresolved"] == []
+
+    def test_empty_nodes_evidence_coords(self, monkeypatch):
+        diag = _check(monkeypatch, [])
+        ev = diag.evidence[0]
+        assert ev.data["owner"] == "owner"
+        assert ev.data["repo"] == "repo"
+        assert ev.data["number"] == 42
+        assert ev.data["url"] == "https://github.com/owner/repo/pull/42"
+
+
+# ---------------------------------------------------------------------------
+# One resolved node only → PASS
+# ---------------------------------------------------------------------------
+
+class TestAllResolved:
+    def test_single_resolved_passes(self, monkeypatch):
+        diag = _check(monkeypatch, [_make_thread(is_resolved=True)])
+        assert diag.status is Status.PASS
+        ev = diag.evidence[0]
+        assert ev.data["total"] == 1
+        assert ev.data["unresolved_count"] == 0
+        assert ev.data["unresolved"] == []
+
+    def test_multiple_resolved_passes(self, monkeypatch):
+        nodes = [_make_thread(is_resolved=True), _make_thread(is_resolved=True, path="other.py")]
+        diag = _check(monkeypatch, nodes)
+        assert diag.status is Status.PASS
+        ev = diag.evidence[0]
+        assert ev.data["total"] == 2
+        assert ev.data["unresolved_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# One unresolved node → FAIL
+# ---------------------------------------------------------------------------
+
+class TestOneUnresolved:
+    def test_single_unresolved_fails(self, monkeypatch):
+        thread = _make_thread(is_resolved=False, path="src/bar.py", line=10)
+        diag = _check(monkeypatch, [thread])
+        assert diag.status is Status.FAIL
+        ev = diag.evidence[0]
+        assert ev.data["total"] == 1
+        assert ev.data["unresolved_count"] == 1
+        assert len(ev.data["unresolved"]) == 1
+        entry = ev.data["unresolved"][0]
+        assert entry["path"] == "src/bar.py"
+        assert entry["line"] == 10
+        assert entry["first_comment_author"] == "alice"
+        assert "discussion" in entry["first_comment_url"]
+
+    def test_unresolved_message_mentions_count(self, monkeypatch):
+        diag = _check(monkeypatch, [_make_thread(is_resolved=False)])
+        assert "1 unresolved" in diag.message
+
+
+# ---------------------------------------------------------------------------
+# Mix: one resolved + one unresolved → FAIL, only unresolved in list
+# ---------------------------------------------------------------------------
+
+class TestMixedThreads:
+    def test_mix_one_resolved_one_unresolved_fails(self, monkeypatch):
+        nodes = [
+            _make_thread(is_resolved=True, path="resolved.py", line=1),
+            _make_thread(is_resolved=False, path="unresolved.py", line=99),
+        ]
+        diag = _check(monkeypatch, nodes)
+        assert diag.status is Status.FAIL
+        ev = diag.evidence[0]
+        assert ev.data["total"] == 2
+        assert ev.data["unresolved_count"] == 1
+        assert len(ev.data["unresolved"]) == 1
+        assert ev.data["unresolved"][0]["path"] == "unresolved.py"
+        assert ev.data["unresolved"][0]["line"] == 99
+
+
+# ---------------------------------------------------------------------------
+# Three unresolved → FAIL, count=3
+# ---------------------------------------------------------------------------
+
+class TestMultipleUnresolved:
+    def test_three_unresolved_fails_count_three(self, monkeypatch):
+        nodes = [
+            _make_thread(is_resolved=False, path=f"file{i}.py", line=i * 10)
+            for i in range(3)
+        ]
+        diag = _check(monkeypatch, nodes)
+        assert diag.status is Status.FAIL
+        ev = diag.evidence[0]
+        assert ev.data["total"] == 3
+        assert ev.data["unresolved_count"] == 3
+        assert len(ev.data["unresolved"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Non-bool isResolved → treated as unresolved (conservative)
+# ---------------------------------------------------------------------------
+
+class TestNonBoolIsResolved:
+    def test_string_is_resolved_treated_as_unresolved(self, monkeypatch):
+        thread = {
+            "id": "T1",
+            "isResolved": "yes",  # not a bool
+            "path": "src/x.py",
+            "line": 5,
+            "comments": {"nodes": []},
+        }
+        diag = _check(monkeypatch, [thread])
+        assert diag.status is Status.FAIL
+        ev = diag.evidence[0]
+        assert ev.data["unresolved_count"] == 1
+
+    def test_null_is_resolved_treated_as_unresolved(self, monkeypatch):
+        thread = {
+            "id": "T1",
+            "isResolved": None,
+            "path": "src/x.py",
+            "line": 5,
+            "comments": {"nodes": []},
+        }
+        diag = _check(monkeypatch, [thread])
+        assert diag.status is Status.FAIL
+
+    def test_missing_path_and_line_falls_back_to_null(self, monkeypatch):
+        thread = {
+            "id": "T1",
+            "isResolved": False,
+            "comments": {"nodes": []},
+        }
+        diag = _check(monkeypatch, [thread])
+        assert diag.status is Status.FAIL
+        entry = diag.evidence[0].data["unresolved"][0]
+        assert entry["path"] is None
+        assert entry["line"] is None
+
+
+# ---------------------------------------------------------------------------
+# Pagination: hasNextPage true → UNAVAILABLE
+# ---------------------------------------------------------------------------
+
+class TestPagination:
+    def test_has_next_page_is_unavailable(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_graphql_response([], has_next_page=True, end_cursor="abc123")),
+        )
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "gh_pagination_unavailable"
+        assert ev.data["has_next_page"] is True
+        assert ev.data["end_cursor"] == "abc123"
+
+    def test_has_next_page_does_not_pass(self, monkeypatch):
+        """Verify the pagination path never returns PASS."""
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_graphql_response([], has_next_page=True)),
+        )
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is not Status.PASS
+
+
+# ---------------------------------------------------------------------------
+# GraphQL errors in response → UNAVAILABLE / gh_graphql_error
+# ---------------------------------------------------------------------------
+
+class TestGraphqlErrors:
+    def _graphql_error_response(self, errors: list[dict]) -> str:
+        return json.dumps({"errors": errors})
+
+    def test_graphql_errors_unavailable(self, monkeypatch):
+        error_response = self._graphql_error_response([
+            {"message": "Could not resolve to a Repository"},
+        ])
+        _patch_both(monkeypatch, _ok(_RESOLVE_OK), _ok(error_response))
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "gh_graphql_error"
+        assert ev.data["op"] == "graphql"
+        assert len(ev.data["errors"]) == 1
+        assert "Repository" in ev.data["errors"][0]
+
+    def test_graphql_errors_truncated_to_200_chars(self, monkeypatch):
+        long_msg = "x" * 300
+        error_response = self._graphql_error_response([{"message": long_msg}])
+        _patch_both(monkeypatch, _ok(_RESOLVE_OK), _ok(error_response))
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        ev = diag.evidence[0]
+        # Message should be truncated (200 chars + ellipsis)
+        assert len(ev.data["errors"][0]) <= 201 + 1  # 200 chars + ellipsis char
+        assert ev.data["errors"][0].endswith("…")
+
+    def test_graphql_errors_include_coords(self, monkeypatch):
+        error_response = self._graphql_error_response([{"message": "some error"}])
+        _patch_both(monkeypatch, _ok(_RESOLVE_OK), _ok(error_response))
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        ev = diag.evidence[0]
+        assert ev.data["owner"] == "owner"
+        assert ev.data["repo"] == "repo"
+        assert ev.data["number"] == 42
+
+
+# ---------------------------------------------------------------------------
+# Missing data key → UNAVAILABLE / gh_missing_field
+# ---------------------------------------------------------------------------
+
+class TestMissingFields:
+    def test_missing_data_key_unavailable(self, monkeypatch):
+        _patch_both(monkeypatch, _ok(_RESOLVE_OK), _ok(json.dumps({"other": "stuff"})))
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "gh_missing_field"
+        assert "data" in ev.data["field"]
+
+    def test_missing_repository_key_unavailable(self, monkeypatch):
+        response = json.dumps({"data": {"other": "stuff"}})
+        _patch_both(monkeypatch, _ok(_RESOLVE_OK), _ok(response))
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "gh_missing_field"
+        assert "repository" in ev.data["field"]
+
+    def test_missing_pull_request_key_unavailable(self, monkeypatch):
+        response = json.dumps({"data": {"repository": {"other": "stuff"}}})
+        _patch_both(monkeypatch, _ok(_RESOLVE_OK), _ok(response))
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "gh_missing_field"
+        assert "pullRequest" in ev.data["field"]
+
+    def test_missing_review_threads_key_unavailable(self, monkeypatch):
+        response = json.dumps({
+            "data": {"repository": {"pullRequest": {"other": "stuff"}}}
+        })
+        _patch_both(monkeypatch, _ok(_RESOLVE_OK), _ok(response))
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "gh_missing_field"
+        assert "reviewThreads" in ev.data["field"]
+
+
+# ---------------------------------------------------------------------------
+# gh non-zero exit → UNAVAILABLE / gh_failure
+# ---------------------------------------------------------------------------
+
+class TestGhFailures:
+    def test_gh_nonzero_exit_unavailable(self, monkeypatch):
+        _patch_both(monkeypatch, _ok(_RESOLVE_OK), _fail(stderr="rate limit exceeded", returncode=1))
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "gh_failure"
+
+    def test_gh_missing_binary_unavailable(self, monkeypatch):
+        monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([
+            _fail(stderr="gh binary not found", returncode=127, binary_missing=True)
+        ]))
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        # binary missing is detected at resolve_target stage
+        ev = diag.evidence[0]
+        assert ev.kind == "gh_missing"
+
+    def test_gh_json_parse_error_unavailable(self, monkeypatch):
+        bad_json = _gh.GhResult(
+            ok=True, stdout="not valid json {{{", stderr="", returncode=0, cmd=("gh",)
+        )
+        _patch_both(monkeypatch, _ok(_RESOLVE_OK), bad_json)
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "gh_json_error"
+
+
+# ---------------------------------------------------------------------------
+# Command construction verification
+# ---------------------------------------------------------------------------
+
+class TestCommandConstruction:
+    def test_graphql_command_contains_expected_args(self, monkeypatch):
+        """Capture the argv passed to run_gh and assert the shape."""
+        captured_args: list = []
+        resolve_queue = [_ok(_RESOLVE_OK)]
+
+        def fake_target_run_gh(args, **kwargs):
+            return resolve_queue.pop(0)
+
+        def fake_graphql_run_gh(args, **kwargs):
+            captured_args.extend(args)
+            return _ok(_graphql_response([]))
+
+        monkeypatch.setattr(_target, "run_gh", fake_target_run_gh)
+        monkeypatch.setattr(gh_backend, "run_gh", fake_graphql_run_gh)
+
+        rule = _make_github_rule()
+        gh_backend.check(rule, "owner/repo#42")
+
+        argv_str = " ".join(captured_args)
+        assert "api" in captured_args
+        assert "graphql" in captured_args
+        # Verify query content mentions reviewThreads with first: 100
+        query_arg = next((a for a in captured_args if "reviewThreads" in a), None)
+        assert query_arg is not None, f"No query arg found; argv: {captured_args!r}"
+        assert "reviewThreads(first: 100)" in query_arg
+        # Verify owner/repo/number args
+        assert any("owner=owner" in a for a in captured_args)
+        assert any("repo=repo" in a for a in captured_args)
+        assert "-F" in captured_args
+        assert "number=42" in captured_args
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic round-trip: to_dict → from_dict
+# ---------------------------------------------------------------------------
+
+class TestDiagRoundTrip:
+    def _rt(self, diag: Diagnostic) -> Diagnostic:
+        return Diagnostic.from_dict(diag.to_dict())
+
+    def test_pass_round_trips(self, monkeypatch):
+        diag = _check(monkeypatch, [])
+        rt = self._rt(diag)
+        assert rt.status is Status.PASS
+        assert rt.evidence[0].kind == "review_threads"
+        assert rt.evidence[0].data["total"] == 0
+
+    def test_fail_round_trips(self, monkeypatch):
+        diag = _check(monkeypatch, [_make_thread(is_resolved=False)])
+        rt = self._rt(diag)
+        assert rt.status is Status.FAIL
+        assert rt.evidence[0].data["unresolved_count"] == 1
+
+    def test_unavailable_pagination_round_trips(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_graphql_response([], has_next_page=True, end_cursor="cur123")),
+        )
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        rt = self._rt(diag)
+        assert rt.status is Status.UNAVAILABLE
+        assert rt.evidence[0].kind == "gh_pagination_unavailable"
+        assert rt.evidence[0].data["end_cursor"] == "cur123"
+
+    def test_unavailable_graphql_error_round_trips(self, monkeypatch):
+        error_response = json.dumps({"errors": [{"message": "some graphql error"}]})
+        _patch_both(monkeypatch, _ok(_RESOLVE_OK), _ok(error_response))
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        rt = self._rt(diag)
+        assert rt.status is Status.UNAVAILABLE
+        assert rt.evidence[0].kind == "gh_graphql_error"
+
+    def test_unavailable_missing_field_round_trips(self, monkeypatch):
+        _patch_both(monkeypatch, _ok(_RESOLVE_OK), _ok(json.dumps({"no_data": True})))
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        rt = self._rt(diag)
+        assert rt.status is Status.UNAVAILABLE
+        assert rt.evidence[0].kind == "gh_missing_field"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via validate()
+# ---------------------------------------------------------------------------
+
+class TestEndToEndValidator:
+    def test_zero_unresolved_threads_exit_0(self, monkeypatch):
+        _patch_both(monkeypatch, _ok(_RESOLVE_OK), _ok(_graphql_response([])))
+        rule = _make_github_rule()
+        ruleset = RuleSet(rules=[rule])
+        report = validate(ruleset, "owner/repo#42", backend="auto")
+        assert len(report.diagnostics) == 1
+        assert report.diagnostics[0].status is Status.PASS
+        assert compute_exit_code(report.diagnostics) == EXIT_OK
+
+    def test_one_unresolved_thread_exit_1(self, monkeypatch):
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(_graphql_response([_make_thread(is_resolved=False)])),
+        )
+        rule = _make_github_rule()
+        ruleset = RuleSet(rules=[rule])
+        report = validate(ruleset, "owner/repo#42", backend="auto")
+        assert len(report.diagnostics) == 1
+        assert report.diagnostics[0].status is Status.FAIL
+        assert compute_exit_code(report.diagnostics) == EXIT_FAIL

--- a/tests/test_github_threads.py
+++ b/tests/test_github_threads.py
@@ -337,6 +337,76 @@ class TestPagination:
         diag = gh_backend.check(rule, "owner/repo#42")
         assert diag.status is not Status.PASS
 
+    def test_missing_has_next_page_fails_closed(self, monkeypatch):
+        """If pageInfo.hasNextPage is absent, treat as paginated (UNAVAILABLE)."""
+        body = json.dumps({
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [],
+                            "pageInfo": {"endCursor": None},  # hasNextPage missing
+                        }
+                    }
+                }
+            }
+        })
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(body),
+        )
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_pagination_unavailable"
+
+    def test_null_has_next_page_fails_closed(self, monkeypatch):
+        body = json.dumps({
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [],
+                            "pageInfo": {"hasNextPage": None, "endCursor": None},
+                        }
+                    }
+                }
+            }
+        })
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(body),
+        )
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_pagination_unavailable"
+
+    def test_non_bool_has_next_page_fails_closed(self, monkeypatch):
+        body = json.dumps({
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [],
+                            "pageInfo": {"hasNextPage": "false", "endCursor": None},
+                        }
+                    }
+                }
+            }
+        })
+        _patch_both(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            _ok(body),
+        )
+        rule = _make_github_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_pagination_unavailable"
+
 
 # ---------------------------------------------------------------------------
 # GraphQL errors in response → UNAVAILABLE / gh_graphql_error


### PR DESCRIPTION
Closes #12

## Summary
Implements `github_threads_resolved`: queries `gh api graphql` for the first 100 review threads on a PR and fails closed if any are unresolved or if pagination is incomplete.

- New `_fetch_review_threads(pr, rule)` runs `gh api graphql` with the `reviewThreads(first: 100)` query (id, isResolved, path, line, first comment author/body/url, pageInfo). All failure paths convert to a Diagnostic via the shared adapter builders (`failure_diag`, `gh_json_diag`, `gh_pagination_diag`, `gh_missing_field_diag`) plus a new `gh_graphql_error` evidence kind for top-level GraphQL `errors` arrays. Each error message is truncated to 200 chars and `_redact`-ed.
- `_check_threads_resolved(rule, pr)` classifies nodes by `isResolved` (non-bool treated conservatively as not-resolved) and emits evidence kind `review_threads` with `total`, `unresolved_count`, `unresolved` list (path/line/first_comment_author/first_comment_url), and PR coordinates. PASS when count is 0; FAIL otherwise.
- Pagination policy: `hasNextPage` must be the literal `False` for the first page to be considered complete. Any other value (`True`, missing key, `None`, non-bool) → UNAVAILABLE / `gh_pagination_unavailable`. This is the fix described below.
- `check()` refactored to two dispatch tables: `_PR_VIEW_HANDLERS` (the existing five kinds, share one `gh pr view`) and `_DIRECT_HANDLERS` (threads, has its own GraphQL call). The unimplemented stub now points only at #13.

## Validation
- `uv run pytest` → **504 passed** (470 → +34 new in `tests/test_github_threads.py`).
- Smoke: `gate-keeper validate docs/example-rules.md --target tests/fixtures/local/pass --backend auto` → exit 1; github rules emit `target_parse_error` against a local-path target. No crashes.
- E2E tests through `validator.validate()` cover both green (zero unresolved → exit 0) and red (one unresolved → exit 1) paths.

## Codex review
Run: `codex review --base main`. One [P2] finding posted as a PR comment. Fixed in commit `cd07150`:
- Pagination guard previously only handled `hasNextPage is True`; missing/null/non-bool values fell through and let a truncated first page silently pass. Now any non-False value fails closed. Three regression tests cover the new shapes.

## Notes
- Full pagination (>100 threads) remains post-MVP; for now the rule fails closed at the boundary, matching the issue's pagination policy.
- All GraphQL error messages and stderr that flow into evidence go through `_gh._redact` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)