### PR TITLE
feat(ci): add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.11.x"
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run tests
+        run: uv run pytest

--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ The initial execution board is
 
 ## Development
 
+Requires Python 3.11 and [uv](https://docs.astral.sh/uv/).
+
 ```bash
 uv sync
 uv run gate-keeper --help
+uv run pytest
 ```
+
+CI runs the same `uv sync` and `uv run pytest` steps on Python 3.11.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` that runs `uv sync` and `uv run pytest` on Python 3.11 for every push and pull request.
- Uses `astral-sh/setup-uv@v5` to install uv and pin the Python version to 3.11 (avoids the readline crash seen with conda environments during bootstrap).
- Updates README to document Python 3.11 requirement and that CI mirrors local dev steps.

## Validation

```
uv run pytest
542 passed in 0.94s
```

CI workflow will run on the PR branch once pushed.

Closes #19

---
**Subagent Review** (claude-sonnet-4-6 / independent context): APPROVE — CI workflow correct, Python 3.11 pinned, pinned action versions, README matches CI, failing tests block workflow. All acceptance criteria satisfied.