### PR TITLE
ci: add ruff and pyright static analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,25 @@ jobs:
 
       - name: Run tests
         run: uv run pytest
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.11.x"
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Ruff check
+        run: uv run ruff check .
+
+      - name: Ruff format
+        run: uv run ruff format --check .
+
+      - name: Pyright
+        run: uv run pyright

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,20 @@ gate-keeper = "gate_keeper.cli:main"
 [dependency-groups]
 dev = [
     "pytest>=8.0,<9",
+    "ruff>=0.9",
+    "pyright>=1.1",
 ]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 110
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+
+[tool.pyright]
+pythonVersion = "3.10"
+typeCheckingMode = "basic"
 
 [build-system]
 requires = ["uv_build>=0.11.7,<0.12.0"]

--- a/src/gate_keeper/_md.py
+++ b/src/gate_keeper/_md.py
@@ -4,6 +4,7 @@ Provides regex patterns and utilities for detecting Markdown task checkboxes
 and stripping fenced code blocks. Both the filesystem and github backends
 import from here to avoid duplication.
 """
+
 from __future__ import annotations
 
 import re
@@ -27,12 +28,12 @@ TASK_UNCHECKED_RE = re.compile(r"^[ \t]*[-*+]\s+\[ \]", re.MULTILINE)
 # be followed only by whitespace.
 
 FENCE_START_RE = re.compile(
-    r"^ {0,3}"                       # at most 3 leading spaces
-    r"(?P<marker>`{3,}|~{3,})"       # the fence run
-    r"(?P<info>[^`\n]*)?"            # info string (no backticks for backtick fences;
-                                     # tilde fences are slightly more permissive but
-                                     # this is good enough for MVP)
-    r"\s*$"                          # only whitespace allowed after info string
+    r"^ {0,3}"  # at most 3 leading spaces
+    r"(?P<marker>`{3,}|~{3,})"  # the fence run
+    r"(?P<info>[^`\n]*)?"  # info string (no backticks for backtick fences;
+    # tilde fences are slightly more permissive but
+    # this is good enough for MVP)
+    r"\s*$"  # only whitespace allowed after info string
 )
 
 

--- a/src/gate_keeper/backends/__init__.py
+++ b/src/gate_keeper/backends/__init__.py
@@ -7,17 +7,17 @@ look up backends by name without importing modules directly.
 Registered names (all three must be present for `--backend` choices):
   ``filesystem``, ``github``, ``llm-rubric``
 """
+
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Callable
 
-from gate_keeper.models import Diagnostic, Rule
-
 # Import backend modules — avoid circular deps by keeping these as plain imports.
 from gate_keeper.backends import filesystem as _fs
 from gate_keeper.backends import github as _gh
 from gate_keeper.backends import llm_rubric as _llm
