### PR TITLE
feat(backends): tool-agnostic CLI runner for external adapters (#93)

### DIFF
--- a/src/gate_keeper/backends/_cli.py
+++ b/src/gate_keeper/backends/_cli.py
@@ -1,0 +1,372 @@
+"""Tool-agnostic CLI runner for external-CLI backend adapters.
+
+Provides:
+- CliResult        — typed result container for arbitrary CLI invocations
+- CliFault         — coarse failure category enum
+- run_cli()        — subprocess wrapper; never raises
+- classify_cli_failure() — triage helper for CliResult failures
+- Diagnostic builders  — cli_missing_diag, cli_failed_diag, cli_timeout_diag
+- failure_diag()   — single dispatch entry point
+
+Mirrors the shape of ``backends/_gh.py`` but holds no GitHub-specific knowledge:
+no auth-marker detection, no built-in token regex. Per-tool adapters wire this
+runner into a backend (e.g. the planned textlint adapter under
+``Backend.EXTERNAL``) and supply their own redaction policy via the optional
+``redactor`` parameter.
+"""
+
+from __future__ import annotations
+
+import enum
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Sequence
+
+from gate_keeper.models import Backend, Diagnostic, Evidence, Rule, Status
+
+Redactor = Callable[[str], str]
+
+
+def _identity(text: str) -> str:
+    return text
+
+
+# ---------------------------------------------------------------------------
+# CliFault
+# ---------------------------------------------------------------------------
+
+
+class CliFault(str, enum.Enum):
+    """Coarse classification of a failed CliResult.
+
+    ``MISSING``      — the executable was not found on PATH.
+    ``TIMEOUT``      — subprocess.TimeoutExpired raised by the OS.
+    ``OS_ERROR``     — any other OSError raised before/while spawning.
+    ``NONZERO_EXIT`` — the process ran to completion with a non-zero status
+                       (this also covers signal-terminated runs reported as
+                       a negative returncode by the OS).
+    """
+
+    MISSING = "missing"
+    TIMEOUT = "timeout"
+    OS_ERROR = "os_error"
+    NONZERO_EXIT = "nonzero_exit"
+
+
+# Sentinel returncodes used when no real OS-level returncode is available.
+# Negative values cannot collide with a real process exit (0–255) and let
+# ``classify_cli_failure`` reconstruct the fault from a CliResult alone.
+_RETURNCODE_BINARY_MISSING = 127  # POSIX convention for "command not found"
+_RETURNCODE_TIMEOUT = -2
+_RETURNCODE_OS_ERROR = -3
+
+
+# ---------------------------------------------------------------------------
+# CliResult
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CliResult:
+    """Typed result of a CLI invocation.
+
+    ``binary_missing`` and ``timed_out`` are tracked as explicit flags rather
+    than inferred from ``returncode`` because Unix reports signal-terminated
+    processes with negative return codes too — for example, SIGHUP yields
+    ``returncode == -1`` — so a sentinel return code would conflate the two.
+    """
+
+    ok: bool
+    stdout: str
+    stderr: str  # already passed through the caller's redactor
+    returncode: int
+    cmd: tuple[str, ...]  # the actual argv, for diagnostics
+    binary_missing: bool = False
+    timed_out: bool = False
+
+
+# ---------------------------------------------------------------------------
+# run_cli
+# ---------------------------------------------------------------------------
+
+
+def run_cli(
+    executable: str,
+    args: Sequence[str],
+    *,
+    input: str | None = None,
+    timeout: float | None = None,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+    redactor: Redactor | None = None,
+) -> CliResult:
+    """Run ``executable <args>`` and return a CliResult; never raises.
+
+    - Captures stdout/stderr as UTF-8 (errors="replace").
+    - Non-zero exit codes are reflected in ``CliResult.ok = False``; no exception.
+    - ``FileNotFoundError``, ``TimeoutExpired``, and other ``OSError`` variants
+      are caught and returned as failed CliResult objects.
+    - ``redactor`` (if provided) is applied to stderr before storing. Callers
+      that handle credentials are expected to supply one; the default is the
+      identity function so no redaction is performed.
+    """
+    redact = redactor or _identity
+    argv: tuple[str, ...] = (executable, *args)
+    try:
+        completed = subprocess.run(
+            list(argv),
+            input=input,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            cwd=cwd,
+            env=env,
+        )
+        return CliResult(
+            ok=completed.returncode == 0,
+            stdout=completed.stdout,
+            stderr=redact(completed.stderr),
+            returncode=completed.returncode,
+            cmd=argv,
+        )
+    except FileNotFoundError:
+        return CliResult(
+            ok=False,
+            stdout="",
+            stderr=f"{executable!r} binary not found",
+            returncode=_RETURNCODE_BINARY_MISSING,
+            cmd=argv,
+            binary_missing=True,
+        )
+    except subprocess.TimeoutExpired as exc:
+        partial_stderr = redact(exc.stderr) if isinstance(exc.stderr, str) else ""
+        return CliResult(
+            ok=False,
+            stdout="",
+            stderr=f"timed out after {exc.timeout}s; {partial_stderr}".strip("; "),
+            returncode=_RETURNCODE_TIMEOUT,
+            cmd=argv,
+            timed_out=True,
+        )
+    except OSError as exc:
+        return CliResult(
+            ok=False,
+            stdout="",
+            stderr=f"OSError: {exc}",
+            returncode=_RETURNCODE_OS_ERROR,
+            cmd=argv,
+        )
+
+
+# ---------------------------------------------------------------------------
+# classify_cli_failure
+# ---------------------------------------------------------------------------
+
+
+def classify_cli_failure(result: CliResult) -> CliFault:
+    """Classify a failed CliResult into a CliFault category.
+
+    Trusts the explicit ``binary_missing`` / ``timed_out`` flags rather than
+    the returncode value — see CliResult docstring.
+    """
+    if result.binary_missing:
+        return CliFault.MISSING
+    if result.timed_out:
+        return CliFault.TIMEOUT
+    if result.returncode == _RETURNCODE_OS_ERROR:
+        return CliFault.OS_ERROR
+    return CliFault.NONZERO_EXIT
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic builders
+# ---------------------------------------------------------------------------
+
+
+_STDERR_EXCERPT_LIMIT = 300
+
+
+def _stderr_excerpt(result: CliResult, limit: int = _STDERR_EXCERPT_LIMIT) -> str:
+    text = result.stderr
+    if len(text) > limit:
+        return text[:limit] + "…"
+    return text
+
+
+def _safe_cmd(result: CliResult, redactor: Redactor | None) -> str:
+    """Return a space-joined command string with the caller's redactor applied per-arg."""
+    redact = redactor or _identity
+    return " ".join(redact(arg) for arg in result.cmd)
+
+
+def _base_diag(
+    rule: Rule,
+    backend: Backend,
+    status: Status,
+    message: str,
+    evidence: list[Evidence],
+) -> Diagnostic:
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=backend,
+        status=status,
+        severity=rule.severity,
+        message=message,
+        evidence=evidence,
+    )
+
+
+def cli_missing_diag(rule: Rule, backend: Backend, executable: str) -> Diagnostic:
+    """Produce an UNAVAILABLE diagnostic when the CLI binary is not on PATH."""
+    return _base_diag(
+        rule,
+        backend,
+        Status.UNAVAILABLE,
+        f"{executable!r} CLI is not installed or not found on PATH; cannot evaluate rule.",
+        [
+            Evidence(
+                kind="cli_missing",
+                data={"executable": executable},
+            )
+        ],
+    )
+
+
+def cli_failed_diag(
+    rule: Rule,
+    backend: Backend,
+    op: str,
+    result: CliResult,
+    *,
+    redactor: Redactor | None = None,
+) -> Diagnostic:
+    """Produce a diagnostic for a non-zero CLI exit (not timeout, not OS error).
+
+    Status is UNAVAILABLE — a non-zero exit means we could not produce a
+    pass/fail answer, which is the fail-closed convention used elsewhere in
+    the codebase.
+    """
+    return _base_diag(
+        rule,
+        backend,
+        Status.UNAVAILABLE,
+        f"{op!r} exited with returncode {result.returncode}.",
+        [
+            Evidence(
+                kind="cli_failure",
+                data={
+                    "op": op,
+                    "executable": result.cmd[0] if result.cmd else "",
+                    "returncode": result.returncode,
+                    "stderr_excerpt": _stderr_excerpt(result),
+                    "cmd": _safe_cmd(result, redactor),
+                },
+            )
+        ],
+    )
+
+
+def cli_timeout_diag(
+    rule: Rule,
+    backend: Backend,
+    op: str,
+    result: CliResult,
+    *,
+    redactor: Redactor | None = None,
+) -> Diagnostic:
+    """Produce an ERROR diagnostic when a CLI invocation timed out.
+
+    Timeout is treated as ERROR (not UNAVAILABLE) because it indicates an
+    abnormal local-environment condition rather than a remote rate-limit /
+    bad-args / missing-data signal. This mirrors how ``_gh.py`` maps negative
+    returncodes to ``Status.ERROR``.
+    """
+    return _base_diag(
+        rule,
+        backend,
+        Status.ERROR,
+        f"{op!r} timed out (returncode {result.returncode}).",
+        [
+            Evidence(
+                kind="cli_timeout",
+                data={
+                    "op": op,
+                    "executable": result.cmd[0] if result.cmd else "",
+                    "returncode": result.returncode,
+                    "stderr_excerpt": _stderr_excerpt(result),
+                    "cmd": _safe_cmd(result, redactor),
+                },
+            )
+        ],
+    )
+
+
+def cli_os_error_diag(
+    rule: Rule,
+    backend: Backend,
+    op: str,
+    result: CliResult,
+    *,
+    redactor: Redactor | None = None,
+) -> Diagnostic:
+    """Produce an ERROR diagnostic for an OSError raised while spawning the CLI."""
+    return _base_diag(
+        rule,
+        backend,
+        Status.ERROR,
+        f"{op!r} failed with an OS error before completion.",
+        [
+            Evidence(
+                kind="cli_os_error",
+                data={
+                    "op": op,
+                    "executable": result.cmd[0] if result.cmd else "",
+                    "returncode": result.returncode,
+                    "stderr_excerpt": _stderr_excerpt(result),
+                    "cmd": _safe_cmd(result, redactor),
+                },
+            )
+        ],
+    )
+
+
+def failure_diag(
+    rule: Rule,
+    backend: Backend,
+    op: str,
+    result: CliResult,
+    *,
+    redactor: Redactor | None = None,
+) -> Diagnostic:
+    """Dispatch to the appropriate failure diagnostic builder based on CliResult.
+
+    This is the single entry point for per-rule checks to call after a failed
+    ``run_cli()`` — it classifies the failure and returns the right Diagnostic.
+    """
+    fault = classify_cli_failure(result)
+    if fault is CliFault.MISSING:
+        executable = result.cmd[0] if result.cmd else ""
+        return cli_missing_diag(rule, backend, executable)
+    if fault is CliFault.TIMEOUT:
+        return cli_timeout_diag(rule, backend, op, result, redactor=redactor)
+    if fault is CliFault.OS_ERROR:
+        return cli_os_error_diag(rule, backend, op, result, redactor=redactor)
+    return cli_failed_diag(rule, backend, op, result, redactor=redactor)
+
+
+__all__ = [
+    "CliFault",
+    "CliResult",
+    "Redactor",
+    "run_cli",
+    "classify_cli_failure",
+    "failure_diag",
+    "cli_missing_diag",
+    "cli_failed_diag",
+    "cli_timeout_diag",
+    "cli_os_error_diag",
+]

