### PR TITLE
docs: record semantic-rubric quality as the project completion trunk

### DIFF
--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -94,10 +94,15 @@ trunk; the related issues (#52–#58) are deferred indefinitely.
 The list in `docs/mvp-readiness.md` under "Upgrade Path After MVP" is an idea
 dump from the MVP cut, not a prioritized roadmap.  Treat #63 as the source of
 truth for what "next" means for semantic-rubric quality work, and treat gateway
-issue #51 as the source of truth for provider wiring.  In particular, follow the
-Anthropic-only, explicit-dotenv contract from #51 rather than any older guidance
-on this page about generic provider autodetection via environment variables such
-as `OPENAI_API_KEY`.
+issue #51 as the source of truth for provider wiring details.
+
+Provider selection is **not fixed** — Anthropic and OpenAI are both viable
+targets.  The one implementation constraint from issue #51 is credential
+transport: load the provider env file explicitly via `python-dotenv` rather than
+reading from `os.environ` directly (the `os.environ` pass-through route was
+rejected to avoid collisions with the host container's global API-key
+environment).  The extension-point guidance on this page (`GATE_KEEPER_LLM_PROVIDER`,
+`OPENAI_API_KEY`, etc.) remains valid as-is.
 
 ## Why deterministic gates remain authoritative
 

--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -75,6 +75,26 @@ To add a provider:
 No other files need to change: the backend registry, classifier, and validator
 already treat `llm-rubric` as a first-class backend.
 
+## Project trunk: semantic rubric quality
+
+Wiring a real provider (gateway issue #51) is the entry point to this project's
+completion trunk, not its end.  The owner's working definition of "completion"
+for `gate-keeper` is the intellectual work that lifts the semantic rubric
+backend to production-grade quality — prompt design, evaluation reproducibility,
+cost / failure policy, hybrid deterministic+semantic rule kinds, semantic
+self-gating, diagnostic output quality, and a severity ladder grounded in
+measured reliability.
+
+That work is tracked under the umbrella issue **#63 (semantic rubric backend
+quality — project completion trunk)**.  Distribution and adoption polish
+(PyPI publish, CI workflow templates, config file, getting-started guide,
+multi-document composition, generic standard rule library) are *not* on this
+trunk; the related issues (#52–#58) are deferred indefinitely.
+
+The list in `docs/mvp-readiness.md` under "Upgrade Path After MVP" is an idea
+dump from the MVP cut, not a prioritized roadmap.  Treat #63 as the source of
+truth for what "next" means.
+
 ## Why deterministic gates remain authoritative
 
 `gate-keeper` is a **compiler for merge gates**, not an AI reviewer.  Its value

--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -93,7 +93,11 @@ trunk; the related issues (#52–#58) are deferred indefinitely.
 
 The list in `docs/mvp-readiness.md` under "Upgrade Path After MVP" is an idea
 dump from the MVP cut, not a prioritized roadmap.  Treat #63 as the source of
-truth for what "next" means.
+truth for what "next" means for semantic-rubric quality work, and treat gateway
+issue #51 as the source of truth for provider wiring.  In particular, follow the
+Anthropic-only, explicit-dotenv contract from #51 rather than any older guidance
+on this page about generic provider autodetection via environment variables such
+as `OPENAI_API_KEY`.
 
 ## Why deterministic gates remain authoritative
 

--- a/docs/mvp-readiness.md
+++ b/docs/mvp-readiness.md
@@ -102,6 +102,11 @@ verifiable without hidden context. Check off items with `uv run` commands and
 
 ## Upgrade Path After MVP
 
+> **Note**: The list below is an idea dump from the MVP cut, **not** a prioritized
+> roadmap.  The project's actual post-MVP trunk is *semantic rubric backend
+> quality* (umbrella tracker: #63, gateway: #51); see `docs/llm-rubric.md`
+> "Project trunk" section.  Items below may or may not become work items.
+
 1. **LLM rubric backend**: Wire in an Anthropic or OpenAI provider to enable
    semantic rule evaluation. Add a `--model` or environment-variable configuration
    path. Promote high-confidence LLM results to `warning` severity; keep `advisory`

--- a/docs/mvp-readiness.md
+++ b/docs/mvp-readiness.md
@@ -106,6 +106,9 @@ verifiable without hidden context. Check off items with `uv run` commands and
 > roadmap.  The project's actual post-MVP trunk is *semantic rubric backend
 > quality* (umbrella tracker: #63, gateway: #51); see `docs/llm-rubric.md`
 > "Project trunk" section.  Items below may or may not become work items.
+> Provider selection is not fixed (Anthropic and OpenAI are both viable); the
+> implementation contract for credential transport is explicit dotenv loading —
+> see issue #51 for details.
 
 1. **LLM rubric backend**: Wire in an Anthropic or OpenAI provider to enable
    semantic rule evaluation. Add a `--model` or environment-variable configuration


### PR DESCRIPTION
## Summary

- Adds a "Project trunk" section to `docs/llm-rubric.md` declaring umbrella issue #63 (semantic rubric backend quality) as the project completion trunk, with #51 as its gateway.
- Adds a clarifying note above `docs/mvp-readiness.md`'s "Upgrade Path After MVP" section to mark that list as an idea dump, not a prioritized roadmap.

## Background

The agent-generated Day 4+ roadmap (#59) conflated "completion" with distribution/adoption polish (#52–#58). Owner clarified that "完成" for this project means the intellectual work that lifts the semantic rubric backend to production quality. These docs reflect that, so future contributors (human or agent) do not re-derive the wrong roadmap from MVP-era artifacts.

Related issue cleanup (already done outside this PR):

- Created umbrella #63 as the active trunk tracker.
- #51 prepended with a "Trunk gateway" banner.
- #52–#58 prepended with deferral banners.
- #59 marked as superseded by #63.

## Test plan

- [ ] `docs/llm-rubric.md` renders cleanly on GitHub.
- [ ] `docs/mvp-readiness.md` renders cleanly on GitHub; the new note appears as a blockquote above the existing list.
- [ ] No code changes; no test suite impact (skip `uv run pytest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)