+from gate_keeper.models import Diagnostic, Rule
 
 # Registry: name -> check callable
 _REGISTRY: dict[str, Callable[[Rule, str | Path], Diagnostic]] = {

--- a/src/gate_keeper/backends/_gh.py
+++ b/src/gate_keeper/backends/_gh.py
@@ -11,6 +11,7 @@ Provides:
 None of these functions perform per-rule logic; they are shared infrastructure
 consumed by per-rule checks landing in issues #9-#13.
 """
+
 from __future__ import annotations
 
 import json

--- a/src/gate_keeper/backends/_target.py
+++ b/src/gate_keeper/backends/_target.py
@@ -9,6 +9,7 @@ Provides:
 Consumers (#10-#13) should call resolve_target() at the start of each
 per-rule check and short-circuit with the returned Diagnostic on failure.
 """
+
 from __future__ import annotations
 
 import re
@@ -36,18 +37,16 @@ from gate_keeper.models import Backend, Diagnostic, Evidence, Rule, Status
 
 _URL_RE = re.compile(
     r"^https?://(?:www\.)?github\.com"
-    r"/([^/\s]+)"      # owner
-    r"/([^/\s]+)"      # repo
-    r"/pull/(\d+)"     # PR number
-    r"/?(?:[?#].*)?"   # optional trailing slash, query, fragment
+    r"/([^/\s]+)"  # owner
+    r"/([^/\s]+)"  # repo
+    r"/pull/(\d+)"  # PR number
+    r"/?(?:[?#].*)?"  # optional trailing slash, query, fragment
     r"$",
     re.IGNORECASE,
 )
 
 # 2. OWNER/REPO#NUMBER shorthand
-_SHORTHAND_RE = re.compile(
-    r"^([A-Za-z0-9._-]+)/([A-Za-z0-9._-]+)#(\d+)$"
-)
+_SHORTHAND_RE = re.compile(r"^([A-Za-z0-9._-]+)/([A-Za-z0-9._-]+)#(\d+)$")
 
 
 # ---------------------------------------------------------------------------

--- a/src/gate_keeper/backends/base.py
+++ b/src/gate_keeper/backends/base.py
@@ -3,6 +3,7 @@
 Each backend receives a Rule and a target, and returns a Diagnostic.
 Implementations must never raise — unexpected errors become ERROR diagnostics.
 """
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/gate_keeper/backends/filesystem.py
+++ b/src/gate_keeper/backends/filesystem.py
@@ -3,18 +3,20 @@
 Evaluates a single compiled Rule against a local target path.
 Never raises — all exceptions are translated into diagnostics.
 """
+
 from __future__ import annotations
 
 import fnmatch
 import re
 from pathlib import Path
 
-name = "filesystem"
-
 from gate_keeper._md import (
-    FENCE_START_RE as _FENCE_START_RE,
     TASK_CHECKED_RE as _TASK_CHECKED_RE,
+)
+from gate_keeper._md import (
     TASK_UNCHECKED_RE as _TASK_UNCHECKED_RE,
+)
+from gate_keeper._md import (
     strip_fenced_blocks as _strip_fenced_blocks_impl,
 )
 from gate_keeper.models import (
@@ -25,6 +27,8 @@ from gate_keeper.models import (
     RuleKind,
     Status,
 )
+
+name = "filesystem"
 
 _FILESYSTEM_KINDS = frozenset(
     {
@@ -163,13 +167,16 @@ def _text_required(rule: Rule, target: Path) -> Diagnostic:
     content, err = _read_file(rule, target)
     if err is not None:
         return err
+    assert content is not None
     path_str = str(target)
     use_regex = bool(rule.params.get("regex", False))
     if use_regex:
         match_count = len(re.findall(pattern, content))
     else:
         match_count = content.count(pattern)
-    evidence = [Evidence(kind="text_match", data={"path": path_str, "pattern": pattern, "match_count": match_count})]
+    evidence = [
+        Evidence(kind="text_match", data={"path": path_str, "pattern": pattern, "match_count": match_count})
+    ]
     if match_count > 0:
         return _diag(rule, Status.PASS, f"{path_str} contains {pattern!r}.", evidence)
     return _diag(rule, Status.FAIL, f"{path_str} does not contain {pattern!r}.", evidence)
@@ -187,15 +194,20 @@ def _text_forbidden(rule: Rule, target: Path) -> Diagnostic:
     content, err = _read_file(rule, target)
     if err is not None:
         return err
+    assert content is not None
     path_str = str(target)
     use_regex = bool(rule.params.get("regex", False))
     if use_regex:
         match_count = len(re.findall(pattern, content))
     else:
         match_count = content.count(pattern)
-    evidence = [Evidence(kind="text_match", data={"path": path_str, "pattern": pattern, "match_count": match_count})]
+    evidence = [
+        Evidence(kind="text_match", data={"path": path_str, "pattern": pattern, "match_count": match_count})
+    ]
     if match_count == 0:
-        return _diag(rule, Status.PASS, f"{path_str} does not contain forbidden pattern {pattern!r}.", evidence)
+        return _diag(
+            rule, Status.PASS, f"{path_str} does not contain forbidden pattern {pattern!r}.", evidence
+        )
     return _diag(rule, Status.FAIL, f"{path_str} contains forbidden pattern {pattern!r}.", evidence)
 
 
@@ -212,12 +224,18 @@ def _markdown_tasks_complete(rule: Rule, target: Path) -> Diagnostic:
     content, err = _read_file(rule, target)
     if err is not None:
         return err
+    assert content is not None
     path_str = str(target)
     scannable = _strip_fenced_blocks(content)
     checked = len(_TASK_CHECKED_RE.findall(scannable))
     unchecked = len(_TASK_UNCHECKED_RE.findall(scannable))
     total = checked + unchecked
-    evidence = [Evidence(kind="markdown_tasks", data={"path": path_str, "checked": checked, "unchecked": unchecked, "total": total})]
+    evidence = [
+        Evidence(
+            kind="markdown_tasks",
+            data={"path": path_str, "checked": checked, "unchecked": unchecked, "total": total},
+        )
+    ]
     if unchecked:
         return _diag(rule, Status.FAIL, f"{path_str} has {unchecked} unchecked task(s) of {total}.", evidence)
     return _diag(rule, Status.PASS, f"{path_str} has all {total} task(s) checked.", evidence)

--- a/src/gate_keeper/backends/github.py
+++ b/src/gate_keeper/backends/github.py
@@ -12,6 +12,7 @@ GraphQL call via ``gh api graphql`` and does NOT use ``_fetch_pr_view``.
 Any failure before dispatch (missing gh, auth, JSON, missing field)
 propagates as UNAVAILABLE — all paths fail closed.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -103,9 +104,13 @@ def _fetch_pr_view(pr: PrTarget, rule: Rule) -> tuple[dict | None, Diagnostic | 
         return None, gh_missing_field_diag(rule, "pr-view", "<unknown rule kind>")
 
     argv = [
-        "pr", "view", str(pr.number),
-        "-R", f"{pr.owner}/{pr.repo}",
-        "--json", fields,
+        "pr",
+        "view",
+        str(pr.number),
+        "-R",
+        f"{pr.owner}/{pr.repo}",
+        "--json",
+        fields,
     ]
     result = run_gh(argv)
     if not result.ok:
@@ -125,6 +130,7 @@ def _fetch_pr_view(pr: PrTarget, rule: Rule) -> tuple[dict | None, Diagnostic | 
 # Per-kind handlers
 # ---------------------------------------------------------------------------
 
+
 def _pr_coords(pr: PrTarget) -> dict:
     """Return the shared coordinate fields appended to every evidence payload."""
     return {"owner": pr.owner, "repo": pr.repo, "number": pr.number, "url": pr.url}
@@ -143,7 +149,12 @@ def _check_pr_open(rule: Rule, pr: PrTarget, data: dict) -> Diagnostic:
 
     if state == "OPEN":
         return _diag(rule, Status.PASS, f"PR {pr.owner}/{pr.repo}#{pr.number} is open.", evidence)
-    return _diag(rule, Status.FAIL, f"PR {pr.owner}/{pr.repo}#{pr.number} is not open (state: {state!r}).", evidence)
+    return _diag(
+        rule,
+        Status.FAIL,
+        f"PR {pr.owner}/{pr.repo}#{pr.number} is not open (state: {state!r}).",
+        evidence,
+    )
 
 
 def _check_not_draft(rule: Rule, pr: PrTarget, data: dict) -> Diagnostic:
@@ -202,10 +213,7 @@ def _check_labels_absent(rule: Rule, pr: PrTarget, data: dict) -> Diagnostic:
     params_labels = rule.params.get("labels")
     if params_labels is None:
         blocking: list[str] = list(_DEFAULT_BLOCKING_LABELS)
-    elif (
-        isinstance(params_labels, list)
-        and all(isinstance(item, str) for item in params_labels)
-    ):
+    elif isinstance(params_labels, list) and all(isinstance(item, str) for item in params_labels):
         blocking = list(params_labels)
     else:
         return Diagnostic(
@@ -444,10 +452,7 @@ def _check_checks_success(rule: Rule, pr: PrTarget, data: dict) -> Diagnostic:
     return _diag(
         rule,
         Status.FAIL,
-        (
-            f"PR {pr.owner}/{pr.repo}#{pr.number}: {summary}; "
-            f"non-successful checks: {non_names!r}."
-        ),
+        (f"PR {pr.owner}/{pr.repo}#{pr.number}: {summary}; non-successful checks: {non_names!r}."),
         evidence,
     )
 
@@ -486,11 +491,16 @@ def _fetch_review_threads(
     - ``(None, None, diag)`` on any failure.
     """
     argv = [
-        "api", "graphql",
-        "-f", f"query={_THREADS_QUERY}",
-        "-f", f"owner={pr.owner}",
-        "-f", f"repo={pr.repo}",
-        "-F", f"number={pr.number}",
+        "api",
+        "graphql",
+        "-f",
+        f"query={_THREADS_QUERY}",
+        "-f",
+        f"owner={pr.owner}",
+        "-f",
+        f"repo={pr.repo}",
+        "-F",
+        f"number={pr.number}",
     ]
     result = run_gh(argv)
 
@@ -570,18 +580,14 @@ def _fetch_review_threads(
         return (
             None,
             None,
-            gh_missing_field_diag(
-                rule, "graphql", "data.repository.pullRequest.reviewThreads.nodes"
-            ),
+            gh_missing_field_diag(rule, "graphql", "data.repository.pullRequest.reviewThreads.nodes"),
         )
 
     if not isinstance(page_info, dict):
         return (
             None,
             None,
-            gh_missing_field_diag(
-                rule, "graphql", "data.repository.pullRequest.reviewThreads.pageInfo"
-            ),
+            gh_missing_field_diag(rule, "graphql", "data.repository.pullRequest.reviewThreads.pageInfo"),
         )
 
     # Pagination guard: hasNextPage must be an explicit ``False`` to treat the
@@ -624,7 +630,9 @@ def _check_threads_resolved(rule: Rule, pr: PrTarget) -> Diagnostic:
     for node in nodes:  # type: ignore[union-attr]
         if not isinstance(node, dict):
             # Treat non-dict nodes conservatively as unresolved
-            unresolved.append({"path": None, "line": None, "first_comment_author": None, "first_comment_url": None})
+            unresolved.append(
+                {"path": None, "line": None, "first_comment_author": None, "first_comment_url": None}
+            )
             continue
 
         is_resolved = node.get("isResolved")
@@ -655,12 +663,14 @@ def _check_threads_resolved(rule: Rule, pr: PrTarget) -> Diagnostic:
                         if isinstance(url, str):
                             first_comment_url = url
 
-            unresolved.append({
-                "path": path,
-                "line": line,
-                "first_comment_author": first_comment_author,
-                "first_comment_url": first_comment_url,
-            })
+            unresolved.append(
+                {
+                    "path": path,
+                    "line": line,
+                    "first_comment_author": first_comment_author,
+                    "first_comment_url": first_comment_url,
+                }
+            )
 
     total = len(nodes)  # type: ignore[arg-type]
     unresolved_count = len(unresolved)
@@ -802,10 +812,7 @@ def _check_non_author_approval(rule: Rule, pr: PrTarget, data: dict) -> Diagnost
         return _diag(
             rule,
             Status.PASS,
-            (
-                f"PR {pr.owner}/{pr.repo}#{pr.number} has independent approval "
-                f"from: {approved_by!r}."
-            ),
+            (f"PR {pr.owner}/{pr.repo}#{pr.number} has independent approval from: {approved_by!r}."),
             evidence,
         )
 
@@ -858,6 +865,7 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
     pr, diag = resolve_target(rule, target_str)
     if diag is not None:
         return diag
+    assert pr is not None
 
     # Direct handlers: make their own gh call, don't need pr-view.
     direct = _DIRECT_HANDLERS.get(rule.kind)
@@ -868,9 +876,7 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
     if handler is None:
         # Defensive fall-through: no known handler for this rule kind.
         # A future malformed or unsupported RuleKind should not crash.
-        _supported = ", ".join(
-            sorted(k.value for k in list(_PR_VIEW_HANDLERS) + list(_DIRECT_HANDLERS))
-        )
+        _supported = ", ".join(sorted(k.value for k in list(_PR_VIEW_HANDLERS) + list(_DIRECT_HANDLERS)))
         return Diagnostic(
             rule_id=rule.id,
             source=rule.source,
@@ -878,8 +884,7 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
             status=Status.UNAVAILABLE,
             severity=rule.severity,
             message=(
-                f"GitHub backend does not implement rule kind {rule.kind.value!r}; "
-                f"supported: {_supported}"
+                f"GitHub backend does not implement rule kind {rule.kind.value!r}; supported: {_supported}"
             ),
             evidence=[
                 Evidence(
@@ -900,5 +905,6 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
     data, fetch_diag = _fetch_pr_view(pr, rule)
     if fetch_diag is not None:
         return fetch_diag
+    assert data is not None
 
     return handler(rule, pr, data)

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -9,6 +9,7 @@ to detect provider credentials and replace the stub body in ``check()`` with
 provider invocation and response-parsing logic. The ``Diagnostic`` contract is
 unchanged.
 """
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/gate_keeper/classifier.py
+++ b/src/gate_keeper/classifier.py
@@ -6,6 +6,7 @@ high-confidence filesystem (explicit predicates), then weaker heuristics, and
 finally semantic fallback. Filesystem checks run before the PR-heading catch-all
 so that file/text rules embedded in PR documents still route to the right backend.
 """
+
 from __future__ import annotations
 
 import re
@@ -133,80 +134,161 @@ def _classify_rule(rule: Rule) -> Rule:
 
     # --- High-confidence GitHub ---
     if _DRAFT_RE.search(text):
-        return _make(rule, RuleKind.GITHUB_NOT_DRAFT, Backend.GITHUB, Confidence.HIGH,
-                     "explicit PR draft-state keyword")
+        return _make(
+            rule,
+            RuleKind.GITHUB_NOT_DRAFT,
+            Backend.GITHUB,
+            Confidence.HIGH,
+            "explicit PR draft-state keyword",
+        )
 
     if _PR_OPEN_RE.search(text):
-        return _make(rule, RuleKind.GITHUB_PR_OPEN, Backend.GITHUB, Confidence.HIGH,
-                     "explicit PR open-state reference")
+        return _make(
+            rule, RuleKind.GITHUB_PR_OPEN, Backend.GITHUB, Confidence.HIGH, "explicit PR open-state reference"
+        )
 
     if _CHECKS_HIGH_RE.search(text):
-        return _make(rule, RuleKind.GITHUB_CHECKS_SUCCESS, Backend.GITHUB, Confidence.HIGH,
-                     "explicit CI/status-check keyword")
+        return _make(
+            rule,
+            RuleKind.GITHUB_CHECKS_SUCCESS,
+            Backend.GITHUB,
+            Confidence.HIGH,
+            "explicit CI/status-check keyword",
+        )
 
     if _THREADS_HIGH_RE.search(text):
-        return _make(rule, RuleKind.GITHUB_THREADS_RESOLVED, Backend.GITHUB, Confidence.HIGH,
-                     "explicit review-thread or resolved-thread keyword")
+        return _make(
+            rule,
+            RuleKind.GITHUB_THREADS_RESOLVED,
+            Backend.GITHUB,
+            Confidence.HIGH,
+            "explicit review-thread or resolved-thread keyword",
+        )
 
     if _APPROVAL_HIGH_RE.search(text):
-        return _make(rule, RuleKind.GITHUB_NON_AUTHOR_APPROVAL, Backend.GITHUB, Confidence.HIGH,
-                     "explicit non-author-approval or independent-review keyword")
+        return _make(
+            rule,
+            RuleKind.GITHUB_NON_AUTHOR_APPROVAL,
+            Backend.GITHUB,
+            Confidence.HIGH,
+            "explicit non-author-approval or independent-review keyword",
+        )
 
     if _LABELS_HIGH_RE.search(text):
-        return _make(rule, RuleKind.GITHUB_LABELS_ABSENT, Backend.GITHUB, Confidence.HIGH,
-                     "explicit blocking-label or do-not-merge keyword")
+        return _make(
+            rule,
+            RuleKind.GITHUB_LABELS_ABSENT,
+            Backend.GITHUB,
+            Confidence.HIGH,
+            "explicit blocking-label or do-not-merge keyword",
+        )
 
     if _PR_TASK_HIGH_RE.search(text):
-        return _make(rule, RuleKind.GITHUB_TASKS_COMPLETE, Backend.GITHUB, Confidence.HIGH,
-                     "explicit PR task/checklist reference")
+        return _make(
+            rule,
+            RuleKind.GITHUB_TASKS_COMPLETE,
+            Backend.GITHUB,
+            Confidence.HIGH,
+            "explicit PR task/checklist reference",
+        )
 
     # --- Medium-confidence GitHub (keyword signals without full explicit phrasing) ---
     if _APPROVAL_MEDIUM_RE.search(text):
-        return _make(rule, RuleKind.GITHUB_NON_AUTHOR_APPROVAL, Backend.GITHUB, Confidence.MEDIUM,
-                     "approval/reviewer keyword without explicit non-author phrasing")
+        return _make(
+            rule,
+            RuleKind.GITHUB_NON_AUTHOR_APPROVAL,
+            Backend.GITHUB,
+            Confidence.MEDIUM,
+            "approval/reviewer keyword without explicit non-author phrasing",
+        )
 
     if _LABELS_MEDIUM_RE.search(text):
-        return _make(rule, RuleKind.GITHUB_LABELS_ABSENT, Backend.GITHUB, Confidence.MEDIUM,
-                     "label keyword without explicit blocking context")
+        return _make(
+            rule,
+            RuleKind.GITHUB_LABELS_ABSENT,
+            Backend.GITHUB,
+            Confidence.MEDIUM,
+            "label keyword without explicit blocking context",
+        )
 
     if _CHECKS_MEDIUM_RE.search(text) and _PR_HEADING_RE.search(heading):
-        return _make(rule, RuleKind.GITHUB_CHECKS_SUCCESS, Backend.GITHUB, Confidence.MEDIUM,
-                     "check keyword under a PR/merge-gate heading")
+        return _make(
+            rule,
+            RuleKind.GITHUB_CHECKS_SUCCESS,
+            Backend.GITHUB,
+            Confidence.MEDIUM,
+            "check keyword under a PR/merge-gate heading",
+        )
 
     # --- High-confidence filesystem (checked before the PR-heading heuristic so
     #     that explicit file/text rules under a PR section route to filesystem) ---
     if _FILE_ABSENT_HIGH_RE.search(text):
-        return _make(rule, RuleKind.FILE_ABSENT, Backend.FILESYSTEM, Confidence.HIGH,
-                     "explicit must-not-exist or is-absent predicate")
+        return _make(
+            rule,
+            RuleKind.FILE_ABSENT,
+            Backend.FILESYSTEM,
+            Confidence.HIGH,
+            "explicit must-not-exist or is-absent predicate",
+        )
 
     if _FILE_EXISTS_HIGH_RE.search(text):
-        return _make(rule, RuleKind.FILE_EXISTS, Backend.FILESYSTEM, Confidence.HIGH,
-                     "explicit must-exist or must-be-present predicate")
+        return _make(
+            rule,
+            RuleKind.FILE_EXISTS,
+            Backend.FILESYSTEM,
+            Confidence.HIGH,
+            "explicit must-exist or must-be-present predicate",
+        )
 
     if _TEXT_FORBIDDEN_HIGH_RE.search(text):
-        return _make(rule, RuleKind.TEXT_FORBIDDEN, Backend.FILESYSTEM, Confidence.HIGH,
-                     "explicit must-not-contain or forbidden-text wording")
+        return _make(
+            rule,
+            RuleKind.TEXT_FORBIDDEN,
+            Backend.FILESYSTEM,
+            Confidence.HIGH,
+            "explicit must-not-contain or forbidden-text wording",
+        )
 
     if _TEXT_REQUIRED_HIGH_RE.search(text):
-        return _make(rule, RuleKind.TEXT_REQUIRED, Backend.FILESYSTEM, Confidence.HIGH,
-                     "explicit must-contain or text-required wording")
+        return _make(
+            rule,
+            RuleKind.TEXT_REQUIRED,
+            Backend.FILESYSTEM,
+            Confidence.HIGH,
+            "explicit must-contain or text-required wording",
+        )
 
     # --- Medium-confidence filesystem ---
     if _PATH_MEDIUM_RE.search(text):
-        return _make(rule, RuleKind.PATH_MATCHES, Backend.FILESYSTEM, Confidence.MEDIUM,
-                     "path/directory keyword without explicit existence predicate")
+        return _make(
+            rule,
+            RuleKind.PATH_MATCHES,
+            Backend.FILESYSTEM,
+            Confidence.MEDIUM,
+            "path/directory keyword without explicit existence predicate",
+        )
 
     # --- PR/GitHub heading heuristic (no stronger signal matched above) ---
     if _PR_HEADING_RE.search(heading):
-        return _make(rule, RuleKind.GITHUB_TASKS_COMPLETE, Backend.GITHUB, Confidence.MEDIUM,
-                     "item under a PR/merge-gate heading with no stronger signal")
+        return _make(
+            rule,
+            RuleKind.GITHUB_TASKS_COMPLETE,
+            Backend.GITHUB,
+            Confidence.MEDIUM,
+            "item under a PR/merge-gate heading with no stronger signal",
+        )
 
     # --- Bare task-checkbox heuristic ---
     # Rules without a normative keyword can only have been emitted by the parser
     # from a task-checkbox line (bullets and paragraphs require normative keywords).
     if not _NORMATIVE_RE.search(text):
-        return _make(rule, RuleKind.MARKDOWN_TASKS_COMPLETE, Backend.FILESYSTEM, Confidence.MEDIUM,
-                     "no normative keyword — likely a bare task-checkbox item")
+        return _make(
+            rule,
+            RuleKind.MARKDOWN_TASKS_COMPLETE,
+            Backend.FILESYSTEM,
+            Confidence.MEDIUM,
+            "no normative keyword — likely a bare task-checkbox item",
+        )
 
     # --- Fallback: ambiguous semantic judgement ---
     return rule  # retains semantic_rubric / llm-rubric / low confidence from parser

--- a/src/gate_keeper/models.py
+++ b/src/gate_keeper/models.py
@@ -123,9 +123,7 @@ class SourceLocation:
         _require_keys(data, {"path", "line"}, {"heading"}, "SourceLocation")
         line = _expect_int(data["line"], "SourceLocation.line")
         if line < 1:
-            raise ValueError(
-                f"SourceLocation.line: expected 1-based line number, got {line}"
-            )
+            raise ValueError(f"SourceLocation.line: expected 1-based line number, got {line}")
         return cls(
             path=_expect_str(data["path"], "SourceLocation.path"),
             line=line,
@@ -274,9 +272,7 @@ class RuleSet:
                 duplicates.add(rule.id)
             seen.add(rule.id)
         if duplicates:
-            raise ValueError(
-                f"RuleSet.rules: duplicate rule ids: {sorted(duplicates)}"
-            )
+            raise ValueError(f"RuleSet.rules: duplicate rule ids: {sorted(duplicates)}")
         return cls(rules=rules)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/gate_keeper/parser.py
+++ b/src/gate_keeper/parser.py
@@ -5,6 +5,7 @@ paragraphs into candidate Rule IR entries.  Classification (kind /
 backend_hint) is deferred to issue #3; all extracted rules carry the neutral
 defaults (semantic_rubric / llm-rubric / low confidence).
 """
+
 from __future__ import annotations
 
 import re
@@ -133,9 +134,7 @@ def parse(path: str, content: str) -> RuleSet:
         if bullet_m:
             text = bullet_m.group(1).strip()
             if _has_normative(text):
-                candidates.append(
-                    _Candidate(text=text, line_start=line_no, heading=heading)
-                )
+                candidates.append(_Candidate(text=text, line_start=line_no, heading=heading))
             i += 1
             continue
 
@@ -144,9 +143,7 @@ def parse(path: str, content: str) -> RuleSet:
         if ordered_m:
             text = ordered_m.group(1).strip()
             if _has_normative(text):
-                candidates.append(
-                    _Candidate(text=text, line_start=line_no, heading=heading)
-                )
+                candidates.append(_Candidate(text=text, line_start=line_no, heading=heading))
             i += 1
             continue
 

--- a/src/gate_keeper/validator.py
+++ b/src/gate_keeper/validator.py
@@ -21,6 +21,7 @@ Rule ordering
 -------------
 Diagnostics are emitted in the same order as ``ruleset.rules``.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -102,9 +103,7 @@ def validate(
         One ``Diagnostic`` per rule, in source order.  Never raises.
     """
     if backend != "auto" and not _registry.is_registered(backend):
-        raise ValueError(
-            f"unknown backend {backend!r}; registered names: {_registry.BACKEND_NAMES}"
-        )
+        raise ValueError(f"unknown backend {backend!r}; registered names: {_registry.BACKEND_NAMES}")
 
     diagnostics: list[Diagnostic] = []
     for rule in ruleset.rules:
@@ -125,10 +124,7 @@ def validate(
                 backend=attributed,
                 status=Status.UNAVAILABLE,
                 severity=rule.severity,
-                message=(
-                    f"no backend registered for {resolved_name!r}; "
-                    "cannot validate rule"
-                ),
+                message=(f"no backend registered for {resolved_name!r}; cannot validate rule"),
                 evidence=[
                     Evidence(
                         kind="registry_miss",

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,10 +1,10 @@
 """Tests for the rule classifier."""
+
 from __future__ import annotations
 
 from gate_keeper.classifier import classify, classify_rule
-from gate_keeper.models import Backend, Confidence, RuleKind, Severity, SourceLocation, Rule
+from gate_keeper.models import Backend, Confidence, Rule, RuleKind, Severity, SourceLocation
 from gate_keeper.parser import parse
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -315,11 +315,7 @@ class TestParserIntegration:
         assert rules[0].confidence is Confidence.LOW
 
     def test_mixed_ruleset_preserves_all_rules(self):
-        md = (
-            "- The CHANGELOG file must exist.\n"
-            "- CI checks must pass.\n"
-            "- Code quality must meet standards.\n"
-        )
+        md = "- The CHANGELOG file must exist.\n- CI checks must pass.\n- Code quality must meet standards.\n"
         rules = _parse_and_classify(md)
         assert len(rules) == 3
         backends = {r.backend_hint for r in rules}
@@ -353,10 +349,7 @@ class TestExplanationInParams:
 
 class TestLowConfidenceVisible:
     def test_low_confidence_rules_present_in_mixed_ruleset(self):
-        md = (
-            "- CI checks must pass.\n"
-            "- Code quality must meet team standards.\n"
-        )
+        md = "- CI checks must pass.\n- Code quality must meet team standards.\n"
         rules = _parse_and_classify(md)
         confidences = {r.confidence for r in rules}
         assert Confidence.HIGH in confidences
@@ -367,9 +360,9 @@ class TestLowConfidenceVisible:
 
     def test_high_medium_low_all_represented(self):
         md = (
-            "- CI checks must pass.\n"                          # HIGH github
-            "- An approval is required before merge.\n"         # MEDIUM github
-            "- Code quality must be adequate.\n"                # LOW llm-rubric
+            "- CI checks must pass.\n"  # HIGH github
+            "- An approval is required before merge.\n"  # MEDIUM github
+            "- Code quality must be adequate.\n"  # LOW llm-rubric
         )
         rules = _parse_and_classify(md)
         conf_map = {r.confidence for r in rules}
@@ -378,12 +371,7 @@ class TestLowConfidenceVisible:
         assert Confidence.LOW in conf_map
 
     def test_classify_preserves_rule_count(self):
-        md = (
-            "- Must review.\n"
-            "- Should test.\n"
-            "- Never skip CI.\n"
-            "- The README file must exist.\n"
-        )
+        md = "- Must review.\n- Should test.\n- Never skip CI.\n- The README file must exist.\n"
         original = parse("test.md", md)
         classified = classify(original)
         assert len(classified.rules) == len(original.rules)

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -1,4 +1,5 @@
 """Tests for gate-keeper compile command."""
+
 from __future__ import annotations
 
 import json

--- a/tests/test_cli_explain.py
+++ b/tests/test_cli_explain.py
@@ -1,4 +1,5 @@
 """Tests for gate-keeper explain command."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -26,7 +27,10 @@ def test_explain_shows_source_lines(capsys):
     captured = capsys.readouterr()
     lines = captured.out.splitlines()
     # At least one header line of the form  path:N: [backend/confidence] id: kind
-    header_lines = [l for l in lines if ".md:" in l and "[" in l and "/high" in l or "/medium" in l or "/low" in l]
+    level_suffixes = ("/high", "/medium", "/low")
+    header_lines = [
+        line for line in lines if ".md:" in line and "[" in line and any(s in line for s in level_suffixes)
+    ]
     assert len(header_lines) > 0
 
 
@@ -52,7 +56,7 @@ def test_explain_shows_reason(capsys):
     rc = main(["explain", str(EXAMPLE_DOC)])
     assert rc == 0
     captured = capsys.readouterr()
-    reason_lines = [l for l in captured.out.splitlines() if l.strip().startswith("reason:")]
+    reason_lines = [line for line in captured.out.splitlines() if line.strip().startswith("reason:")]
     assert len(reason_lines) > 0
 
 

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -1,4 +1,5 @@
 """Tests for gate-keeper validate command."""
+
 from __future__ import annotations
 
 import json
@@ -27,20 +28,31 @@ SIMPLE_RULES = Path(__file__).parent / "fixtures" / "validate" / "rules-file-exi
 class TestBasicInvocation:
     def test_validate_existing_file_exits_zero(self, capsys):
         """Simple file-exists rule against an existing file exits 0."""
-        rc = main([
-            "validate", str(SIMPLE_RULES),
-            "--target", str(PASS_README),
-            "--backend", "filesystem",
-            "--format", "text",
-        ])
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+                "--format",
+                "text",
+            ]
+        )
         assert rc == EXIT_OK
 
     def test_validate_missing_document_exits_2(self, capsys):
-        rc = main([
-            "validate", "/nonexistent/rules.md",
-            "--target", str(PASS_DIR),
-            "--backend", "auto",
-        ])
+        rc = main(
+            [
+                "validate",
+                "/nonexistent/rules.md",
+                "--target",
+                str(PASS_DIR),
+                "--backend",
+                "auto",
+            ]
+        )
         assert rc == EXIT_USAGE
         captured = capsys.readouterr()
         assert "error:" in captured.err
@@ -48,35 +60,52 @@ class TestBasicInvocation:
     def test_validate_non_utf8_document_exits_2(self, tmp_path, capsys):
         bad = tmp_path / "binary.md"
         bad.write_bytes(b"\xff\xfe not utf-8 \x80\x81")
-        rc = main([
-            "validate", str(bad),
-            "--target", str(PASS_DIR),
-            "--backend", "auto",
-        ])
+        rc = main(
+            [
+                "validate",
+                str(bad),
+                "--target",
+                str(PASS_DIR),
+                "--backend",
+                "auto",
+            ]
+        )
         assert rc == EXIT_USAGE
         captured = capsys.readouterr()
         assert "error:" in captured.err
         assert "UTF-8" in captured.err
 
     def test_validate_text_format_produces_output(self, capsys):
-        rc = main([
-            "validate", str(SIMPLE_RULES),
-            "--target", str(PASS_README),
-            "--backend", "filesystem",
-            "--format", "text",
-        ])
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+                "--format",
+                "text",
+            ]
+        )
         captured = capsys.readouterr()
         assert rc == EXIT_OK
         # text format includes backend/status in square brackets
         assert "[filesystem/" in captured.out
 
     def test_validate_json_format_produces_valid_json(self, capsys):
-        rc = main([
-            "validate", str(SIMPLE_RULES),
-            "--target", str(PASS_README),
-            "--backend", "filesystem",
-            "--format", "json",
-        ])
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+                "--format",
+                "json",
+            ]
+        )
         assert rc == EXIT_OK
         captured = capsys.readouterr()
         data = json.loads(captured.out)
@@ -93,48 +122,73 @@ class TestBasicInvocation:
 class TestBackendChoices:
     def test_auto_backend_accepted(self, capsys):
         """auto backend routes the file_exists rule to filesystem → PASS."""
-        rc = main([
-            "validate", str(SIMPLE_RULES),
-            "--target", str(PASS_README),
-            "--backend", "auto",
-        ])
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "auto",
+            ]
+        )
         assert rc == EXIT_OK
 
     def test_filesystem_backend_accepted(self, capsys):
-        rc = main([
-            "validate", str(SIMPLE_RULES),
-            "--target", str(PASS_README),
-            "--backend", "filesystem",
-        ])
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+            ]
+        )
         assert rc == EXIT_OK
 
     def test_github_backend_accepted_but_unavailable(self, capsys):
         """github backend is registered; file_exists → UNSUPPORTED → exit 1."""