--- a/tests/test_cli_runner.py
+++ b/tests/test_cli_runner.py
@@ -1,0 +1,508 @@
+"""Tests for the tool-agnostic CLI runner (gate_keeper.backends._cli).
+
+Covers:
+- run_cli: missing binary, non-zero exit, timeout, OS error, optional redactor
+- classify_cli_failure: each CliFault category, signal-terminated runs
+- Diagnostic builders: backend, status, evidence shape, fail-closed status mapping
+- failure_diag dispatch
+- Round-trip via Diagnostic.from_dict / to_dict
+- Redactor applied to stderr and to evidence['cmd']
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from gate_keeper.backends._cli import (
+    CliFault,
+    CliResult,
+    classify_cli_failure,
+    cli_failed_diag,
+    cli_missing_diag,
+    cli_os_error_diag,
+    cli_timeout_diag,
+    failure_diag,
+    run_cli,
+)
+from gate_keeper.models import (
+    Backend,
+    Confidence,
+    Diagnostic,
+    Rule,
+    RuleKind,
+    Severity,
+    SourceLocation,
+    Status,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _rule(rule_id: str = "test-rule") -> Rule:
+    return Rule(
+        id=rule_id,
+        title="Test CLI rule",
+        source=SourceLocation(path="rules.md", line=1),
+        text="some rule text",
+        kind=RuleKind.TEXT_REQUIRED,
+        severity=Severity.ERROR,
+        backend_hint=Backend.FILESYSTEM,
+        confidence=Confidence.HIGH,
+        params={},
+    )
+
+
+def _make_completed(stdout: str = "", stderr: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(
+        args=["tool"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+# ---------------------------------------------------------------------------
+# run_cli — binary missing
+# ---------------------------------------------------------------------------
+
+
+class TestRunCliMissing:
+    def test_file_not_found_returns_failed_result(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: (_ for _ in ()).throw(FileNotFoundError("not found")),
+        )
+        result = run_cli("textlint", ["README.md"])
+        assert result.ok is False
+        assert result.binary_missing is True
+        assert result.timed_out is False
+        assert result.returncode == 127
+        assert result.cmd == ("textlint", "README.md")
+        assert "textlint" in result.stderr
+
+    def test_missing_classifies_as_missing(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: (_ for _ in ()).throw(FileNotFoundError()),
+        )
+        result = run_cli("textlint", ["README.md"])
+        assert classify_cli_failure(result) is CliFault.MISSING
+
+
+# ---------------------------------------------------------------------------
+# run_cli — non-zero exit
+# ---------------------------------------------------------------------------
+
+
+class TestRunCliNonZeroExit:
+    def test_nonzero_exit_ok_false(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: _make_completed(stderr="bad input", returncode=2),
+        )
+        result = run_cli("textlint", ["x"])
+        assert result.ok is False
+        assert result.returncode == 2
+        assert result.stderr == "bad input"
+        assert result.binary_missing is False
+        assert result.timed_out is False
+
+    def test_zero_exit_ok_true(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: _make_completed(stdout="all good", returncode=0),
+        )
+        result = run_cli("textlint", [])
+        assert result.ok is True
+        assert result.returncode == 0
+        assert result.stdout == "all good"
+
+    def test_argv_starts_with_executable(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **kw: _make_completed(returncode=1)
+        )
+        result = run_cli("eslint", ["--fix", "src/"])
+        assert result.cmd == ("eslint", "--fix", "src/")
+
+
+# ---------------------------------------------------------------------------
+# run_cli — timeout and OSError
+# ---------------------------------------------------------------------------
+
+
+class TestRunCliExceptions:
+    def test_timeout_returns_failed_result(self, monkeypatch):
+        def _raise(*a, **kw):
+            raise subprocess.TimeoutExpired(cmd=["tool"], timeout=5.0)
+
+        monkeypatch.setattr(subprocess, "run", _raise)
+        result = run_cli("tool", [], timeout=5.0)
+        assert result.ok is False
+        assert result.returncode == -2
+        assert result.timed_out is True
+        assert result.binary_missing is False
+
+    def test_timeout_classifies_as_timeout(self, monkeypatch):
+        def _raise(*a, **kw):
+            raise subprocess.TimeoutExpired(cmd=["tool"], timeout=1.0)
+
+        monkeypatch.setattr(subprocess, "run", _raise)
+        result = run_cli("tool", [], timeout=1.0)
+        assert classify_cli_failure(result) is CliFault.TIMEOUT
+
+    def test_os_error_returns_failed_result(self, monkeypatch):
+        def _raise(*a, **kw):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(subprocess, "run", _raise)
+        result = run_cli("tool", [])
+        assert result.ok is False
+        assert result.returncode == -3
+        assert result.binary_missing is False
+        assert result.timed_out is False
+        assert "permission denied" in result.stderr
+
+    def test_os_error_classifies_as_os_error(self, monkeypatch):
+        def _raise(*a, **kw):
+            raise OSError("nope")
+
+        monkeypatch.setattr(subprocess, "run", _raise)
+        result = run_cli("tool", [])
+        assert classify_cli_failure(result) is CliFault.OS_ERROR
+
+
+# ---------------------------------------------------------------------------
+# run_cli — redactor
+# ---------------------------------------------------------------------------
+
+
+class TestRunCliRedactor:
+    def test_default_no_redaction(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: _make_completed(stderr="secret=abc123", returncode=1),
+        )
+        result = run_cli("tool", [])
+        # No redactor passed → stderr unchanged.
+        assert result.stderr == "secret=abc123"
+
+    def test_custom_redactor_applied_to_stderr(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: _make_completed(stderr="secret=abc123", returncode=1),
+        )
+        result = run_cli(
+            "tool",
+            [],
+            redactor=lambda s: s.replace("abc123", "[redacted]"),
+        )
+        assert "abc123" not in result.stderr
+        assert "[redacted]" in result.stderr
+
+    def test_redactor_applied_to_partial_stderr_on_timeout(self, monkeypatch):
+        def _raise(*a, **kw):
+            raise subprocess.TimeoutExpired(
+                cmd=["tool"], timeout=2.0, stderr="leak=xyz"
+            )
+
+        monkeypatch.setattr(subprocess, "run", _raise)
+        result = run_cli(
+            "tool",
+            [],
+            timeout=2.0,
+            redactor=lambda s: s.replace("xyz", "[scrubbed]"),
+        )
+        assert "xyz" not in result.stderr
+        assert "[scrubbed]" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# classify_cli_failure
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyCliFailure:
+    def _result(
+        self,
+        returncode: int,
+        *,
+        binary_missing: bool = False,
+        timed_out: bool = False,
+    ) -> CliResult:
+        return CliResult(
+            ok=False,
+            stdout="",
+            stderr="",
+            returncode=returncode,
+            cmd=("tool",),
+            binary_missing=binary_missing,
+            timed_out=timed_out,
+        )
+
+    def test_binary_missing_flag_is_missing(self):
+        assert (
+            classify_cli_failure(self._result(127, binary_missing=True))
+            is CliFault.MISSING
+        )
+
+    def test_timed_out_flag_is_timeout(self):
+        assert (
+            classify_cli_failure(self._result(-2, timed_out=True)) is CliFault.TIMEOUT
+        )
+
+    def test_os_error_returncode_is_os_error(self):
+        # Returncode -3 without timed_out/binary_missing flags maps to OS_ERROR.
+        assert classify_cli_failure(self._result(-3)) is CliFault.OS_ERROR
+
+    def test_arbitrary_nonzero_is_nonzero_exit(self):
+        assert classify_cli_failure(self._result(1)) is CliFault.NONZERO_EXIT
+
+    def test_signal_terminated_negative_returncode_is_nonzero_exit(self):
+        # SIGHUP terminates with returncode -1; flags are not set, so this
+        # must NOT be classified as MISSING or TIMEOUT.
+        assert classify_cli_failure(self._result(-1)) is CliFault.NONZERO_EXIT
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic builders
+# ---------------------------------------------------------------------------
+
+
+class TestDiagBuilders:
+    def test_cli_missing_diag(self):
+        rule = _rule()
+        diag = cli_missing_diag(rule, Backend.FILESYSTEM, "textlint")
+        assert diag.backend is Backend.FILESYSTEM
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.severity is rule.severity
+        assert len(diag.evidence) == 1
+        ev = diag.evidence[0]
+        assert ev.kind == "cli_missing"
+        assert ev.data["executable"] == "textlint"
+
+    def test_cli_failed_diag_status_unavailable(self):
+        rule = _rule()
+        result = CliResult(
+            ok=False,
+            stdout="",
+            stderr="bad input",
+            returncode=2,
+            cmd=("textlint", "README.md"),
+        )
+        diag = cli_failed_diag(rule, Backend.FILESYSTEM, "lint", result)
+        # Fail-closed: a non-zero exit yields UNAVAILABLE, not FAIL.
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.backend is Backend.FILESYSTEM
+        ev = diag.evidence[0]
+        assert ev.kind == "cli_failure"
+        assert ev.data["op"] == "lint"
+        assert ev.data["executable"] == "textlint"
+        assert ev.data["returncode"] == 2
+        assert "bad input" in ev.data["stderr_excerpt"]
+        assert ev.data["cmd"] == "textlint README.md"
+
+    def test_cli_failed_diag_truncates_long_stderr(self):
+        rule = _rule()
+        long_stderr = "x" * 5000
+        result = CliResult(
+            ok=False, stdout="", stderr=long_stderr, returncode=1, cmd=("tool",)
+        )
+        diag = cli_failed_diag(rule, Backend.FILESYSTEM, "op", result)
+        excerpt = diag.evidence[0].data["stderr_excerpt"]
+        assert len(excerpt) < len(long_stderr)
+        assert excerpt.endswith("…")
+
+    def test_cli_timeout_diag_status_error(self):
+        rule = _rule()
+        result = CliResult(
+            ok=False,
+            stdout="",
+            stderr="timed out after 5.0s",
+            returncode=-2,
+            cmd=("tool",),
+            timed_out=True,
+        )
+        diag = cli_timeout_diag(rule, Backend.FILESYSTEM, "op", result)
+        # Timeout is an environmental failure → ERROR, not UNAVAILABLE.
+        assert diag.status is Status.ERROR
+        assert diag.evidence[0].kind == "cli_timeout"
+
+    def test_cli_os_error_diag_status_error(self):
+        rule = _rule()
+        result = CliResult(
+            ok=False,
+            stdout="",
+            stderr="OSError: nope",
+            returncode=-3,
+            cmd=("tool",),
+        )
+        diag = cli_os_error_diag(rule, Backend.FILESYSTEM, "op", result)
+        assert diag.status is Status.ERROR
+        assert diag.evidence[0].kind == "cli_os_error"
+
+    def test_redactor_applied_to_evidence_cmd(self):
+        rule = _rule()
+        result = CliResult(
+            ok=False,
+            stdout="",
+            stderr="",
+            returncode=1,
+            cmd=("tool", "--token", "supersecret"),
+        )
+        diag = cli_failed_diag(
+            rule,
+            Backend.FILESYSTEM,
+            "op",
+            result,
+            redactor=lambda s: s.replace("supersecret", "[redacted]"),
+        )
+        cmd_value = diag.evidence[0].data["cmd"]
+        assert "supersecret" not in cmd_value
+        assert "[redacted]" in cmd_value
+
+    def test_diag_propagates_rule_source_and_severity(self):
+        rule = Rule(
+            id="r1",
+            title="t",
+            source=SourceLocation(path="a/b.md", line=42, heading="H"),
+            text="t",
+            kind=RuleKind.TEXT_REQUIRED,
+            severity=Severity.WARNING,
+            backend_hint=Backend.FILESYSTEM,
+            confidence=Confidence.LOW,
+            params={},
+        )
+        diag = cli_missing_diag(rule, Backend.FILESYSTEM, "tool")
+        assert diag.rule_id == "r1"
+        assert diag.source.path == "a/b.md"
+        assert diag.source.line == 42
+        assert diag.severity is Severity.WARNING
+
+
+# ---------------------------------------------------------------------------
+# failure_diag dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestFailureDiagDispatch:
+    def test_missing_routes_to_cli_missing(self):
+        rule = _rule()
+        result = CliResult(
+            ok=False,
+            stdout="",
+            stderr="not found",
+            returncode=127,
+            cmd=("textlint",),
+            binary_missing=True,
+        )
+        diag = failure_diag(rule, Backend.FILESYSTEM, "lint", result)
+        assert diag.evidence[0].kind == "cli_missing"
+        assert diag.evidence[0].data["executable"] == "textlint"
+        assert diag.status is Status.UNAVAILABLE
+
+    def test_timeout_routes_to_cli_timeout(self):
+        rule = _rule()
+        result = CliResult(
+            ok=False,
+            stdout="",
+            stderr="timed out",
+            returncode=-2,
+            cmd=("tool",),
+            timed_out=True,
+        )
+        diag = failure_diag(rule, Backend.FILESYSTEM, "lint", result)
+        assert diag.evidence[0].kind == "cli_timeout"
+        assert diag.status is Status.ERROR
+
+    def test_os_error_routes_to_cli_os_error(self):
+        rule = _rule()
+        result = CliResult(
+            ok=False,
+            stdout="",
+            stderr="OSError: x",
+            returncode=-3,
+            cmd=("tool",),
+        )
+        diag = failure_diag(rule, Backend.FILESYSTEM, "lint", result)
+        assert diag.evidence[0].kind == "cli_os_error"
+        assert diag.status is Status.ERROR
+
+    def test_generic_nonzero_routes_to_cli_failure(self):
+        rule = _rule()
+        result = CliResult(
+            ok=False, stdout="", stderr="boom", returncode=1, cmd=("tool",)
+        )
+        diag = failure_diag(rule, Backend.FILESYSTEM, "lint", result)
+        assert diag.evidence[0].kind == "cli_failure"
+        assert diag.status is Status.UNAVAILABLE
+
+    def test_dispatch_passes_redactor_through(self):
+        rule = _rule()
+        result = CliResult(
+            ok=False,
+            stdout="",
+            stderr="leaked=topsecret",
+            returncode=1,
+            cmd=("tool", "--key", "topsecret"),
+        )
+        diag = failure_diag(
+            rule,
+            Backend.FILESYSTEM,
+            "lint",
+            result,
+            redactor=lambda s: s.replace("topsecret", "[X]"),
+        )
+        assert "topsecret" not in diag.evidence[0].data["cmd"]
+
+
+# ---------------------------------------------------------------------------
+# Round-trip schema compliance
+# ---------------------------------------------------------------------------
+
+
+class TestDiagRoundTrip:
+    def _round_trip(self, diag: Diagnostic) -> Diagnostic:
+        return Diagnostic.from_dict(diag.to_dict())
+
+    def test_cli_missing_diag_round_trips(self):
+        diag = cli_missing_diag(_rule(), Backend.FILESYSTEM, "textlint")
+        rebuilt = self._round_trip(diag)
+        assert rebuilt.status is Status.UNAVAILABLE
+        assert rebuilt.backend is Backend.FILESYSTEM
+        assert rebuilt.evidence[0].kind == "cli_missing"
+        assert rebuilt.evidence[0].data["executable"] == "textlint"
+
+    def test_cli_failed_diag_round_trips(self):
+        result = CliResult(
+            ok=False, stdout="", stderr="err", returncode=1, cmd=("tool", "arg")
+        )
+        diag = cli_failed_diag(_rule(), Backend.FILESYSTEM, "op", result)
+        rebuilt = self._round_trip(diag)
+        assert rebuilt.evidence[0].data["op"] == "op"
+        assert rebuilt.evidence[0].data["returncode"] == 1
+
+    def test_cli_timeout_diag_round_trips(self):
+        result = CliResult(
+            ok=False, stdout="", stderr="t", returncode=-2, cmd=("t",), timed_out=True
+        )
+        diag = cli_timeout_diag(_rule(), Backend.FILESYSTEM, "op", result)
+        rebuilt = self._round_trip(diag)
+        assert rebuilt.status is Status.ERROR
+        assert rebuilt.evidence[0].kind == "cli_timeout"
+
+    def test_cli_os_error_diag_round_trips(self):
+        result = CliResult(
+            ok=False, stdout="", stderr="o", returncode=-3, cmd=("t",)
+        )
+        diag = cli_os_error_diag(_rule(), Backend.FILESYSTEM, "op", result)
+        rebuilt = self._round_trip(diag)
+        assert rebuilt.status is Status.ERROR
+        assert rebuilt.evidence[0].kind == "cli_os_error"

--- a/tests/test_cli_runner.py
+++ b/tests/test_cli_runner.py
@@ -124,9 +124,7 @@ class TestRunCliNonZeroExit:
         assert result.stdout == "all good"
 
     def test_argv_starts_with_executable(self, monkeypatch):
-        monkeypatch.setattr(
-            subprocess, "run", lambda *a, **kw: _make_completed(returncode=1)
-        )
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_completed(returncode=1))
         result = run_cli("eslint", ["--fix", "src/"])
         assert result.cmd == ("eslint", "--fix", "src/")
 
@@ -209,9 +207,7 @@ class TestRunCliRedactor:
 
     def test_redactor_applied_to_partial_stderr_on_timeout(self, monkeypatch):
         def _raise(*a, **kw):
-            raise subprocess.TimeoutExpired(
-                cmd=["tool"], timeout=2.0, stderr="leak=xyz"
-            )
+            raise subprocess.TimeoutExpired(cmd=["tool"], timeout=2.0, stderr="leak=xyz")
 
         monkeypatch.setattr(subprocess, "run", _raise)
         result = run_cli(
@@ -248,15 +244,10 @@ class TestClassifyCliFailure:
         )
 
     def test_binary_missing_flag_is_missing(self):
-        assert (
-            classify_cli_failure(self._result(127, binary_missing=True))
-            is CliFault.MISSING
-        )
+        assert classify_cli_failure(self._result(127, binary_missing=True)) is CliFault.MISSING
 
     def test_timed_out_flag_is_timeout(self):
-        assert (
-            classify_cli_failure(self._result(-2, timed_out=True)) is CliFault.TIMEOUT
-        )
+        assert classify_cli_failure(self._result(-2, timed_out=True)) is CliFault.TIMEOUT
 
     def test_os_error_returncode_is_os_error(self):
         # Returncode -3 without timed_out/binary_missing flags maps to OS_ERROR.
@@ -312,9 +303,7 @@ class TestDiagBuilders:
     def test_cli_failed_diag_truncates_long_stderr(self):
         rule = _rule()
         long_stderr = "x" * 5000
-        result = CliResult(
-            ok=False, stdout="", stderr=long_stderr, returncode=1, cmd=("tool",)
-        )
+        result = CliResult(ok=False, stdout="", stderr=long_stderr, returncode=1, cmd=("tool",))
         diag = cli_failed_diag(rule, Backend.FILESYSTEM, "op", result)
         excerpt = diag.evidence[0].data["stderr_excerpt"]
         assert len(excerpt) < len(long_stderr)
@@ -437,9 +426,7 @@ class TestFailureDiagDispatch:
 
     def test_generic_nonzero_routes_to_cli_failure(self):
         rule = _rule()
-        result = CliResult(
-            ok=False, stdout="", stderr="boom", returncode=1, cmd=("tool",)
-        )
+        result = CliResult(ok=False, stdout="", stderr="boom", returncode=1, cmd=("tool",))
         diag = failure_diag(rule, Backend.FILESYSTEM, "lint", result)
         assert diag.evidence[0].kind == "cli_failure"
         assert diag.status is Status.UNAVAILABLE
@@ -481,27 +468,21 @@ class TestDiagRoundTrip:
         assert rebuilt.evidence[0].data["executable"] == "textlint"
 
     def test_cli_failed_diag_round_trips(self):
-        result = CliResult(
-            ok=False, stdout="", stderr="err", returncode=1, cmd=("tool", "arg")
-        )
+        result = CliResult(ok=False, stdout="", stderr="err", returncode=1, cmd=("tool", "arg"))
         diag = cli_failed_diag(_rule(), Backend.FILESYSTEM, "op", result)
         rebuilt = self._round_trip(diag)
         assert rebuilt.evidence[0].data["op"] == "op"
         assert rebuilt.evidence[0].data["returncode"] == 1
 
     def test_cli_timeout_diag_round_trips(self):
-        result = CliResult(
-            ok=False, stdout="", stderr="t", returncode=-2, cmd=("t",), timed_out=True
-        )
+        result = CliResult(ok=False, stdout="", stderr="t", returncode=-2, cmd=("t",), timed_out=True)
         diag = cli_timeout_diag(_rule(), Backend.FILESYSTEM, "op", result)
         rebuilt = self._round_trip(diag)
         assert rebuilt.status is Status.ERROR
         assert rebuilt.evidence[0].kind == "cli_timeout"
 
     def test_cli_os_error_diag_round_trips(self):
-        result = CliResult(
-            ok=False, stdout="", stderr="o", returncode=-3, cmd=("t",)
-        )
+        result = CliResult(ok=False, stdout="", stderr="o", returncode=-3, cmd=("t",))
         diag = cli_os_error_diag(_rule(), Backend.FILESYSTEM, "op", result)
         rebuilt = self._round_trip(diag)
         assert rebuilt.status is Status.ERROR


### PR DESCRIPTION
## Summary

Implements the generic CLI runner module under `src/gate_keeper/backends/_cli.py` that future external-tool adapters (textlint per umbrella #80) will share. Extracts the reusable subprocess + fail-closed Diagnostic patterns from `backends/_gh.py` into a tool-agnostic surface that holds no GitHub-specific knowledge (no auth-marker detection, no built-in token regex; redaction is supplied by the caller).

### Public surface

- `run_cli(executable, args, *, input, timeout, cwd, env, redactor) -> CliResult` — never raises; catches `FileNotFoundError`, `TimeoutExpired`, and other `OSError` variants.
- `CliResult` — `ok`, `stdout`, `stderr` (already redacted), `returncode`, `cmd`, plus explicit `binary_missing` / `timed_out` flags so signal-terminated runs (e.g. SIGHUP → returncode `-1`) are not conflated with sentinel codes.
- `CliFault` — `MISSING`, `TIMEOUT`, `OS_ERROR`, `NONZERO_EXIT`.
- `classify_cli_failure(result) -> CliFault`.
- Diagnostic builders: `cli_missing_diag`, `cli_failed_diag`, `cli_timeout_diag`, `cli_os_error_diag`, plus `failure_diag()` single-dispatch entry point.

### Status mapping (mirrors `_gh.py`)

| Failure | Status |
|---|---|
| Binary missing | `UNAVAILABLE` |
| Non-zero exit | `UNAVAILABLE` |
| Timeout | `ERROR` |
| OSError | `ERROR` |

## Validation

| Command | Result |
|---|---|
| `uv run pytest` | 644 passed |
| `uv run pytest tests/test_cli_runner.py -v` | 33 passed |
| `uvx ruff check src/gate_keeper/backends/_cli.py tests/test_cli_runner.py` | All checks passed |
| `uvx pyright src/gate_keeper/backends/_cli.py tests/test_cli_runner.py` | 0 errors, 0 warnings |

## Out of scope (per issue #93)

- Tool-specific output parsing (lives in adapters).
- Refactoring `_gh.py` to use this runner — separate follow-up.
- Streaming stdout.

Closes #93.