### PR TITLE
feat(cli): add explain command for rule-to-backend mapping

### DIFF
--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -32,6 +32,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="output format (default: json)",
     )
 
+    explain_parser = subparsers.add_parser(
+        "explain",
+        help="show how each rule in a document maps to a backend",
+    )
+    explain_parser.add_argument("document", help="path to a rule document")
+    explain_parser.add_argument(
+        "--format",
+        choices=["text"],
+        default="text",
+        help="output format (default: text)",
+    )
+
     validate_parser = subparsers.add_parser(
         "validate",
         help="validate an artifact against a rule document",
@@ -78,6 +90,36 @@ def _cmd_compile(args: argparse.Namespace) -> int:
     ruleset = classifier.classify(ruleset)
 
     print(json.dumps(ruleset.to_dict(), indent=2))
+    return EXIT_OK
+
+
+def _cmd_explain(args: argparse.Namespace) -> int:
+    from pathlib import Path
+
+    from gate_keeper import classifier, parser
+    from gate_keeper.diagnostics import render_explain_text
+
+    path = Path(args.document)
+
+    if not path.exists():
+        print(f"error: {args.document}: No such file or directory", file=sys.stderr)
+        return EXIT_USAGE
+
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"error: {args.document}: {exc.strerror}", file=sys.stderr)
+        return EXIT_USAGE
+    except UnicodeDecodeError as exc:
+        print(f"error: {args.document}: not valid UTF-8 ({exc.reason})", file=sys.stderr)
+        return EXIT_USAGE
+
+    ruleset = parser.parse(str(path), content)
+    ruleset = classifier.classify(ruleset)
+
+    rendered = render_explain_text(ruleset.rules)
+    if rendered:
+        print(rendered)
     return EXIT_OK
 
 
@@ -136,6 +178,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "compile":
         return _cmd_compile(args)
+
+    if args.command == "explain":
+        return _cmd_explain(args)
 
     if args.command == "validate":
         return _cmd_validate(args)

--- a/src/gate_keeper/diagnostics.py
+++ b/src/gate_keeper/diagnostics.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Sequence
 
-from gate_keeper.models import Diagnostic, DiagnosticReport, Status
+from gate_keeper.models import Diagnostic, DiagnosticReport, Rule, Status
 
 EXIT_OK = 0
 EXIT_FAIL = 1
@@ -59,6 +59,27 @@ def render_text(diagnostics: Sequence[Diagnostic]) -> str:
             f"{d.message}"
             f"{evidence_part}"
         )
+    return "\n".join(lines)
+
+
+def render_explain_text(rules: Sequence[Rule]) -> str:
+    """Render rule-to-backend routing decisions as human-readable text.
+
+    Each rule block: path:line: [backend/confidence] rule_id: kind
+      <rule text>
+      reason: <classifier explanation>
+    """
+    lines = []
+    for rule in rules:
+        explanation = rule.params.get("classifier_explanation", "no explanation available")
+        heading_part = f" ({rule.source.heading})" if rule.source.heading else ""
+        lines.append(
+            f"{rule.source.path}:{rule.source.line}:{heading_part} "
+            f"[{rule.backend_hint.value}/{rule.confidence.value}] "
+            f"{rule.id}: {rule.kind.value}"
+        )
+        lines.append(f"  {rule.text}")
+        lines.append(f"  reason: {explanation}")
     return "\n".join(lines)
 
 

--- a/tests/test_cli_explain.py
+++ b/tests/test_cli_explain.py
@@ -1,0 +1,91 @@
+"""Tests for gate-keeper explain command."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gate_keeper.cli import main
+
+REPO_ROOT = Path(__file__).parent.parent
+EXAMPLE_DOC = REPO_ROOT / "docs" / "example-rules.md"
+
+
+def test_explain_smoke_exit_0(capsys):
+    """Explain the example document: exits 0 and produces non-empty output."""
+    rc = main(["explain", str(EXAMPLE_DOC), "--format", "text"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert captured.out.strip() != ""
+
+
+def test_explain_shows_source_lines(capsys):
+    """Each rule block references a source line number."""
+    rc = main(["explain", str(EXAMPLE_DOC)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    lines = captured.out.splitlines()
+    # At least one header line of the form  path:N: [backend/confidence] id: kind
+    header_lines = [l for l in lines if ".md:" in l and "[" in l and "/high" in l or "/medium" in l or "/low" in l]
+    assert len(header_lines) > 0
+
+
+def test_explain_shows_backend_and_confidence(capsys):
+    """Output contains both filesystem and github backend references."""
+    rc = main(["explain", str(EXAMPLE_DOC)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "filesystem" in captured.out
+    assert "github" in captured.out
+
+
+def test_explain_shows_confidence_levels(capsys):
+    """Output includes confidence values (high, medium, or low)."""
+    rc = main(["explain", str(EXAMPLE_DOC)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert any(level in captured.out for level in ("high", "medium", "low"))
+
+
+def test_explain_shows_reason(capsys):
+    """Each rule block contains a 'reason:' line."""
+    rc = main(["explain", str(EXAMPLE_DOC)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    reason_lines = [l for l in captured.out.splitlines() if l.strip().startswith("reason:")]
+    assert len(reason_lines) > 0
+
+
+def test_explain_low_confidence_visible(capsys, tmp_path):
+    """A document with ambiguous rules shows low-confidence routing."""
+    doc = tmp_path / "ambiguous.md"
+    doc.write_text("# Review\n\nThis change is important and must be evaluated carefully.\n")
+    rc = main(["explain", str(doc)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "low" in captured.out
+
+
+def test_explain_missing_file_exits_2(capsys):
+    """Missing document exits 2 with an error on stderr."""
+    rc = main(["explain", "/nonexistent/file.md"])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "error:" in captured.err
+
+
+def test_explain_non_utf8_exits_2(tmp_path, capsys):
+    """Non-UTF-8 document exits 2 with a UTF-8 error on stderr."""
+    bad = tmp_path / "binary.md"
+    bad.write_bytes(b"\xff\xfe not utf-8 \x80\x81")
+    rc = main(["explain", str(bad)])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "UTF-8" in captured.err
+
+
+def test_explain_help_available(capsys):
+    """explain --help exits 0 and shows the subcommand description."""
+    with pytest.raises(SystemExit) as exc_info:
+        main(["explain", "--help"])
+    assert exc_info.value.code == 0


### PR DESCRIPTION
## Summary

- Adds `gate-keeper explain DOCUMENT --format text` subcommand.
- For each extracted rule, shows: source `path:line`, `[backend/confidence]`, rule kind, rule text, and the classifier's reason phrase.
- Low-confidence (`low`) routing is visibly distinguished from `high`/`medium` in the output.
- Uses the `classifier_explanation` already stored in `rule.params` by the deterministic classifier — no new data computed at explain time.
- Adds `tests/test_cli_explain.py` with 9 tests covering smoke, source lines, backends, confidence levels, reason lines, low-confidence visibility, missing file, non-UTF-8, and help.

## Validation

```
uv run pytest
551 passed in 1.00s

uv run gate-keeper explain docs/example-rules.md --format text
docs/example-rules.md:8: (Example Gate-Keeper Rules > Filesystem Checks) [filesystem/high] rule-example-rules-L8: file_exists
  `README.md` must exist in the repository root.
  reason: explicit must-exist or must-be-present predicate
...
```

Closes #16

---
**Subagent Review** (claude-sonnet-4-6 / independent context): APPROVE — explain command correctly implemented, mirrors compile error handling, compiler-style output format, 9 tests cover all acceptance criteria including low-confidence visibility and source lines.