-        rc = main([
-            "validate", str(SIMPLE_RULES),
-            "--target", str(PASS_README),
-            "--backend", "github",
-        ])
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "github",
+            ]
+        )
         # github stub returns UNAVAILABLE for all rules → exit 1
         assert rc == EXIT_FAIL
 
     def test_llm_rubric_backend_accepted_but_unavailable(self, capsys):
         """llm-rubric backend is registered; all rules → UNAVAILABLE → exit 1."""
-        rc = main([
-            "validate", str(SIMPLE_RULES),
-            "--target", str(PASS_README),
-            "--backend", "llm-rubric",
-        ])
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "llm-rubric",
+            ]
+        )
         assert rc == EXIT_FAIL
 
     def test_unknown_backend_rejected_by_argparse(self, capsys):
         """argparse rejects unknown backend names before main() runs."""
         with pytest.raises(SystemExit) as exc_info:
-            main([
-                "validate", str(SIMPLE_RULES),
-                "--target", str(PASS_README),
-                "--backend", "totally-fake",
-            ])
+            main(
+                [
+                    "validate",
+                    str(SIMPLE_RULES),
+                    "--target",
+                    str(PASS_README),
+                    "--backend",
+                    "totally-fake",
+                ]
+            )
         assert exc_info.value.code == 2
 
 
