### PR TITLE
feat(llm-rubric): add LLM rubric backend interface (#15)

### DIFF
--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -42,7 +42,7 @@ fail-closed behavior: an unconfigured evaluator must not silently pass rules.
 
 ## Rubric input/output shape
 
-When a provider is added, `_build_rubric_input()` in `backends/llm_rubric.py`
+When a provider is added, `_build_rubric_input()` in `src/gate_keeper/backends/llm_rubric.py`
 defines the context passed to the model:
 
 ```json
@@ -65,7 +65,7 @@ The expected provider response is a `Diagnostic` with:
 
 To add a provider:
 
-1. Implement `_is_configured() -> bool` in `backends/llm_rubric.py` to detect
+1. Implement `_is_configured() -> bool` in `src/gate_keeper/backends/llm_rubric.py` to detect
    credentials (e.g. `GATE_KEEPER_LLM_PROVIDER`, `OPENAI_API_KEY`).
 2. Add a provider client call in the `if _is_configured():` branch of `check()`.
 3. Map the model response to a `Diagnostic` following the shape above.

--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -1,0 +1,89 @@
+# LLM Rubric Backend
+
+## Purpose
+
+The `llm-rubric` backend handles rules that cannot be verified deterministically.
+When the classifier cannot match a rule to a filesystem or GitHub pattern it falls
+back to `kind=semantic_rubric` with `backend_hint=llm-rubric` and `confidence=low`.
+These are rules that require reading and reasoning about content — e.g.
+"documentation must be clear" — rather than checking a concrete predicate.
+
+## Advisory status
+
+LLM-evaluated rules are **advisory evidence, not authoritative gates**.
+
+The classifier only routes a rule here when deterministic evidence is absent.
+Even with a configured provider, the result reflects a probabilistic judgement on
+natural-language text, not a machine-verifiable fact.  Deterministic backends
+(`filesystem`, `github`) remain the authoritative control plane for merge gates.
+
+Do not promote a `semantic_rubric` rule to `severity=error` without carefully
+considering that:
+
+- the result depends on prompt quality, model version, and token context;
+- two runs of the same rule may produce different results;
+- a PASS from the LLM does not guarantee the claim is true.
+
+Use `severity=advisory` or `severity=warning` for semantic rules.
+
+## Current MVP behavior
+
+No LLM provider is configured in the MVP. Every `semantic_rubric` rule returns:
+
+```
+status:      unavailable
+backend:     llm-rubric
+evidence[0]: provider_unconfigured { rule_text, rule_kind, target }
+remediation: Configure an LLM provider to enable semantic rule evaluation.
+```
+
+`unavailable` is a non-passing status; the CLI exits `1`.  This is intentional
+fail-closed behavior: an unconfigured evaluator must not silently pass rules.
+
+## Rubric input/output shape
+
+When a provider is added, `_build_rubric_input()` in `backends/llm_rubric.py`
+defines the context passed to the model:
+
+```json
+{
+  "rule_text": "<verbatim rule text from the document>",
+  "rule_kind": "semantic_rubric",
+  "target":    "<filesystem path or PR reference>"
+}
+```
+
+The expected provider response is a `Diagnostic` with:
+
+- `status`: `pass` or `fail` (never `unavailable` when the provider responds).
+- `message`: a single-line summary of the evaluation.
+- `evidence`: at minimum one entry with `kind="llm_judgment"` and the model's
+  explanation in `data`.
+- `remediation` (optional): suggested action when `status=fail`.
+
+## Extension point
+
+To add a provider:
+
+1. Implement `_is_configured() -> bool` in `backends/llm_rubric.py` to detect
+   credentials (e.g. `GATE_KEEPER_LLM_PROVIDER`, `OPENAI_API_KEY`).
+2. Add a provider client call in the `if _is_configured():` branch of `check()`.
+3. Map the model response to a `Diagnostic` following the shape above.
+4. Keep the unconfigured fallback (`_is_configured() == False`) unchanged so the
+   fail-closed contract holds when credentials are absent.
+
+No other files need to change: the backend registry, classifier, and validator
+already treat `llm-rubric` as a first-class backend.
+
+## Why deterministic gates remain authoritative
+
+`gate-keeper` is a **compiler for merge gates**, not an AI reviewer.  Its value
+comes from reproducible, evidence-bearing results that CI pipelines can trust.
+
+LLM evaluation adds coverage for rules that humans write in natural language but
+that do not map cleanly to a file check or a GitHub API field.  It is a complement
+to deterministic checks — not a replacement.
+
+When a rule has both a deterministic and a semantic interpretation, prefer the
+deterministic route.  The classifier does this automatically: it only routes to
+`llm-rubric` after exhausting all GitHub and filesystem patterns.

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -1,8 +1,12 @@
-"""LLM-rubric backend stub for gate-keeper (MVP placeholder).
+"""LLM-rubric backend for gate-keeper (MVP stub).
 
-Provider-specific implementation is out of scope for the MVP. This stub is
-registered so that `--backend llm-rubric` is a valid choice. All rules return
-Status.UNAVAILABLE (fail-closed) until a provider is configured.
+Provider-specific implementation is out of scope for the MVP. This module is
+registered so that ``--backend llm-rubric`` is a valid choice and rules that
+fall through classifier heuristics have a defined home.
+
+Extension point: when adding a real provider, implement ``_is_configured()``
+to detect provider credentials and replace the stub body in ``check()`` with a
+call to ``_invoke_provider()``.  The ``Diagnostic`` contract is unchanged.
 """
 from __future__ import annotations
 
@@ -13,8 +17,45 @@ from gate_keeper.models import Backend, Diagnostic, Evidence, Rule, Status
 name = "llm-rubric"
 
 
+def _is_configured() -> bool:
+    """Return True when an LLM provider is configured.
+
+    Always False for the MVP.  A real implementation would inspect env vars
+    or a config file (e.g. GATE_KEEPER_LLM_PROVIDER, OPENAI_API_KEY, etc.).
+    """
+    return False
+
+
+def _build_rubric_input(rule: Rule, target: str | Path) -> dict:
+    """Build the context a future provider call would consume.
+
+    Shape:
+      rule_text  — verbatim normative text for the model to evaluate.
+      rule_kind  — classifier-assigned kind (``semantic_rubric`` in practice).
+      target     — artifact under evaluation (filesystem path or PR reference).
+
+    A provider implementation passes this to the model and parses the
+    pass/fail judgment and explanation from the response.
+    """
+    return {
+        "rule_text": rule.text,
+        "rule_kind": rule.kind.value,
+        "target": str(target),
+    }
+
+
 def check(rule: Rule, target: str | Path) -> Diagnostic:
-    """Return UNAVAILABLE; no LLM provider is configured for the MVP."""
+    """Evaluate a semantic-rubric rule against *target*.
+
+    Returns UNAVAILABLE (exits non-zero) until a provider is configured.
+    The evidence block carries the rubric input so downstream consumers can
+    see exactly what would be sent to the provider.
+    """
+    if _is_configured():
+        # Provider call would go here; out of scope for the MVP.
+        raise NotImplementedError("LLM provider integration is out of scope for the MVP")
+
+    rubric_input = _build_rubric_input(rule, target)
     return Diagnostic(
         rule_id=rule.id,
         source=rule.source,
@@ -24,8 +65,12 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
         message="LLM rubric backend is not configured; skipping rule.",
         evidence=[
             Evidence(
-                kind="backend_stub",
-                data={"backend": "llm-rubric", "rule_kind": rule.kind.value},
+                kind="provider_unconfigured",
+                data=rubric_input,
             )
         ],
+        remediation=(
+            "Configure an LLM provider to enable semantic rule evaluation. "
+            "See docs/llm-rubric.md for the extension point."
+        ),
     )

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -5,8 +5,9 @@ registered so that ``--backend llm-rubric`` is a valid choice and rules that
 fall through classifier heuristics have a defined home.
 
 Extension point: when adding a real provider, implement ``_is_configured()``
-to detect provider credentials and replace the stub body in ``check()`` with a
-call to ``_invoke_provider()``.  The ``Diagnostic`` contract is unchanged.
+to detect provider credentials and replace the stub body in ``check()`` with
+provider invocation and response-parsing logic. The ``Diagnostic`` contract is
+unchanged.
 """
 from __future__ import annotations
 

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -6,10 +6,6 @@ We verify that compute_exit_code treats these diagnostics as non-zero.
 """
 from __future__ import annotations
 
-from pathlib import Path
-
-import pytest
-
 from gate_keeper.backends import llm_rubric as llm_backend
 from gate_keeper.diagnostics import EXIT_FAIL, EXIT_OK, compute_exit_code
 from gate_keeper.models import (

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -1,0 +1,119 @@
+"""Tests for the LLM-rubric backend stub.
+
+Acceptance criterion: "Running LLM-backed validation without configuration
+returns a non-passing diagnostic."
+We verify that compute_exit_code treats these diagnostics as non-zero.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gate_keeper.backends import llm_rubric as llm_backend
+from gate_keeper.diagnostics import EXIT_FAIL, EXIT_OK, compute_exit_code
+from gate_keeper.models import (
+    Backend,
+    Confidence,
+    Rule,
+    RuleKind,
+    Severity,
+    SourceLocation,
+    Status,
+)
+from gate_keeper.validator import validate
+
+
+def _semantic_rule(kind: RuleKind = RuleKind.SEMANTIC_RUBRIC) -> Rule:
+    return Rule(
+        id="stub-llm-rule",
+        title="Stub semantic rule",
+        source=SourceLocation(path="rules.md", line=5),
+        text="The documentation should be clear and comprehensive",
+        kind=kind,
+        severity=Severity.ERROR,
+        backend_hint=Backend.LLM_RUBRIC,
+        confidence=Confidence.LOW,
+        params={},
+    )
+
+
+class TestLlmRubricBackendStub:
+    def test_check_returns_unavailable(self, tmp_path):
+        rule = _semantic_rule()
+        diag = llm_backend.check(rule, tmp_path)
+        assert diag.status is Status.UNAVAILABLE
+
+    def test_check_backend_is_llm_rubric(self, tmp_path):
+        rule = _semantic_rule()
+        diag = llm_backend.check(rule, tmp_path)
+        assert diag.backend is Backend.LLM_RUBRIC
+
+    def test_check_preserves_rule_id(self, tmp_path):
+        rule = _semantic_rule()
+        diag = llm_backend.check(rule, tmp_path)
+        assert diag.rule_id == rule.id
+
+    def test_check_preserves_severity(self, tmp_path):
+        rule = _semantic_rule()
+        diag = llm_backend.check(rule, tmp_path)
+        assert diag.severity is rule.severity
+
+    def test_check_has_evidence(self, tmp_path):
+        rule = _semantic_rule()
+        diag = llm_backend.check(rule, tmp_path)
+        assert len(diag.evidence) >= 1
+
+    def test_evidence_kind_is_provider_unconfigured(self, tmp_path):
+        rule = _semantic_rule()
+        diag = llm_backend.check(rule, tmp_path)
+        assert diag.evidence[0].kind == "provider_unconfigured"
+
+    def test_evidence_includes_rule_text(self, tmp_path):
+        rule = _semantic_rule()
+        diag = llm_backend.check(rule, tmp_path)
+        assert diag.evidence[0].data["rule_text"] == rule.text
+
+    def test_evidence_includes_rule_kind(self, tmp_path):
+        rule = _semantic_rule()
+        diag = llm_backend.check(rule, tmp_path)
+        assert diag.evidence[0].data["rule_kind"] == rule.kind.value
+
+    def test_evidence_includes_target(self, tmp_path):
+        rule = _semantic_rule()
+        diag = llm_backend.check(rule, tmp_path)
+        assert diag.evidence[0].data["target"] == str(tmp_path)
+
+    def test_check_has_remediation(self, tmp_path):
+        rule = _semantic_rule()
+        diag = llm_backend.check(rule, tmp_path)
+        assert diag.remediation is not None
+        assert len(diag.remediation) > 0
+
+    def test_unavailable_exit_code_is_nonzero(self, tmp_path):
+        """Acceptance criterion: unavailable → exit non-zero."""
+        rule = _semantic_rule()
+        diag = llm_backend.check(rule, tmp_path)
+        code = compute_exit_code([diag])
+        assert code == EXIT_FAIL
+        assert code != EXIT_OK
+
+    def test_check_with_pr_target_still_unavailable(self):
+        """Non-filesystem targets (PR references) also return UNAVAILABLE."""
+        rule = _semantic_rule()
+        diag = llm_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.backend is Backend.LLM_RUBRIC
+
+    def test_via_validator_auto_dispatch_semantic_rule_nonzero(self, tmp_path):
+        """End-to-end: validator auto-dispatches semantic_rubric rule to llm-rubric."""
+        from gate_keeper.models import RuleSet
+
+        rule = _semantic_rule()
+        ruleset = RuleSet(rules=[rule])
+        report = validate(ruleset, tmp_path, backend="auto")
+        assert len(report.diagnostics) == 1
+        diag = report.diagnostics[0]
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.backend is Backend.LLM_RUBRIC
+        assert compute_exit_code(report.diagnostics) == EXIT_FAIL


### PR DESCRIPTION
Closes #15

## Summary

- Extends `src/gate_keeper/backends/llm_rubric.py` with `_is_configured()` and `_build_rubric_input()` helpers that establish a clear extension point for future providers. Evidence kind changed from `backend_stub` → `provider_unconfigured`; `remediation` field added so downstream consumers know how to enable the backend.
- Adds `tests/test_llm_rubric_backend.py` (13 tests) covering UNAVAILABLE status, backend identity, evidence structure, exit-code, end-to-end validator dispatch, and non-filesystem targets.
- Adds `docs/llm-rubric.md` explaining routing, advisory status, why deterministic gates remain authoritative, rubric input/output shape, and the provider extension point.

## Acceptance criteria

| Criterion | Status |
|---|---|
| Rules can route to `llm-rubric` | ✅ classifier semantic fallback already routes `semantic_rubric` kind; backend registered |
| Unconfigured validation returns non-passing diagnostic | ✅ `UNAVAILABLE` + `EXIT_FAIL` verified in tests |
| Docs explain advisory status and deterministic authority | ✅ `docs/llm-rubric.md` |
| Future provider work has a clear extension point | ✅ `_is_configured()` / `_build_rubric_input()` helpers with inline guidance |

## Validation

```
$ uv run pytest tests/
============================= test session starts ==============================
collected 542 items

... 542 passed in 0.54s ==============================
```

New LLM rubric tests specifically:

```
$ uv run pytest tests/test_llm_rubric_backend.py -v
tests/test_llm_rubric_backend.py::TestLlmRubricBackendStub::test_check_returns_unavailable PASSED
tests/test_llm_rubric_backend.py::TestLlmRubricBackendStub::test_check_backend_is_llm_rubric PASSED
tests/test_llm_rubric_backend.py::TestLlmRubricBackendStub::test_check_preserves_rule_id PASSED
tests/test_llm_rubric_backend.py::TestLlmRubricBackendStub::test_check_preserves_severity PASSED
tests/test_llm_rubric_backend.py::TestLlmRubricBackendStub::test_check_has_evidence PASSED
tests/test_llm_rubric_backend.py::TestLlmRubricBackendStub::test_evidence_kind_is_provider_unconfigured PASSED
tests/test_llm_rubric_backend.py::TestLlmRubricBackendStub::test_evidence_includes_rule_text PASSED
tests/test_llm_rubric_backend.py::TestLlmRubricBackendStub::test_evidence_includes_rule_kind PASSED
tests/test_llm_rubric_backend.py::TestLlmRubricBackendStub::test_evidence_includes_target PASSED
tests/test_llm_rubric_backend.py::TestLlmRubricBackendStub::test_check_has_remediation PASSED
tests/test_llm_rubric_backend.py::TestLlmRubricBackendStub::test_unavailable_exit_code_is_nonzero PASSED
tests/test_llm_rubric_backend.py::TestLlmRubricBackendStub::test_check_with_pr_target_still_unavailable PASSED
tests/test_llm_rubric_backend.py::TestLlmRubricBackendStub::test_via_validator_auto_dispatch_semantic_rule_nonzero PASSED
13 passed in 0.03s
```