@@ -146,21 +200,31 @@ class TestBackendChoices:
 class TestExitCodes:
     def test_file_exists_pass_exits_0(self, capsys):
         """File exists → PASS → exit 0."""
-        rc = main([
-            "validate", str(SIMPLE_RULES),
-            "--target", str(PASS_README),
-            "--backend", "filesystem",
-        ])
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+            ]
+        )
         assert rc == EXIT_OK
 
     def test_file_exists_missing_exits_1(self, capsys):
         """File missing → FAIL → exit 1."""
         missing = FAIL_DIR / "README.md"
-        rc = main([
-            "validate", str(SIMPLE_RULES),
-            "--target", str(missing),
-            "--backend", "filesystem",
-        ])
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(missing),
+                "--backend",
+                "filesystem",
+            ]
+        )
         assert rc == EXIT_FAIL
 
 
@@ -172,11 +236,16 @@ class TestExitCodes:
 class TestExampleRulesSmoke:
     def test_example_rules_auto_pass_fixture_does_not_raise(self, capsys):
         """AC-6: runs without exception; emits diagnostics; returns a numeric exit code."""
-        rc = main([
-            "validate", str(EXAMPLE_DOC),
-            "--target", str(PASS_DIR),
-            "--backend", "auto",
-        ])
+        rc = main(
+            [
+                "validate",
+                str(EXAMPLE_DOC),
+                "--target",
+                str(PASS_DIR),
+                "--backend",
+                "auto",
+            ]
+        )
         # filesystem rules pass; github/llm-rubric stubs are UNAVAILABLE → exit 1
         assert rc in (EXIT_OK, EXIT_FAIL)
         captured = capsys.readouterr()
@@ -184,12 +253,18 @@ class TestExampleRulesSmoke:
         assert captured.out.strip()
 
     def test_example_rules_json_format_valid_report(self, capsys):
-        rc = main([
-            "validate", str(EXAMPLE_DOC),
-            "--target", str(PASS_DIR),
-            "--backend", "auto",
-            "--format", "json",
-        ])
+        rc = main(
+            [
+                "validate",
+                str(EXAMPLE_DOC),
+                "--target",
+                str(PASS_DIR),
+                "--backend",
+                "auto",
+                "--format",
+                "json",
+            ]
+        )
         assert rc in (EXIT_OK, EXIT_FAIL)
         captured = capsys.readouterr()
         data = json.loads(captured.out)
@@ -205,12 +280,18 @@ class TestExampleRulesSmoke:
 
     def test_example_rules_has_github_unavailable_diagnostics(self, capsys):
         """GitHub rules in example-rules.md produce UNAVAILABLE (fail-closed)."""
-        main([
-            "validate", str(EXAMPLE_DOC),
-            "--target", str(PASS_DIR),
-            "--backend", "auto",
-            "--format", "json",
-        ])
+        main(
+            [
+                "validate",
+                str(EXAMPLE_DOC),
+                "--target",
+                str(PASS_DIR),
+                "--backend",
+                "auto",
+                "--format",
+                "json",
+            ]
+        )
         captured = capsys.readouterr()
         data = json.loads(captured.out)
         statuses = {d["status"] for d in data["diagnostics"]}
@@ -225,12 +306,18 @@ class TestExampleRulesSmoke:
 
 class TestDiagnosticFields:
     def test_all_diagnostics_have_required_fields_in_json(self, capsys):
-        main([
-            "validate", str(SIMPLE_RULES),
-            "--target", str(PASS_README),
-            "--backend", "filesystem",
-            "--format", "json",
-        ])
+        main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+                "--format",
+                "json",
+            ]
+        )
         captured = capsys.readouterr()
         data = json.loads(captured.out)
         for diag in data["diagnostics"]:
@@ -243,12 +330,18 @@ class TestDiagnosticFields:
             assert "evidence" in diag
 
     def test_text_format_includes_backend_and_status(self, capsys):
-        main([
-            "validate", str(SIMPLE_RULES),
-            "--target", str(PASS_README),
-            "--backend", "filesystem",
-            "--format", "text",
-        ])
+        main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+                "--format",
+                "text",
+            ]
+        )
         captured = capsys.readouterr()
         # text format: [backend/status] in every line
         assert "[filesystem/" in captured.out

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import json
 
-import pytest
-
 from gate_keeper.diagnostics import (
     EXIT_FAIL,
     EXIT_OK,
@@ -24,10 +22,10 @@ from gate_keeper.models import (
     Status,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _loc(path: str = "rules.md", line: int = 5, heading: str | None = None) -> SourceLocation:
     return SourceLocation(path=path, line=line, heading=heading)
@@ -61,6 +59,7 @@ def _ev(kind: str = "test_evidence", **data) -> Evidence:
 # ---------------------------------------------------------------------------
 # Exit-code policy
 # ---------------------------------------------------------------------------
+
 
 def test_all_pass_exits_0():
     diags = [_diag(status=Status.PASS), _diag(rule_id="r2", status=Status.PASS)]
@@ -96,6 +95,7 @@ def test_exit_usage_constant_is_2():
 # Exit-2 helper
 # ---------------------------------------------------------------------------
 
+
 def test_usage_error_returns_exit_2():
     msg, code = usage_error("cannot read input.md")
     assert code == EXIT_USAGE
@@ -110,6 +110,7 @@ def test_usage_error_prefixes_error():
 # ---------------------------------------------------------------------------
 # Text renderer — all-pass
 # ---------------------------------------------------------------------------
+
 
 def test_text_all_pass_contains_required_fields():
     diags = [_diag(status=Status.PASS, message="all good", path="doc.md", line=12)]
@@ -137,6 +138,7 @@ def test_text_one_diagnostic_per_line():
 # Text renderer — fail
 # ---------------------------------------------------------------------------
 
+
 def test_text_one_fail_surfaced():
     diags = [
         _diag(rule_id="r1", status=Status.PASS, message="fine"),
@@ -151,6 +153,7 @@ def test_text_one_fail_surfaced():
 # ---------------------------------------------------------------------------
 # Text renderer — evidence
 # ---------------------------------------------------------------------------
+
 
 def test_text_evidence_included():
     ev = _ev("text_match", path="AGENTS.md", match_count=3)
@@ -185,6 +188,7 @@ def test_text_evidence_newlines_escaped():
 # ---------------------------------------------------------------------------
 # JSON renderer — all-pass
 # ---------------------------------------------------------------------------
+
 
 def test_json_all_pass_status_preserved():
     diags = [_diag(status=Status.PASS)]
@@ -223,6 +227,7 @@ def test_json_snapshot_stable():
 # JSON renderer — fail
 # ---------------------------------------------------------------------------
 
+
 def test_json_one_fail_surfaced():
     diags = [_diag(rule_id="r1", status=Status.FAIL, message="broke")]
     output = json.loads(render_json(diags))
@@ -233,6 +238,7 @@ def test_json_one_fail_surfaced():
 # ---------------------------------------------------------------------------
 # JSON renderer — unavailable distinguishable from fail
 # ---------------------------------------------------------------------------
+
 
 def test_json_unavailable_distinguishable_from_fail():
     diags = [
@@ -254,6 +260,7 @@ def test_json_unavailable_exits_1():
 # ---------------------------------------------------------------------------
 # JSON renderer — determinism
 # ---------------------------------------------------------------------------
+
 
 def test_json_deterministic_ordering():
     diags = [_diag(rule_id="r1", status=Status.PASS), _diag(rule_id="r2", status=Status.FAIL)]

--- a/tests/test_e2e_local.py
+++ b/tests/test_e2e_local.py
@@ -4,6 +4,7 @@ Drives the full local pipeline without GitHub auth or network access.
 Each test covers a specific filesystem rule kind against purpose-built fixtures
 under tests/fixtures/local/{pass,fail}/.
 """
+
 from __future__ import annotations
 
 from dataclasses import replace
@@ -26,11 +27,7 @@ def _ruleset():
 
 
 def _rules(kind: RuleKind) -> list:
-    return [
-        r
-        for r in _ruleset().rules
-        if r.kind is kind and r.backend_hint is Backend.FILESYSTEM
-    ]
+    return [r for r in _ruleset().rules if r.kind is kind and r.backend_hint is Backend.FILESYSTEM]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_e2e_smoke.py
+++ b/tests/test_e2e_smoke.py
@@ -4,6 +4,7 @@ Verifies the full compile → classify → validate → exit-code pipeline throu
 the CLI entry point without any network access. GitHub backend tests in this
 file monkeypatch run_gh to avoid live calls.
 """
+
 from __future__ import annotations
 
 import json
@@ -36,30 +37,47 @@ class TestLocalPassFixture:
 
     def test_file_exists_pass_exits_zero(self, capsys):
         """README.md must exist — pass/README.md exists → exit 0."""
-        rc = main([
-            "validate", str(SMOKE_RULES),
-            "--target", str(PASS_README),
-            "--backend", "filesystem",
-            "--format", "text",
-        ])
+        rc = main(
+            [
+                "validate",
+                str(SMOKE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+                "--format",
+                "text",
+            ]
+        )
         assert rc == EXIT_OK
 
     def test_file_exists_pass_emits_pass_diagnostic(self, capsys):
-        main([
-            "validate", str(SMOKE_RULES),
-            "--target", str(PASS_README),
-            "--backend", "filesystem",
-        ])
+        main(
+            [
+                "validate",
+                str(SMOKE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+            ]
+        )
         captured = capsys.readouterr()
         assert "[filesystem/pass]" in captured.out
 
     def test_validate_pass_json_format_exit_zero(self, capsys):
-        rc = main([
-            "validate", str(SMOKE_RULES),
-            "--target", str(PASS_README),
-            "--backend", "filesystem",
-            "--format", "json",
-        ])
+        rc = main(
+            [
+                "validate",
+                str(SMOKE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+                "--format",
+                "json",
+            ]
+        )
         assert rc == EXIT_OK
         captured = capsys.readouterr()
         data = json.loads(captured.out)
@@ -77,41 +95,63 @@ class TestLocalFailFixture:
 
     def test_file_exists_missing_exits_one(self, capsys):
         """README.md must exist — fail/README.md is absent → exit 1."""
-        rc = main([
-            "validate", str(SMOKE_RULES),
-            "--target", str(FAIL_README),
-            "--backend", "filesystem",
-            "--format", "text",
-        ])
+        rc = main(
+            [
+                "validate",
+                str(SMOKE_RULES),
+                "--target",
+                str(FAIL_README),
+                "--backend",
+                "filesystem",
+                "--format",
+                "text",
+            ]
+        )
         assert rc == EXIT_FAIL
 
     def test_file_exists_missing_emits_fail_diagnostic(self, capsys):
-        main([
-            "validate", str(SMOKE_RULES),
-            "--target", str(FAIL_README),
-            "--backend", "filesystem",
-        ])
+        main(
+            [
+                "validate",
+                str(SMOKE_RULES),
+                "--target",
+                str(FAIL_README),
+                "--backend",
+                "filesystem",
+            ]
+        )
         captured = capsys.readouterr()
         assert "[filesystem/fail]" in captured.out
 
     def test_file_exists_missing_emits_useful_message(self, capsys):
         """Failing diagnostic includes the path and a useful description."""
-        main([
-            "validate", str(SMOKE_RULES),
-            "--target", str(FAIL_README),
-            "--backend", "filesystem",
-        ])
+        main(
+            [
+                "validate",
+                str(SMOKE_RULES),
+                "--target",
+                str(FAIL_README),
+                "--backend",
+                "filesystem",
+            ]
+        )
         captured = capsys.readouterr()
         assert str(FAIL_README) in captured.out
         assert "not exist" in captured.out or "absent" in captured.out or "fail" in captured.out
 
     def test_json_format_fail_has_evidence(self, capsys):
-        main([
-            "validate", str(SMOKE_RULES),
-            "--target", str(FAIL_README),
-            "--backend", "filesystem",
-            "--format", "json",
-        ])
+        main(
+            [
+                "validate",
+                str(SMOKE_RULES),
+                "--target",
+                str(FAIL_README),
+                "--backend",
+                "filesystem",
+                "--format",
+                "json",
+            ]
+        )
         captured = capsys.readouterr()
         data = json.loads(captured.out)
         assert data["diagnostics"]
@@ -164,20 +204,31 @@ class TestExampleRulesLocalTarget:
 
     def test_example_rules_local_target_auto_returns_exit_code(self, capsys):
         """Runs without exception; filesystem rules may pass, github rules unavailable."""
-        rc = main([
-            "validate", str(EXAMPLE_RULES),
-            "--target", str(PASS_DIR),
-            "--backend", "auto",
-        ])
+        rc = main(
+            [
+                "validate",
+                str(EXAMPLE_RULES),
+                "--target",
+                str(PASS_DIR),
+                "--backend",
+                "auto",
+            ]
+        )
         assert rc in (EXIT_OK, EXIT_FAIL)
 
     def test_example_rules_local_target_produces_diagnostics(self, capsys):
-        main([
-            "validate", str(EXAMPLE_RULES),
-            "--target", str(PASS_DIR),
-            "--backend", "auto",
-            "--format", "json",
-        ])
+        main(
+            [
+                "validate",
+                str(EXAMPLE_RULES),
+                "--target",
+                str(PASS_DIR),
+                "--backend",
+                "auto",
+                "--format",
+                "json",
+            ]
+        )
         captured = capsys.readouterr()
         data = json.loads(captured.out)
         assert "diagnostics" in data
@@ -203,22 +254,26 @@ def _unavailable_result() -> _gh.GhResult:
     )
 
 
-_RESOLVE_PAYLOAD = json.dumps({
-    "number": 99,
-    "url": "https://github.com/owner/repo/pull/99",
-})
+_RESOLVE_PAYLOAD = json.dumps(
+    {
+        "number": 99,
+        "url": "https://github.com/owner/repo/pull/99",
+    }
+)
 
-_PR_VIEW_PAYLOAD = json.dumps({
-    "state": "OPEN",
-    "isDraft": False,
-    "labels": [],
-    "body": "no tasks here",
-    "statusCheckRollup": [],
-    "reviews": [],
-    "headRefName": "feat/branch",
-    "baseRefName": "main",
-    "author": {"login": "alice"},
-})
+_PR_VIEW_PAYLOAD = json.dumps(
+    {
+        "state": "OPEN",
+        "isDraft": False,
+        "labels": [],
+        "body": "no tasks here",
+        "statusCheckRollup": [],
+        "reviews": [],
+        "headRefName": "feat/branch",
+        "baseRefName": "main",
+        "author": {"login": "alice"},
+    }
+)
 
 
 class TestGithubCommandConstruction:
@@ -244,22 +299,32 @@ class TestGithubCommandConstruction:
     def test_pr_view_called_for_github_rule(self, monkeypatch, capsys):
         """GitHub backend issues a gh pr view command for GitHub rule kinds."""
         calls = self._capture_gh_calls(monkeypatch)
-        main([
-            "validate", str(EXAMPLE_RULES),
-            "--target", "https://github.com/owner/repo/pull/99",
-            "--backend", "github",
-        ])
+        main(
+            [
+                "validate",
+                str(EXAMPLE_RULES),
+                "--target",
+                "https://github.com/owner/repo/pull/99",
+                "--backend",
+                "github",
+            ]
+        )
         gh_commands = [c for c in calls if "pr" in c and "view" in c]
         assert gh_commands, "expected at least one 'gh pr view' call"
 
     def test_pr_view_includes_json_flag(self, monkeypatch, capsys):
         """gh pr view commands use --json for structured output."""
         calls = self._capture_gh_calls(monkeypatch)
-        main([
-            "validate", str(EXAMPLE_RULES),
-            "--target", "https://github.com/owner/repo/pull/99",
-            "--backend", "github",
-        ])
+        main(
+            [
+                "validate",
+                str(EXAMPLE_RULES),
+                "--target",
+                "https://github.com/owner/repo/pull/99",
+                "--backend",
+                "github",
+            ]
+        )
         pr_view_calls = [c for c in calls if "pr" in c and "view" in c]
         for call in pr_view_calls:
             assert "--json" in call, f"gh pr view call missing --json: {call}"
@@ -275,15 +340,21 @@ class TestGithubCommandConstruction:
         monkeypatch.setattr("gate_keeper.backends._target.run_gh", spy_run_gh)
         monkeypatch.setattr("gate_keeper.backends.github.run_gh", spy_run_gh)
 
-        main([
-            "validate", str(SMOKE_RULES),
-            "--target", str(PASS_README),
-            "--backend", "filesystem",
-        ])
+        main(
+            [
+                "validate",
+                str(SMOKE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+            ]
+        )
         assert gh_calls == [], "filesystem backend must not call gh"
 
     def test_missing_gh_binary_produces_unavailable_not_crash(self, monkeypatch, capsys):
         """When gh binary is missing, GitHub rules emit UNAVAILABLE (fail-closed)."""
+
         def fake_missing(args: tuple[str, ...]) -> _gh.GhResult:
             return _gh.GhResult(
                 ok=False,
@@ -297,12 +368,18 @@ class TestGithubCommandConstruction:
         monkeypatch.setattr("gate_keeper.backends._target.run_gh", fake_missing)
         monkeypatch.setattr("gate_keeper.backends.github.run_gh", fake_missing)
 
-        rc = main([
-            "validate", str(EXAMPLE_RULES),
-            "--target", "https://github.com/owner/repo/pull/1",
-            "--backend", "github",
-            "--format", "json",
-        ])
+        rc = main(
+            [
+                "validate",
+                str(EXAMPLE_RULES),
+                "--target",
+                "https://github.com/owner/repo/pull/1",
+                "--backend",
+                "github",
+                "--format",
+                "json",
+            ]
+        )
         assert rc == EXIT_FAIL
         captured = capsys.readouterr()
         data = json.loads(captured.out)

--- a/tests/test_filesystem_backend.py
+++ b/tests/test_filesystem_backend.py
@@ -1,9 +1,8 @@
 """Tests for gate_keeper.backends.filesystem."""
+
 from __future__ import annotations
 
 from pathlib import Path
-
-import pytest
 
 from gate_keeper.backends.filesystem import check
 from gate_keeper.models import (
@@ -156,7 +155,9 @@ class TestTextRequired:
 
     def test_regex_mode_fail(self):
         target = _FIXTURES / "content.txt"
-        diag = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": r"NEVER_MATCHES_\d{99}", "regex": True}), target)
+        diag = check(
+            _rule(RuleKind.TEXT_REQUIRED, {"pattern": r"NEVER_MATCHES_\d{99}", "regex": True}), target
+        )
         assert diag.status is Status.FAIL
 
     def test_evidence_match_count(self):
@@ -263,9 +264,7 @@ class TestMarkdownTasksComplete:
 
     def test_checkboxes_inside_code_block_ignored(self, tmp_path):
         f = tmp_path / "doc.md"
-        f.write_text(
-            "Real tasks:\n- [x] done\n\n```\n- [ ] inside code block\n```\n"
-        )
+        f.write_text("Real tasks:\n- [x] done\n\n```\n- [ ] inside code block\n```\n")
         diag = check(_rule(RuleKind.MARKDOWN_TASKS_COMPLETE), f)
         assert diag.status is Status.PASS
         ev = next(e for e in diag.evidence if e.kind == "markdown_tasks")
@@ -328,6 +327,7 @@ class TestDiagnosticContract:
 
     def _assert_valid(self, diag):
         from gate_keeper.models import Diagnostic
+
         d = Diagnostic.from_dict(diag.to_dict())
         assert d.rule_id == diag.rule_id
         assert d.status == diag.status

--- a/tests/test_gh_adapter.py
+++ b/tests/test_gh_adapter.py
@@ -9,12 +9,10 @@ Covers:
 - Pagination and missing-field evidence
 - Token redaction in stderr_excerpt inside evidence
 """
+
 from __future__ import annotations
 
 import subprocess
-from unittest.mock import MagicMock
-
-import pytest
 
 from gate_keeper.backends._gh import (
     GhResult,
@@ -75,7 +73,9 @@ def _make_completed(stdout: str = "", stderr: str = "", returncode: int = 0):
 
 class TestRunGhMissing:
     def test_file_not_found_returns_failed_result(self, monkeypatch):
-        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: (_ for _ in ()).throw(FileNotFoundError("not found")))
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **kw: (_ for _ in ()).throw(FileNotFoundError("not found"))
+        )
         result = run_gh(["pr", "view"])
         assert result.ok is False
         assert result.binary_missing is True
@@ -91,9 +91,7 @@ class TestRunGhMissing:
     def test_negative_returncode_is_not_missing(self):
         # SIGHUP terminates with returncode -1; this must NOT be misclassified
         # as "binary missing" — only the binary_missing flag carries that meaning.
-        result = GhResult(
-            ok=False, stdout="", stderr="", returncode=-1, cmd=("gh", "pr", "view")
-        )
+        result = GhResult(ok=False, stdout="", stderr="", returncode=-1, cmd=("gh", "pr", "view"))
         assert classify_gh_failure(result) == "failure"
 
 
@@ -104,14 +102,18 @@ class TestRunGhMissing:
 
 class TestRunGhNonZeroExit:
     def test_nonzero_exit_ok_false(self, monkeypatch):
-        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_completed(stderr="something went wrong", returncode=1))
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **kw: _make_completed(stderr="something went wrong", returncode=1)
+        )
         result = run_gh(["pr", "view", "42"])
         assert result.ok is False
         assert result.returncode == 1
         assert result.stderr == "something went wrong"
 
     def test_zero_exit_ok_true(self, monkeypatch):
-        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_completed(stdout='{"number":1}', returncode=0))
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **kw: _make_completed(stdout='{"number":1}', returncode=0)
+        )
         result = run_gh(["pr", "view"])
         assert result.ok is True
         assert result.returncode == 0
@@ -507,6 +509,7 @@ class TestTokenRedactionInEvidence:
         )
         # Manually redact as run_gh would have done
         from gate_keeper.backends._gh import _redact
+
         redacted_stderr = _redact(result.stderr)
         result_redacted = GhResult(
             ok=False,
@@ -555,10 +558,7 @@ class TestTokenRedactionInEvidence:
             # Per-arg redaction may produce either the token sentinel or the
             # auth-header sentinel; both are acceptable as long as the secret
             # is gone.
-            assert (
-                "[redacted-token]" in cmd_value
-                or "[redacted-auth-header]" in cmd_value
-            )
+            assert "[redacted-token]" in cmd_value or "[redacted-auth-header]" in cmd_value
 
     def test_github_pat_in_argv_redacted_from_evidence_cmd(self):
         fake_token = "github_pat_" + "K" * 60

--- a/tests/test_github_backend_stub.py
+++ b/tests/test_github_backend_stub.py
@@ -3,9 +3,8 @@
 Acceptance criterion 2: "No unavailable evidence path exits 0."
 We verify that compute_exit_code treats these diagnostics as non-zero.
 """
-from __future__ import annotations
 
-from pathlib import Path
+from __future__ import annotations
 
 import pytest
 
@@ -60,12 +59,17 @@ class TestGithubBackendStub:
 
         from gate_keeper.backends import _gh, _target
 
-        resolve_payload = json.dumps(
-            {"number": 42, "url": "https://github.com/owner/repo/pull/42"}
-        )
+        resolve_payload = json.dumps({"number": 42, "url": "https://github.com/owner/repo/pull/42"})
         pr_view_payload = json.dumps(
-            {"state": "OPEN", "isDraft": False, "labels": [], "body": "",
-             "statusCheckRollup": [], "reviews": [], "author": {"login": "octocat"}}
+            {
+                "state": "OPEN",
+                "isDraft": False,
+                "labels": [],
+                "body": "",
+                "statusCheckRollup": [],
+                "reviews": [],
+                "author": {"login": "octocat"},
+            }
         )
 
         call_count = [0]
@@ -74,11 +78,17 @@ class TestGithubBackendStub:
             call_count[0] += 1
             if call_count[0] == 1:
                 return _gh.GhResult(
-                    ok=True, stdout=resolve_payload, stderr="", returncode=0,
+                    ok=True,
+                    stdout=resolve_payload,
+                    stderr="",
+                    returncode=0,
                     cmd=("gh", *args),
                 )
             return _gh.GhResult(
-                ok=True, stdout=pr_view_payload, stderr="", returncode=0,
+                ok=True,
+                stdout=pr_view_payload,
+                stderr="",
+                returncode=0,
                 cmd=("gh", *args),
             )
 

--- a/tests/test_github_checks_success.py
+++ b/tests/test_github_checks_success.py
@@ -4,12 +4,11 @@ Uses the same _patch_both / _ok / _RESOLVE_OK helpers as
 tests/test_github_pr_state.py.  A local _pr_view_checks_json helper
 builds a gh pr view payload that includes statusCheckRollup.
 """
+
 from __future__ import annotations
 
 import json
 from typing import Any
-
-import pytest
 
 from gate_keeper.backends import _gh, _target
 from gate_keeper.backends import github as gh_backend
@@ -27,7 +26,6 @@ from gate_keeper.models import (
     Status,
 )
 from gate_keeper.validator import validate
-
 
 # ---------------------------------------------------------------------------
 # Shared helpers (mirrors test_github_pr_state.py)
@@ -100,6 +98,7 @@ def _check_rule(monkeypatch, rollup: Any = None, *, include_rollup: bool = True)
 # ---------------------------------------------------------------------------
 # Unit: _classify_check_entry
 # ---------------------------------------------------------------------------
+
 
 class TestClassifyCheckEntry:
     def test_status_context_success(self):
@@ -230,6 +229,7 @@ class TestClassifyCheckEntry:
 # Handler: missing / malformed rollup field
 # ---------------------------------------------------------------------------
 
+
 class TestMissingRollup:
     def test_missing_statuscheckrollup_field_unavailable(self, monkeypatch):
         diag = _check_rule(monkeypatch, include_rollup=False)
@@ -287,6 +287,7 @@ class TestRollupShapeFlexibility:
 # Handler: empty rollup → vacuous PASS
 # ---------------------------------------------------------------------------
 
+
 class TestEmptyRollup:
     def test_empty_rollup_passes(self, monkeypatch):
         diag = _check_rule(monkeypatch, rollup=[])
@@ -310,6 +311,7 @@ class TestEmptyRollup:
 # ---------------------------------------------------------------------------
 # Handler: single SUCCESS entries
 # ---------------------------------------------------------------------------
+
 
 class TestSingleSuccessEntries:
     def test_single_checkrun_success_passes(self, monkeypatch):
@@ -369,6 +371,7 @@ class TestSingleSuccessEntries:
 # Handler: failures / non-successful checks
 # ---------------------------------------------------------------------------
 
+
 class TestNonSuccessfulChecks:
     def test_one_failure_fails(self, monkeypatch):
         rollup = [
@@ -387,9 +390,7 @@ class TestNonSuccessfulChecks:
 
     def test_pending_fails(self, monkeypatch):
         """StatusContext with state PENDING fails."""
-        rollup = [
-            {"__typename": "StatusContext", "context": "ci/test", "state": "PENDING"}
-        ]
+        rollup = [{"__typename": "StatusContext", "context": "ci/test", "state": "PENDING"}]
         diag = _check_rule(monkeypatch, rollup=rollup)
         assert diag.status is Status.FAIL
         ev = diag.evidence[0]
@@ -441,9 +442,7 @@ class TestNonSuccessfulChecks:
         assert ev.data["non_successful"][0]["state"] == "QUEUED"
 
     def test_statuscontext_error_fails(self, monkeypatch):
-        rollup = [
-            {"__typename": "StatusContext", "context": "ci/deploy", "state": "ERROR"}
-        ]
+        rollup = [{"__typename": "StatusContext", "context": "ci/deploy", "state": "ERROR"}]
         diag = _check_rule(monkeypatch, rollup=rollup)
         assert diag.status is Status.FAIL
 
@@ -481,9 +480,7 @@ class TestNonSuccessfulChecks:
         assert diag.status is Status.FAIL
         ev = diag.evidence[0]
         assert ev.data["successful"] == ["lint"]
-        assert ev.data["non_successful"] == [
-            {"name": "ci/integration", "state": "FAILURE"}
-        ]
+        assert ev.data["non_successful"] == [{"name": "ci/integration", "state": "FAILURE"}]
         assert ev.data["total"] == 2
         assert ev.data["summary"] == "1/2 checks passed"
 
@@ -491,6 +488,7 @@ class TestNonSuccessfulChecks:
 # ---------------------------------------------------------------------------
 # Evidence: round-trip through to_dict / from_dict
 # ---------------------------------------------------------------------------
+
 
 class TestDiagRoundTrip:
     def _round_trip(self, diag: Diagnostic) -> Diagnostic:
@@ -538,6 +536,7 @@ class TestDiagRoundTrip:
 # ---------------------------------------------------------------------------
 # End-to-end via validate()
 # ---------------------------------------------------------------------------
+
 
 class TestEndToEndValidator:
     def test_all_success_passes_exit_0(self, monkeypatch):

--- a/tests/test_github_independent_review.py
+++ b/tests/test_github_independent_review.py
@@ -7,12 +7,11 @@ Each test monkeypatches:
 Helper ``_pr_view_json`` accepts keyword fields including ``reviews`` and ``author``
 so callers can construct arbitrary payloads without raw JSON strings.
 """
+
 from __future__ import annotations
 
 import json
 from typing import Any
-
-import pytest
 
 from gate_keeper.backends import _gh, _target
 from gate_keeper.backends import github as gh_backend
@@ -393,6 +392,7 @@ class TestDiagnosticRoundTrip:
 
     def _make_diag(self, status: Status, approved_by: list[str], non_approved: list[dict]) -> Diagnostic:
         from gate_keeper.models import Evidence, SourceLocation
+
         return Diagnostic(
             rule_id="test-approval",
             source=SourceLocation(path="rules.md", line=1),
@@ -432,6 +432,7 @@ class TestDiagnosticRoundTrip:
 
     def test_unavailable_diag_round_trips(self):
         from gate_keeper.models import Evidence, SourceLocation
+
         d = Diagnostic(
             rule_id="test-approval",
             source=SourceLocation(path="rules.md", line=1),
@@ -463,12 +464,8 @@ class TestEndToEnd:
             author=_author("octocat"),
             reviews=[_review("alice", "APPROVED", submitted_at="2026-04-29T10:00:00Z")],
         )
-        monkeypatch.setattr(
-            _target, "run_gh", _make_run_gh_sequence([_ok(_RESOLVE_OK)])
-        )
-        monkeypatch.setattr(
-            gh_backend, "run_gh", _make_run_gh_sequence([_ok(json.dumps(payload))])
-        )
+        monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([_ok(_RESOLVE_OK)]))
+        monkeypatch.setattr(gh_backend, "run_gh", _make_run_gh_sequence([_ok(json.dumps(payload))]))
 
         rule = _make_non_author_approval_rule()
         ruleset = RuleSet(rules=[rule])
@@ -484,12 +481,8 @@ class TestEndToEnd:
             author=_author("octocat"),
             reviews=[],
         )
-        monkeypatch.setattr(
-            _target, "run_gh", _make_run_gh_sequence([_ok(_RESOLVE_OK)])
-        )
-        monkeypatch.setattr(
-            gh_backend, "run_gh", _make_run_gh_sequence([_ok(json.dumps(payload))])
-        )
+        monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([_ok(_RESOLVE_OK)]))
+        monkeypatch.setattr(gh_backend, "run_gh", _make_run_gh_sequence([_ok(json.dumps(payload))]))
 
         rule = _make_non_author_approval_rule()
         ruleset = RuleSet(rules=[rule])

--- a/tests/test_github_pr_state.py
+++ b/tests/test_github_pr_state.py
@@ -8,12 +8,10 @@ A helper ``_make_run_gh`` produces a fake ``run_gh`` that cycles through a list
 of pre-configured ``GhResult`` objects in order, so the two calls (resolve +
 fetch) can return different payloads.
 """
+
 from __future__ import annotations
 
 import json
-from typing import Any
-
-import pytest
 
 from gate_keeper.backends import _gh, _target
 from gate_keeper.backends import github as gh_backend
@@ -29,7 +27,6 @@ from gate_keeper.models import (
     Status,
 )
 from gate_keeper.validator import validate
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -94,6 +91,7 @@ def _pr_view_json(**fields) -> str:
 # PR Open
 # ---------------------------------------------------------------------------
 
+
 class TestCheckPrOpen:
     def test_open_state_passes(self, monkeypatch):
         _patch_both(
@@ -145,6 +143,7 @@ class TestCheckPrOpen:
 # ---------------------------------------------------------------------------
 # Not Draft
 # ---------------------------------------------------------------------------
+
 
 class TestCheckNotDraft:
     def test_not_draft_passes(self, monkeypatch):
@@ -199,6 +198,7 @@ class TestCheckNotDraft:
 # Labels Absent
 # ---------------------------------------------------------------------------
 
+
 class TestCheckLabelsAbsent:
     def test_missing_labels_field_unavailable(self, monkeypatch):
         _patch_both(
@@ -228,11 +228,14 @@ class TestCheckLabelsAbsent:
         _patch_both(
             monkeypatch,
             _ok(_RESOLVE_OK),
-            _ok(_pr_view_json(
-                state="OPEN", isDraft=False,
-                labels=[{"name": "do-not-merge"}],
-                body="",
-            )),
+            _ok(
+                _pr_view_json(
+                    state="OPEN",
+                    isDraft=False,
+                    labels=[{"name": "do-not-merge"}],
+                    body="",
+                )
+            ),
         )
         rule = _make_github_rule(RuleKind.GITHUB_LABELS_ABSENT)
         diag = gh_backend.check(rule, "owner/repo#42")
@@ -244,11 +247,14 @@ class TestCheckLabelsAbsent:
         _patch_both(
             monkeypatch,
             _ok(_RESOLVE_OK),
-            _ok(_pr_view_json(
-                state="OPEN", isDraft=False,
-                labels=[{"name": "DO-NOT-MERGE"}],
-                body="",
-            )),
+            _ok(
+                _pr_view_json(
+                    state="OPEN",
+                    isDraft=False,
+                    labels=[{"name": "DO-NOT-MERGE"}],
+                    body="",
+                )
+            ),
         )
         rule = _make_github_rule(RuleKind.GITHUB_LABELS_ABSENT)
         diag = gh_backend.check(rule, "owner/repo#42")
@@ -260,11 +266,14 @@ class TestCheckLabelsAbsent:
         _patch_both(
             monkeypatch,
             _ok(_RESOLVE_OK),
-            _ok(_pr_view_json(
-                state="OPEN", isDraft=False,
-                labels=[{"name": "blocked"}, {"name": "feature"}],
-                body="",
-            )),
+            _ok(
+                _pr_view_json(
+                    state="OPEN",
+                    isDraft=False,
+                    labels=[{"name": "blocked"}, {"name": "feature"}],
+                    body="",
+                )
+            ),
         )
         rule = _make_github_rule(RuleKind.GITHUB_LABELS_ABSENT)
         diag = gh_backend.check(rule, "owner/repo#42")
@@ -275,11 +284,14 @@ class TestCheckLabelsAbsent:
         _patch_both(
             monkeypatch,
             _ok(_RESOLVE_OK),
-            _ok(_pr_view_json(
-                state="OPEN", isDraft=False,
-                labels=[{"name": "custom-block"}],
-                body="",
-            )),
+            _ok(
+                _pr_view_json(
+                    state="OPEN",
+                    isDraft=False,
+                    labels=[{"name": "custom-block"}],
+                    body="",
+                )
+            ),
         )
         rule = _make_github_rule(
             RuleKind.GITHUB_LABELS_ABSENT,
@@ -294,11 +306,14 @@ class TestCheckLabelsAbsent:
         _patch_both(
             monkeypatch,
             _ok(_RESOLVE_OK),
-            _ok(_pr_view_json(
-                state="OPEN", isDraft=False,
-                labels=[{"name": "do-not-merge"}],
-                body="",
-            )),
+            _ok(
+                _pr_view_json(
+                    state="OPEN",
+                    isDraft=False,
+                    labels=[{"name": "do-not-merge"}],
+                    body="",
+                )
+            ),
         )
         rule = _make_github_rule(
             RuleKind.GITHUB_LABELS_ABSENT,
@@ -344,11 +359,14 @@ class TestCheckLabelsAbsent:
         _patch_both(
             monkeypatch,
             _ok(_RESOLVE_OK),
-            _ok(_pr_view_json(
-                state="OPEN", isDraft=False,
-                labels=[{"name": "needs-decision"}],
-                body="",
-            )),
+            _ok(
+                _pr_view_json(
+                    state="OPEN",
+                    isDraft=False,
+                    labels=[{"name": "needs-decision"}],
+                    body="",
+                )
+            ),
         )
         rule = _make_github_rule(RuleKind.GITHUB_LABELS_ABSENT)  # no params
         diag = gh_backend.check(rule, "owner/repo#42")
@@ -360,6 +378,7 @@ class TestCheckLabelsAbsent:
 # ---------------------------------------------------------------------------
 # Tasks Complete
 # ---------------------------------------------------------------------------
+
 
 class TestCheckTasksComplete:
     def test_null_body_unavailable(self, monkeypatch):
@@ -390,12 +409,14 @@ class TestCheckTasksComplete:
         # Build the JSON payload by hand because _pr_view_json filters None.
         import json
 
-        bad_payload = json.dumps({
-            "state": "OPEN",
-            "isDraft": False,
-            "labels": [],
-            "body": 42,  # numeric, not a string
-        })
+        bad_payload = json.dumps(
+            {
+                "state": "OPEN",
+                "isDraft": False,
+                "labels": [],
+                "body": 42,  # numeric, not a string
+            }
+        )
         _patch_both(
             monkeypatch,
             _ok(_RESOLVE_OK),
@@ -481,6 +502,7 @@ class TestCheckTasksComplete:
 # Evidence structure
 # ---------------------------------------------------------------------------
 
+
 class TestEvidenceStructure:
     """Verify that evidence payloads contain the expected coordinate fields."""
 
@@ -522,6 +544,7 @@ class TestEvidenceStructure:
 # Fetch failures (gh error, auth, JSON) propagate before dispatch
 # ---------------------------------------------------------------------------
 
+
 class TestFetchFailures:
     def test_gh_missing_binary_returns_unavailable(self, monkeypatch):
         """If gh is missing at resolve time, we get UNAVAILABLE immediately."""
@@ -547,9 +570,7 @@ class TestFetchFailures:
 
     def test_fetch_json_error_returns_unavailable(self, monkeypatch):
         monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([_ok(_RESOLVE_OK)]))
-        bad_json = _gh.GhResult(
-            ok=True, stdout="not-json", stderr="", returncode=0, cmd=("gh",)
-        )
+        bad_json = _gh.GhResult(ok=True, stdout="not-json", stderr="", returncode=0, cmd=("gh",))
         monkeypatch.setattr(gh_backend, "run_gh", _make_run_gh_sequence([bad_json]))
         rule = _make_github_rule(RuleKind.GITHUB_PR_OPEN)
         diag = gh_backend.check(rule, "owner/repo#42")
@@ -560,6 +581,7 @@ class TestFetchFailures:
 # ---------------------------------------------------------------------------
 # End-to-end via validator
 # ---------------------------------------------------------------------------
+
 
 class TestEndToEndValidator:
     def test_pr_open_rule_passes_via_validator(self, monkeypatch):

--- a/tests/test_github_threads.py
+++ b/tests/test_github_threads.py
@@ -11,12 +11,10 @@ For the threads handler the two gh calls happen sequentially:
 So _make_run_gh_sequence is used with a two-element queue when both
 calls are exercised.
 """
+
 from __future__ import annotations
 
 import json
-from typing import Any
-
-import pytest
 
 from gate_keeper.backends import _gh, _target
 from gate_keeper.backends import github as gh_backend
@@ -33,7 +31,6 @@ from gate_keeper.models import (
     Status,
 )
 from gate_keeper.validator import validate
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -106,21 +103,23 @@ def _graphql_response(
     end_cursor: str | None = "Y3Vy",
 ) -> str:
     """Build a well-formed GraphQL response JSON string."""
-    return json.dumps({
-        "data": {
-            "repository": {
-                "pullRequest": {
-                    "reviewThreads": {
-                        "nodes": nodes,
-                        "pageInfo": {
-                            "hasNextPage": has_next_page,
-                            "endCursor": end_cursor,
-                        },
+    return json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": nodes,
+                            "pageInfo": {
+                                "hasNextPage": has_next_page,
+                                "endCursor": end_cursor,
+                            },
+                        }
                     }
                 }
             }
         }
-    })
+    )
 
 
 def _make_thread(
@@ -162,6 +161,7 @@ def _check(monkeypatch, nodes: list[dict], **kwargs) -> Diagnostic:
 # Zero nodes → PASS
 # ---------------------------------------------------------------------------
 
+
 class TestZeroNodes:
     def test_empty_nodes_passes(self, monkeypatch):
         diag = _check(monkeypatch, [])
@@ -185,6 +185,7 @@ class TestZeroNodes:
 # One resolved node only → PASS
 # ---------------------------------------------------------------------------
 
+
 class TestAllResolved:
     def test_single_resolved_passes(self, monkeypatch):
         diag = _check(monkeypatch, [_make_thread(is_resolved=True)])
@@ -206,6 +207,7 @@ class TestAllResolved:
 # ---------------------------------------------------------------------------
 # One unresolved node → FAIL
 # ---------------------------------------------------------------------------
+
 
 class TestOneUnresolved:
     def test_single_unresolved_fails(self, monkeypatch):
@@ -231,6 +233,7 @@ class TestOneUnresolved:
 # Mix: one resolved + one unresolved → FAIL, only unresolved in list
 # ---------------------------------------------------------------------------
 
+
 class TestMixedThreads:
     def test_mix_one_resolved_one_unresolved_fails(self, monkeypatch):
         nodes = [
@@ -251,12 +254,10 @@ class TestMixedThreads:
 # Three unresolved → FAIL, count=3
 # ---------------------------------------------------------------------------
 
+
 class TestMultipleUnresolved:
     def test_three_unresolved_fails_count_three(self, monkeypatch):
-        nodes = [
-            _make_thread(is_resolved=False, path=f"file{i}.py", line=i * 10)
-            for i in range(3)
-        ]
+        nodes = [_make_thread(is_resolved=False, path=f"file{i}.py", line=i * 10) for i in range(3)]
         diag = _check(monkeypatch, nodes)
         assert diag.status is Status.FAIL
         ev = diag.evidence[0]
@@ -268,6 +269,7 @@ class TestMultipleUnresolved:
 # ---------------------------------------------------------------------------
 # Non-bool isResolved → treated as unresolved (conservative)
 # ---------------------------------------------------------------------------
+
 
 class TestNonBoolIsResolved:
     def test_string_is_resolved_treated_as_unresolved(self, monkeypatch):
@@ -311,6 +313,7 @@ class TestNonBoolIsResolved:
 # Pagination: hasNextPage true → UNAVAILABLE
 # ---------------------------------------------------------------------------
 
+
 class TestPagination:
     def test_has_next_page_is_unavailable(self, monkeypatch):
         _patch_both(
@@ -339,18 +342,20 @@ class TestPagination:
 
     def test_missing_has_next_page_fails_closed(self, monkeypatch):
         """If pageInfo.hasNextPage is absent, treat as paginated (UNAVAILABLE)."""
-        body = json.dumps({
-            "data": {
-                "repository": {
-                    "pullRequest": {
-                        "reviewThreads": {
-                            "nodes": [],
-                            "pageInfo": {"endCursor": None},  # hasNextPage missing
+        body = json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "nodes": [],
+                                "pageInfo": {"endCursor": None},  # hasNextPage missing
+                            }
                         }
                     }
                 }
             }
-        })
+        )
         _patch_both(
             monkeypatch,
             _ok(_RESOLVE_OK),
@@ -362,18 +367,20 @@ class TestPagination:
         assert diag.evidence[0].kind == "gh_pagination_unavailable"
 
     def test_null_has_next_page_fails_closed(self, monkeypatch):
-        body = json.dumps({
-            "data": {
-                "repository": {
-                    "pullRequest": {
-                        "reviewThreads": {
-                            "nodes": [],
-                            "pageInfo": {"hasNextPage": None, "endCursor": None},
+        body = json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "nodes": [],
+                                "pageInfo": {"hasNextPage": None, "endCursor": None},
+                            }
                         }
                     }
                 }
             }
-        })
+        )
         _patch_both(
             monkeypatch,
             _ok(_RESOLVE_OK),
@@ -385,18 +392,20 @@ class TestPagination:
         assert diag.evidence[0].kind == "gh_pagination_unavailable"
 
     def test_non_bool_has_next_page_fails_closed(self, monkeypatch):
-        body = json.dumps({
-            "data": {
-                "repository": {
-                    "pullRequest": {
-                        "reviewThreads": {
-                            "nodes": [],
-                            "pageInfo": {"hasNextPage": "false", "endCursor": None},
+        body = json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "nodes": [],
+                                "pageInfo": {"hasNextPage": "false", "endCursor": None},
+                            }
                         }
                     }
                 }
             }
-        })
+        )
         _patch_both(
             monkeypatch,
             _ok(_RESOLVE_OK),
@@ -412,14 +421,17 @@ class TestPagination:
 # GraphQL errors in response → UNAVAILABLE / gh_graphql_error
 # ---------------------------------------------------------------------------
 
+
 class TestGraphqlErrors:
     def _graphql_error_response(self, errors: list[dict]) -> str:
         return json.dumps({"errors": errors})
 
     def test_graphql_errors_unavailable(self, monkeypatch):
-        error_response = self._graphql_error_response([
-            {"message": "Could not resolve to a Repository"},
-        ])
+        error_response = self._graphql_error_response(
+            [
+                {"message": "Could not resolve to a Repository"},
+            ]
+        )
         _patch_both(monkeypatch, _ok(_RESOLVE_OK), _ok(error_response))
         rule = _make_github_rule()
         diag = gh_backend.check(rule, "owner/repo#42")
@@ -456,6 +468,7 @@ class TestGraphqlErrors:
 # Missing data key → UNAVAILABLE / gh_missing_field
 # ---------------------------------------------------------------------------
 
+
 class TestMissingFields:
     def test_missing_data_key_unavailable(self, monkeypatch):
         _patch_both(monkeypatch, _ok(_RESOLVE_OK), _ok(json.dumps({"other": "stuff"})))
@@ -487,9 +500,7 @@ class TestMissingFields:
         assert "pullRequest" in ev.data["field"]
 
     def test_missing_review_threads_key_unavailable(self, monkeypatch):
-        response = json.dumps({
-            "data": {"repository": {"pullRequest": {"other": "stuff"}}}
-        })
+        response = json.dumps({"data": {"repository": {"pullRequest": {"other": "stuff"}}}})
         _patch_both(monkeypatch, _ok(_RESOLVE_OK), _ok(response))
         rule = _make_github_rule()
         diag = gh_backend.check(rule, "owner/repo#42")
@@ -503,6 +514,7 @@ class TestMissingFields:
 # gh non-zero exit → UNAVAILABLE / gh_failure
 # ---------------------------------------------------------------------------
 
+
 class TestGhFailures:
     def test_gh_nonzero_exit_unavailable(self, monkeypatch):
         _patch_both(monkeypatch, _ok(_RESOLVE_OK), _fail(stderr="rate limit exceeded", returncode=1))
@@ -513,9 +525,11 @@ class TestGhFailures:
         assert ev.kind == "gh_failure"
 
     def test_gh_missing_binary_unavailable(self, monkeypatch):
-        monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([
-            _fail(stderr="gh binary not found", returncode=127, binary_missing=True)
-        ]))
+        monkeypatch.setattr(
+            _target,
+            "run_gh",
+            _make_run_gh_sequence([_fail(stderr="gh binary not found", returncode=127, binary_missing=True)]),
+        )
         rule = _make_github_rule()
         diag = gh_backend.check(rule, "owner/repo#42")
         assert diag.status is Status.UNAVAILABLE
@@ -524,9 +538,7 @@ class TestGhFailures:
         assert ev.kind == "gh_missing"
 
     def test_gh_json_parse_error_unavailable(self, monkeypatch):
-        bad_json = _gh.GhResult(
-            ok=True, stdout="not valid json {{{", stderr="", returncode=0, cmd=("gh",)
-        )
+        bad_json = _gh.GhResult(ok=True, stdout="not valid json {{{", stderr="", returncode=0, cmd=("gh",))
         _patch_both(monkeypatch, _ok(_RESOLVE_OK), bad_json)
         rule = _make_github_rule()
         diag = gh_backend.check(rule, "owner/repo#42")
@@ -538,6 +550,7 @@ class TestGhFailures:
 # ---------------------------------------------------------------------------
 # Command construction verification
 # ---------------------------------------------------------------------------
+
 
 class TestCommandConstruction:
     def test_graphql_command_contains_expected_args(self, monkeypatch):
@@ -558,7 +571,6 @@ class TestCommandConstruction:
         rule = _make_github_rule()
         gh_backend.check(rule, "owner/repo#42")
 
-        argv_str = " ".join(captured_args)
         assert "api" in captured_args
         assert "graphql" in captured_args
         # Verify query content mentions reviewThreads with first: 100
@@ -575,6 +587,7 @@ class TestCommandConstruction:
 # ---------------------------------------------------------------------------
 # Diagnostic round-trip: to_dict → from_dict
 # ---------------------------------------------------------------------------
+
 
 class TestDiagRoundTrip:
     def _rt(self, diag: Diagnostic) -> Diagnostic:
@@ -627,6 +640,7 @@ class TestDiagRoundTrip:
 # ---------------------------------------------------------------------------
 # End-to-end via validate()
 # ---------------------------------------------------------------------------
+
 
 class TestEndToEndValidator:
     def test_zero_unresolved_threads_exit_0(self, monkeypatch):

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -4,6 +4,7 @@ Acceptance criterion: "Running LLM-backed validation without configuration
 returns a non-passing diagnostic."
 We verify that compute_exit_code treats these diagnostics as non-zero.
 """
+
 from __future__ import annotations
 
 from gate_keeper.backends import llm_rubric as llm_backend

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -4,6 +4,7 @@ Focused tests for strip_fenced_blocks and the task-box regexes.
 The task-box patterns are also exercised indirectly via
 test_filesystem_backend.py::TestMarkdownTasksComplete.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -111,22 +112,28 @@ class TestStripFencedBlocks:
 
 
 class TestTaskBoxRegexes:
-    @pytest.mark.parametrize("line", [
-        "- [ ] item",
-        "* [ ] item",
-        "+ [ ] item",
-        "  - [ ] indented",
-        "\t- [ ] tab-indented",
-    ])
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "- [ ] item",
+            "* [ ] item",
+            "+ [ ] item",
+            "  - [ ] indented",
+            "\t- [ ] tab-indented",
+        ],
+    )
     def test_unchecked_matches(self, line):
         assert TASK_UNCHECKED_RE.search(line) is not None
 
-    @pytest.mark.parametrize("line", [
-        "- [x] done",
-        "- [X] done",
-        "* [x] done",
-        "  - [X] indented",
-    ])
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "- [x] done",
+            "- [X] done",
+            "* [x] done",
+            "  - [X] indented",
+        ],
+    )
     def test_checked_matches(self, line):
         assert TASK_CHECKED_RE.search(line) is not None
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,7 +12,6 @@ from gate_keeper.models import (
     Diagnostic,
     DiagnosticReport,
     Evidence,
-    Rule,
     RuleKind,
     RuleSet,
     Severity,
@@ -92,9 +91,7 @@ def _diagnostic_payload() -> dict:
                 "status": "fail",
                 "severity": "error",
                 "message": "missing pattern",
-                "evidence": [
-                    {"kind": "text_match", "data": {"match_count": 0}}
-                ],
+                "evidence": [{"kind": "text_match", "data": {"match_count": 0}}],
                 "remediation": "add the pattern",
             }
         ]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,9 +1,8 @@
 """Tests for the Markdown rule document parser."""
+
 from __future__ import annotations
 
 from pathlib import Path
-
-import pytest
 
 from gate_keeper.models import Backend, Confidence, RuleKind, Severity
 from gate_keeper.parser import parse, parse_file
@@ -14,6 +13,7 @@ FIXTURES = Path(__file__).parent / "fixtures" / "parser"
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _parse(content: str) -> list:
     return parse("test.md", content).rules
@@ -26,6 +26,7 @@ def _texts(content: str) -> list[str]:
 # ---------------------------------------------------------------------------
 # ATX heading context
 # ---------------------------------------------------------------------------
+
 
 class TestHeadingContext:
     def test_rule_under_heading_carries_heading(self):
@@ -58,6 +59,7 @@ class TestHeadingContext:
 # ---------------------------------------------------------------------------
 # Bullet list rules
 # ---------------------------------------------------------------------------
+
 
 class TestBulletRules:
     def test_normative_bullet_extracted(self):
@@ -129,6 +131,7 @@ class TestBulletRules:
 # Ordered list rules
 # ---------------------------------------------------------------------------
 
+
 class TestOrderedListRules:
     def test_normative_ordered_item_extracted(self):
         texts = _texts("1. Every PR must have a description.\n")
@@ -154,6 +157,7 @@ class TestOrderedListRules:
 # ---------------------------------------------------------------------------
 # Task checkboxes
 # ---------------------------------------------------------------------------
+
 
 class TestTaskCheckboxes:
     def test_unchecked_task_extracted(self):
@@ -186,6 +190,7 @@ class TestTaskCheckboxes:
 # ---------------------------------------------------------------------------
 # Normative paragraphs
 # ---------------------------------------------------------------------------
+
 
 class TestNormativeParagraphs:
     def test_normative_paragraph_extracted(self):
@@ -221,6 +226,7 @@ class TestNormativeParagraphs:
 # ---------------------------------------------------------------------------
 # Code fence exclusion
 # ---------------------------------------------------------------------------
+
 
 class TestCodeFenceExclusion:
     def test_backtick_fence_content_ignored(self):
@@ -262,6 +268,7 @@ class TestCodeFenceExclusion:
 # Source location metadata
 # ---------------------------------------------------------------------------
 
+
 class TestSourceLocation:
     def test_line_number_is_one_based(self):
         rules = _parse("- Must review.\n")
@@ -302,6 +309,7 @@ class TestSourceLocation:
 # IR field defaults
 # ---------------------------------------------------------------------------
 
+
 class TestIRDefaults:
     def test_kind_is_semantic_rubric(self):
         rules = _parse("- Must review.\n")
@@ -328,15 +336,14 @@ class TestIRDefaults:
 # Fixture file integration
 # ---------------------------------------------------------------------------
 
+
 class TestFixtureFiles:
     def test_basic_rules_fixture(self):
         rules = parse_file(FIXTURES / "basic-rules.md").rules
         texts = [r.text for r in rules]
         # Three normative bullets + three task checkboxes; two normative ordered items
         # Non-normative bullets and narrative ignored
-        normative_bullets = [t for t in texts if any(
-            kw in t.lower() for kw in ("must", "should", "never")
-        )]
+        normative_bullets = [t for t in texts if any(kw in t.lower() for kw in ("must", "should", "never"))]
         assert len(normative_bullets) >= 3
         # Task checkboxes always present regardless of keywords
         task_texts = {"Tests pass", "Code reviewed", "Documentation updated"}

--- a/tests/test_target_resolver.py
+++ b/tests/test_target_resolver.py
@@ -6,12 +6,11 @@ Covers:
 - Command construction: exact argv captured
 - Round-trip schema compliance for all produced Diagnostic shapes
 """
+
 from __future__ import annotations
 
-import pytest
-
-from gate_keeper.backends._target import PrTarget, parse_target, resolve_target
 from gate_keeper.backends._gh import GhResult
+from gate_keeper.backends._target import PrTarget, parse_target, resolve_target
 from gate_keeper.models import (
     Backend,
     Confidence,
@@ -20,7 +19,6 @@ from gate_keeper.models import (
     RuleKind,
     Severity,
     SourceLocation,
-    Status,
 )
 
 # ---------------------------------------------------------------------------
@@ -298,12 +296,18 @@ class TestResolveTargetFailures:
         assert ev_data["owner"] == "octocat"
         assert ev_data["repo"] == "hello"
         assert ev_data["number"] == 123
-        assert "Could not resolve" in ev_data["stderr_excerpt"] or "not found" in ev_data["stderr_excerpt"].lower()
+        assert (
+            "Could not resolve" in ev_data["stderr_excerpt"]
+            or "not found" in ev_data["stderr_excerpt"].lower()
+        )
 
     def test_pr_not_found_stderr_excerpt_included(self, monkeypatch):
         stderr_msg = "GraphQL: Could not resolve to a Repository with the name 'octo/missing'"
         result = GhResult(
-            ok=False, stdout="", stderr=stderr_msg, returncode=1,
+            ok=False,
+            stdout="",
+            stderr=stderr_msg,
+            returncode=1,
             cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
         )
         monkeypatch.setattr("gate_keeper.backends._target.run_gh", lambda args: result)
@@ -314,7 +318,10 @@ class TestResolveTargetFailures:
 
     def test_malformed_json_returns_gh_json_error_diag(self, monkeypatch):
         result = GhResult(
-            ok=True, stdout="{not json}", stderr="", returncode=0,
+            ok=True,
+            stdout="{not json}",
+            stderr="",
+            returncode=0,
             cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
         )
         monkeypatch.setattr("gate_keeper.backends._target.run_gh", lambda args: result)
@@ -326,7 +333,10 @@ class TestResolveTargetFailures:
     def test_missing_url_field_returns_gh_missing_field_diag(self, monkeypatch):
         # url absent, number present
         result = GhResult(
-            ok=True, stdout='{"number":123}', stderr="", returncode=0,
+            ok=True,
+            stdout='{"number":123}',
+            stderr="",
+            returncode=0,
             cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
         )
         monkeypatch.setattr("gate_keeper.backends._target.run_gh", lambda args: result)
@@ -353,7 +363,10 @@ class TestResolveTargetFailures:
 
     def test_generic_gh_failure_returns_gh_failure_diag(self, monkeypatch):
         result = GhResult(
-            ok=False, stdout="", stderr="some unexpected server error", returncode=1,
+            ok=False,
+            stdout="",
+            stderr="some unexpected server error",
+            returncode=1,
             cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
         )
         monkeypatch.setattr("gate_keeper.backends._target.run_gh", lambda args: result)
@@ -456,7 +469,10 @@ class TestDiagRoundTrip:
 
     def test_gh_json_error_round_trips(self, monkeypatch):
         result = GhResult(
-            ok=True, stdout="{not json}", stderr="", returncode=0,
+            ok=True,
+            stdout="{not json}",
+            stderr="",
+            returncode=0,
             cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
         )
         monkeypatch.setattr("gate_keeper.backends._target.run_gh", lambda args: result)
@@ -467,7 +483,10 @@ class TestDiagRoundTrip:
 
     def test_gh_missing_field_round_trips(self, monkeypatch):
         result = GhResult(
-            ok=True, stdout='{"number":123}', stderr="", returncode=0,
+            ok=True,
+            stdout='{"number":123}',
+            stderr="",
+            returncode=0,
             cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
         )
         monkeypatch.setattr("gate_keeper.backends._target.run_gh", lambda args: result)
@@ -478,7 +497,10 @@ class TestDiagRoundTrip:
 
     def test_gh_failure_round_trips(self, monkeypatch):
         result = GhResult(
-            ok=False, stdout="", stderr="some unexpected error", returncode=1,
+            ok=False,
+            stdout="",
+            stderr="some unexpected error",
+            returncode=1,
             cmd=("gh", "pr", "view", "123", "-R", "octocat/hello", "--json", "number,url"),
         )
         monkeypatch.setattr("gate_keeper.backends._target.run_gh", lambda args: result)
@@ -496,8 +518,10 @@ class TestDiagRoundTrip:
 class TestReExports:
     def test_resolve_target_re_exported(self):
         from gate_keeper.backends.github import resolve_target as rt
+
         assert rt is resolve_target
 
     def test_pr_target_re_exported(self):
         from gate_keeper.backends.github import PrTarget as PT
+
         assert PT is PrTarget

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -3,10 +3,8 @@
 All backend interactions use lightweight stubs registered via the registry so
 no filesystem I/O or network access is required.
 """
-from __future__ import annotations
 
-from pathlib import Path
-from typing import Callable
+from __future__ import annotations
 
 import pytest
 
@@ -16,7 +14,6 @@ from gate_keeper.models import (
     Confidence,
     Diagnostic,
     DiagnosticReport,
-    Evidence,
     Rule,
     RuleKind,
     Severity,
@@ -24,7 +21,6 @@ from gate_keeper.models import (
     Status,
 )
 from gate_keeper.validator import validate
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -51,6 +47,7 @@ def _rule(
 
 def _make_ruleset(*rules: Rule):
     from gate_keeper.models import RuleSet
+
     return RuleSet(rules=list(rules))
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -30,13 +30,19 @@ source = { editable = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "pyright" },
     { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.0,<9" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1" },
+    { name = "pytest", specifier = ">=8.0,<9" },
+    { name = "ruff", specifier = ">=0.9" },
+]
 
 [[package]]
 name = "iniconfig"
@@ -45,6 +51,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
 ]
 
 [[package]]
@@ -75,6 +90,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.409"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -90,6 +118,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `ruff>=0.9` and `pyright>=1.1` as dev dependencies with minimal config (E/F/I rules, `line-length=110`, `typeCheckingMode=basic`)
- Fixes all 43 pre-existing ruff violations across `src/` and `tests/` (unused imports, unsorted imports, ambiguous variable names, lines too long)
- Fixes 16 pyright type errors: restores accidentally-removed `filesystem.name`, adds `assert`-narrowing after tuple-unpacking guards, fixes invalid `strict = false` pyright config
- Adds a parallel `lint` job to `.github/workflows/ci.yml` with `ruff check`, `ruff format --check`, and `pyright` steps

Closes #60

## Validation

```
$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
36 files already formatted

$ uv run pyright
0 errors, 0 warnings, 0 informations

$ uv run pytest
567 passed in 1.01s
```