### PR TITLE
feat(external): add Backend.EXTERNAL dispatcher and adapter contract (#92)

### DIFF
--- a/docs/backend-external.md
+++ b/docs/backend-external.md
@@ -1,0 +1,94 @@
+# `Backend.EXTERNAL` — adapter pattern for third-party tools
+
+This document is the contract for the `external` backend: a single dispatcher
+that routes rules to per-tool adapters (textlint, vale, eslint, …). Tracking
+umbrella: #80. New tools integrate as adapters here, not as new
+`Backend` enum values.
+
+## Why one backend, many adapters
+
+The `Backend` enum is a stable surface in the IR (see
+[`docs/rule-ir.md`](rule-ir.md)). Adding a new enum entry per tool would
+churn that surface for every integration and force every consumer of the IR
+to update. A single `external` backend with a per-tool adapter selector keeps
+the IR stable while letting the adapter set evolve independently.
+
+## Selecting an adapter
+
+A rule routed to this backend has:
+
+- `backend_hint = "external"`
+- `kind = "external_check"`
+- `params.tool = "<adapter id>"` — the registered name of the adapter
+  (e.g. `"textlint"`).
+
+All other `params` keys are forwarded verbatim to the adapter, which owns its
+own per-tool key set. The dispatcher does not validate adapter-specific keys.
+
+## Adapter protocol
+
+```python
+from gate_keeper.backends.external import ExternalAdapter, register
+from gate_keeper.models import Diagnostic, Rule
+from pathlib import Path
+
+class MyAdapter:
+    name = "my-tool"
+
+    def check(self, rule: Rule, target: str | Path) -> Diagnostic:
+        ...
+
+register(MyAdapter())
+```
+
+Adapters must:
+
+- expose a non-empty string `name` matching the value rules use in `params.tool`;
+- implement `check(rule, target) -> Diagnostic` and never raise — return an
+  `unavailable` Diagnostic with adapter-defined evidence on internal failure;
+- set `Diagnostic.backend = Backend.EXTERNAL` on every returned diagnostic;
+- echo `Diagnostic.rule_id`, `Diagnostic.source`, and `Diagnostic.severity`
+  from the input rule.
+
+The dispatcher additionally traps any exception an adapter raises (defence in
+depth) and converts it to `unavailable` / `adapter_error`, but adapters should
+not rely on this — surface a structured diagnostic of your own instead.
+
+## Dispatcher behaviour (fail-closed)
+
+| Condition | Status | Evidence kind |
+| --------- | ------ | ------------- |
+| `kind` is not `external_check` | `unsupported` | `backend_capability` |
+| `params.tool` missing or non-string or empty | `unavailable` | `params_error` |
+| `params.tool` is set but no adapter is registered for it | `unsupported` | `adapter_unknown` (lists currently registered adapters) |
+| Adapter raises | `unavailable` | `adapter_error` (records exception type and truncated message) |
+| Adapter returns a diagnostic | passthrough | _(adapter-defined)_ |
+
+`pass` is only ever produced by the adapter itself. Missing or
+malformed routing data never collapses to `pass`.
+
+## Registry lifecycle
+
+The registry is a process-local dict in `gate_keeper.backends.external`.
+Adapter registration is intended to happen during application setup. The
+foundation ships with **no** adapters registered — the first concrete
+adapter (textlint) lands in a follow-up issue under #80.
+
+For test isolation, the module exposes:
+
+- `clear_adapters()` — drop everything;
+- `snapshot_adapters()` / `restore_adapters(snapshot)` — save/restore around
+  a test that mutates the registry.
+
+## Out of scope for the foundation
+
+- Concrete adapter implementations (textlint, vale, …).
+- Subprocess invocation conventions, version pinning, or tool installation.
+- Classifier rules that route Markdown text to `external_check` — the
+  classifier still has no `external` branch; rules use `external_check`
+  only when authored that way (or compiled from a future adapter-aware
+  classification pass).
+- Concrete `--backend external` invocation flows; the choice is exposed
+  for symmetry with the other backends, but the foundation has no adapters
+  registered, so every rule routed there returns `unsupported` /
+  `adapter_unknown` until #80 lands at least one adapter.

--- a/docs/rule-ir.md
+++ b/docs/rule-ir.md
@@ -79,13 +79,19 @@ shape beyond those two top-level keys.
 ## Enums
 
 ### `Backend`
-`filesystem`, `github`, `llm-rubric`
+`filesystem`, `github`, `llm-rubric`, `external`
+
+The `external` backend is a single dispatcher for third-party tool adapters
+(textlint, vale, eslint, …). New tools register as adapters under this
+backend rather than minting new `Backend` enum values; see
+[`docs/backend-external.md`](backend-external.md) for the adapter contract.
 
 ### `RuleKind`
 `file_exists`, `file_absent`, `path_matches`, `text_required`, `text_forbidden`,
 `markdown_tasks_complete`, `github_pr_open`, `github_not_draft`,
 `github_labels_absent`, `github_tasks_complete`, `github_checks_success`,
-`github_threads_resolved`, `github_non_author_approval`, `semantic_rubric`
+`github_threads_resolved`, `github_non_author_approval`, `semantic_rubric`,
+`external_check`
 
 ### `Severity`
 `error`, `warning`, `advisory`
@@ -102,6 +108,7 @@ shape beyond those two top-level keys.
 | ------ | ------------ | ------- | ----- |
 | `github_labels_absent` | `labels` | `["blocked","do-not-merge","needs-decision"]` | List of blocking label names (case-insensitive). Absent key uses default list; explicit `[]` means no blocking labels → always PASS. |
 | `github_checks_success` | _(none)_ | — | Evaluates every entry in `statusCheckRollup` as required; only `SUCCESS` state/conclusion passes. Branch protection remains the authoritative control plane. |
+| `external_check` | `tool` | _(required)_ | String adapter id selecting which `external` adapter handles the rule (e.g. `"textlint"`). Missing → `unavailable` / `params_error`; unregistered → `unsupported` / `adapter_unknown`. All other `params` keys are forwarded verbatim to the adapter, which owns its own per-tool keys. See [`docs/backend-external.md`](backend-external.md). |
 
 ## `github_non_author_approval` — formal evidence and limitations
 

--- a/src/gate_keeper/backends/__init__.py
+++ b/src/gate_keeper/backends/__init__.py
@@ -4,8 +4,12 @@ Maps backend name strings to callable check functions.  Each entry wraps a
 module-level ``check(rule, target) -> Diagnostic`` function so callers can
 look up backends by name without importing modules directly.
 
-Registered names (all three must be present for `--backend` choices):
-  ``filesystem``, ``github``, ``llm-rubric``
+Registered names (all four must be present for `--backend` choices):
+  ``filesystem``, ``github``, ``llm-rubric``, ``external``
+
+The ``external`` backend is a dispatcher for third-party tool adapters
+(textlint, vale, …); see ``gate_keeper.backends.external`` and
+``docs/backend-external.md`` for the adapter contract.
 """
 
 from __future__ import annotations
@@ -14,6 +18,7 @@ from pathlib import Path
 from typing import Callable
 
 # Import backend modules — avoid circular deps by keeping these as plain imports.
+from gate_keeper.backends import external as _ext
 from gate_keeper.backends import filesystem as _fs
 from gate_keeper.backends import github as _gh
 from gate_keeper.backends import llm_rubric as _llm
@@ -24,6 +29,7 @@ _REGISTRY: dict[str, Callable[[Rule, str | Path], Diagnostic]] = {
     _fs.name: _fs.check,
     _gh.name: _gh.check,
     _llm.name: _llm.check,
+    _ext.name: _ext.check,
 }
 
 #: Sorted list of all registered backend names (used for argparse ``choices``).

--- a/src/gate_keeper/backends/external.py
+++ b/src/gate_keeper/backends/external.py
@@ -1,0 +1,212 @@
+"""Backend.EXTERNAL — adapter-pattern contract for third-party tools.
+
+Third-party validation tools (textlint, vale, eslint, …) integrate as adapters
+behind this single backend rather than minting one ``Backend`` enum value per
+tool. The umbrella tracking issue is #80; this module is the foundation only —
+no adapter implementations live here.
+
+Routing
+-------
+``validate`` reaches this module via the ``backends`` registry under the name
+``external``. The dispatcher routes a rule to the adapter named by
+``rule.params["tool"]``.
+
+Params contract
+---------------
+Rules with ``backend_hint == external`` and ``kind == external_check`` MUST set
+``params["tool"]`` to a registered adapter id (string). All other ``params``
+keys are forwarded verbatim to the adapter, which owns its own per-tool keys.
+
+Fail-closed behaviour
+---------------------
+The dispatcher never raises:
+
+- missing or non-string ``params.tool`` → ``UNAVAILABLE`` /
+  ``params_error`` evidence;
+- unknown ``params.tool`` (no adapter registered) → ``UNSUPPORTED`` /
+  ``adapter_unknown`` evidence (lists currently registered adapters);
+- adapter raises → ``UNAVAILABLE`` / ``adapter_error`` evidence (never
+  surfaces ``PASS`` or crashes the orchestrator);
+- a rule whose ``kind`` is not ``external_check`` → ``UNSUPPORTED`` /
+  ``backend_capability`` evidence, mirroring the filesystem backend.
+
+The registry is process-local and intentionally empty by default. Tests must
+restore the registry they touch (use ``snapshot_adapters`` /
+``restore_adapters`` or ``clear_adapters``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from gate_keeper.models import (
+    Backend,
+    Diagnostic,
+    Evidence,
+    Rule,
+    RuleKind,
+    Status,
+)
+
+name = "external"
+
+
+@runtime_checkable
+class ExternalAdapter(Protocol):
+    """Protocol every external-tool adapter must satisfy.
+
+    Implementations must never raise: any unexpected error should be returned
+    as an ``UNAVAILABLE`` ``Diagnostic`` with ``adapter_error`` evidence so the
+    overall report stays well-formed. The dispatcher will additionally trap
+    raised exceptions as a defence-in-depth measure, but adapters should still
+    handle their own errors.
+    """
+
+    name: str
+
+    def check(self, rule: Rule, target: str | Path) -> Diagnostic:
+        """Evaluate *rule* against *target* and return a Diagnostic."""
+        ...
+
+
+_ADAPTERS: dict[str, ExternalAdapter] = {}
+
+
+def register(adapter: ExternalAdapter) -> None:
+    """Register *adapter* under ``adapter.name``.
+
+    Raises ``ValueError`` if the name is empty or already registered. This is a
+    programmer-error path that surfaces during application setup, not during
+    rule evaluation, so raising here is safe.
+    """
+    if not isinstance(adapter.name, str) or not adapter.name:
+        raise ValueError("ExternalAdapter.name must be a non-empty string")
+    if adapter.name in _ADAPTERS:
+        raise ValueError(f"external adapter {adapter.name!r} is already registered")
+    _ADAPTERS[adapter.name] = adapter
+
+
+def unregister(adapter_name: str) -> None:
+    """Remove the adapter registered under *adapter_name* (no-op if absent)."""
+    _ADAPTERS.pop(adapter_name, None)
+
+
+def clear_adapters() -> None:
+    """Drop every registered adapter. Intended for test isolation."""
+    _ADAPTERS.clear()
+
+
+def adapter_names() -> list[str]:
+    """Return a sorted snapshot of currently registered adapter ids."""
+    return sorted(_ADAPTERS)
+
+
+def snapshot_adapters() -> dict[str, ExternalAdapter]:
+    """Return a shallow copy of the current registry (for test save/restore)."""
+    return dict(_ADAPTERS)
+
+
+def restore_adapters(snapshot: dict[str, ExternalAdapter]) -> None:
+    """Replace the registry with *snapshot* (intended for test teardown)."""
+    _ADAPTERS.clear()
+    _ADAPTERS.update(snapshot)
+
+
+def _diag(
+    rule: Rule,
+    status: Status,
+    message: str,
+    evidence: list[Evidence],
+    remediation: str | None = None,
+) -> Diagnostic:
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=Backend.EXTERNAL,
+        status=status,
+        severity=rule.severity,
+        message=message,
+        evidence=evidence,
+        remediation=remediation,
+    )
+
+
+def check(rule: Rule, target: str | Path) -> Diagnostic:
+    """Dispatch *rule* to the adapter named by ``rule.params['tool']``.
+
+    See module docstring for the full fail-closed contract.
+    """
+    if rule.kind is not RuleKind.EXTERNAL_CHECK:
+        return _diag(
+            rule,
+            Status.UNSUPPORTED,
+            f"rule kind {rule.kind.value!r} is not supported by the external backend",
+            [Evidence(kind="backend_capability", data={"backend": name, "kind": rule.kind.value})],
+        )
+
+    tool = rule.params.get("tool")
+    if not isinstance(tool, str) or not tool:
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            "params.tool is required for external_check but was not provided",
+            [Evidence(kind="params_error", data={"missing": "tool"})],
+            remediation=(
+                "Set params.tool to a registered external adapter id. See "
+                "docs/backend-external.md for the contract."
+            ),
+        )
+
+    adapter = _ADAPTERS.get(tool)
+    if adapter is None:
+        return _diag(
+            rule,
+            Status.UNSUPPORTED,
+            f"no external adapter registered for tool {tool!r}",
+            [
+                Evidence(
+                    kind="adapter_unknown",
+                    data={"tool": tool, "registered": adapter_names()},
+                )
+            ],
+            remediation=(
+                "Register an adapter for this tool before validating, or remove the rule. "
+                "See docs/backend-external.md."
+            ),
+        )
+
+    try:
+        return adapter.check(rule, target)
+    except Exception as exc:  # noqa: BLE001 — fail-closed: never let adapter errors crash validation
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            f"external adapter {tool!r} raised; treating as unavailable",
+            [
+                Evidence(
+                    kind="adapter_error",
+                    data={
+                        "tool": tool,
+                        "type": type(exc).__name__,
+                        "message": str(exc)[:500],
+                    },
+                )
+            ],
+            remediation=(
+                "Investigate the adapter exception (see evidence) and rerun once the adapter is healthy."
+            ),
+        )
+
+
+__all__ = [
+    "ExternalAdapter",
+    "adapter_names",
+    "check",
+    "clear_adapters",
+    "name",
+    "register",
+    "restore_adapters",
+    "snapshot_adapters",
+    "unregister",
+]

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -8,7 +8,7 @@ from gate_keeper import __version__
 from gate_keeper.diagnostics import EXIT_OK, EXIT_USAGE
 
 # Backend choices exposed by the registry (always includes auto).
-_BACKEND_CHOICES = ["auto", "filesystem", "github", "llm-rubric"]
+_BACKEND_CHOICES = ["auto", "filesystem", "github", "llm-rubric", "external"]
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/src/gate_keeper/models.py
+++ b/src/gate_keeper/models.py
@@ -16,6 +16,7 @@ class Backend(str, enum.Enum):
     FILESYSTEM = "filesystem"
     GITHUB = "github"
     LLM_RUBRIC = "llm-rubric"
+    EXTERNAL = "external"
 
 
 class Status(str, enum.Enum):
@@ -53,6 +54,7 @@ class RuleKind(str, enum.Enum):
     GITHUB_THREADS_RESOLVED = "github_threads_resolved"
     GITHUB_NON_AUTHOR_APPROVAL = "github_non_author_approval"
     SEMANTIC_RUBRIC = "semantic_rubric"
+    EXTERNAL_CHECK = "external_check"
 
 
 def _require_keys(

--- a/tests/test_external_backend.py
+++ b/tests/test_external_backend.py
@@ -1,0 +1,249 @@
+"""Foundation tests for ``Backend.EXTERNAL`` (issue #92).
+
+These tests pin the dispatcher contract documented in
+``docs/backend-external.md``: how the backend reacts when ``params.tool`` is
+missing, points at an unknown adapter, points at a registered adapter, or when
+the adapter raises. They do not exercise any concrete adapter — that lives in
+follow-ups under umbrella #80.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gate_keeper import backends as _registry
+from gate_keeper.backends import external
+from gate_keeper.models import (
+    Backend,
+    Confidence,
+    Diagnostic,
+    Evidence,
+    Rule,
+    RuleKind,
+    Severity,
+    SourceLocation,
+    Status,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    """Snapshot and restore the adapter registry around every test."""
+    snapshot = external.snapshot_adapters()
+    external.clear_adapters()
+    try:
+        yield
+    finally:
+        external.restore_adapters(snapshot)
+
+
+def _rule(kind: RuleKind = RuleKind.EXTERNAL_CHECK, **params) -> Rule:
+    return Rule(
+        id="test-rule",
+        title="Test rule",
+        source=SourceLocation(path="test.md", line=1),
+        text="test rule text",
+        kind=kind,
+        severity=Severity.ERROR,
+        backend_hint=Backend.EXTERNAL,
+        confidence=Confidence.HIGH,
+        params=dict(params),
+    )
+
+
+class _PassingAdapter:
+    """Minimal adapter that returns a PASS diagnostic with adapter-named evidence."""
+
+    name = "fake-tool"
+
+    def check(self, rule: Rule, target: str | Path) -> Diagnostic:
+        return Diagnostic(
+            rule_id=rule.id,
+            source=rule.source,
+            backend=Backend.EXTERNAL,
+            status=Status.PASS,
+            severity=rule.severity,
+            message=f"{self.name} ok",
+            evidence=[Evidence(kind="fake_tool_run", data={"target": str(target)})],
+        )
+
+
+class _FailingAdapter:
+    name = "fail-tool"
+
+    def check(self, rule: Rule, target: str | Path) -> Diagnostic:
+        return Diagnostic(
+            rule_id=rule.id,
+            source=rule.source,
+            backend=Backend.EXTERNAL,
+            status=Status.FAIL,
+            severity=rule.severity,
+            message=f"{self.name} reported a violation",
+            evidence=[Evidence(kind="fake_tool_run", data={"target": str(target)})],
+            remediation="fix the violation",
+        )
+
+
+class _RaisingAdapter:
+    name = "boom-tool"
+
+    def check(self, rule: Rule, target: str | Path) -> Diagnostic:
+        raise RuntimeError("adapter exploded")
+
+
+# ---------------------------------------------------------------------------
+# Registry behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_registry_starts_empty(self):
+        assert external.adapter_names() == []
+
+    def test_register_adds_adapter(self):
+        external.register(_PassingAdapter())
+        assert external.adapter_names() == ["fake-tool"]
+
+    def test_register_rejects_duplicate_name(self):
+        external.register(_PassingAdapter())
+        with pytest.raises(ValueError, match="already registered"):
+            external.register(_PassingAdapter())
+
+    def test_register_rejects_empty_name(self):
+        class _Bad:
+            name = ""
+
+            def check(self, rule, target):
+                raise AssertionError("should not be called")
+
+        with pytest.raises(ValueError, match="non-empty string"):
+            external.register(_Bad())  # type: ignore[arg-type]
+
+    def test_unregister_is_idempotent(self):
+        external.register(_PassingAdapter())
+        external.unregister("fake-tool")
+        external.unregister("fake-tool")  # second call is a no-op
+        assert external.adapter_names() == []
+
+    def test_clear_adapters_drops_everything(self):
+        external.register(_PassingAdapter())
+        external.register(_FailingAdapter())
+        external.clear_adapters()
+        assert external.adapter_names() == []
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher behaviour (fail-closed contract)
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcher:
+    def test_unsupported_kind_is_unsupported(self):
+        rule = _rule(kind=RuleKind.FILE_EXISTS, tool="fake-tool")
+        diag = external.check(rule, "irrelevant")
+        assert diag.status is Status.UNSUPPORTED
+        assert diag.backend is Backend.EXTERNAL
+        assert diag.evidence[0].kind == "backend_capability"
+        assert diag.evidence[0].data == {"backend": "external", "kind": "file_exists"}
+
+    def test_missing_tool_is_unavailable(self):
+        diag = external.check(_rule(), "irrelevant")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.backend is Backend.EXTERNAL
+        assert diag.evidence[0].kind == "params_error"
+        assert diag.evidence[0].data == {"missing": "tool"}
+        assert diag.remediation is not None  # contract: explain how to fix
+
+    @pytest.mark.parametrize("bad", [None, "", 0, [], {}, 42])
+    def test_non_string_or_empty_tool_is_unavailable(self, bad):
+        rule = _rule(tool=bad)
+        diag = external.check(rule, "irrelevant")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "params_error"
+
+    def test_unknown_tool_is_unsupported_and_lists_registered(self):
+        external.register(_PassingAdapter())
+        rule = _rule(tool="not-registered")
+        diag = external.check(rule, "irrelevant")
+        assert diag.status is Status.UNSUPPORTED
+        assert diag.backend is Backend.EXTERNAL
+        assert diag.evidence[0].kind == "adapter_unknown"
+        assert diag.evidence[0].data["tool"] == "not-registered"
+        assert diag.evidence[0].data["registered"] == ["fake-tool"]
+
+    def test_dispatch_to_registered_adapter_returns_adapter_diagnostic(self):
+        external.register(_PassingAdapter())
+        rule = _rule(tool="fake-tool")
+        diag = external.check(rule, "some/target")
+        assert diag.status is Status.PASS
+        assert diag.backend is Backend.EXTERNAL
+        assert diag.rule_id == rule.id
+        assert diag.source == rule.source
+        assert diag.severity is Severity.ERROR
+        assert diag.evidence[0].kind == "fake_tool_run"
+        assert diag.evidence[0].data == {"target": "some/target"}
+
+    def test_failing_adapter_passthrough(self):
+        external.register(_FailingAdapter())
+        rule = _rule(tool="fail-tool")
+        diag = external.check(rule, "some/target")
+        assert diag.status is Status.FAIL
+        assert diag.remediation == "fix the violation"
+
+    def test_raising_adapter_is_unavailable_not_pass(self):
+        external.register(_RaisingAdapter())
+        rule = _rule(tool="boom-tool")
+        diag = external.check(rule, "some/target")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.backend is Backend.EXTERNAL
+        assert diag.evidence[0].kind == "adapter_error"
+        assert diag.evidence[0].data["tool"] == "boom-tool"
+        assert diag.evidence[0].data["type"] == "RuntimeError"
+        assert "exploded" in diag.evidence[0].data["message"]
+
+    def test_dispatcher_does_not_validate_adapter_specific_params(self):
+        """Per-tool params are forwarded; the dispatcher only owns ``tool``."""
+        captured: dict[str, object] = {}
+
+        class _CapturingAdapter:
+            name = "capture"
+
+            def check(self, rule: Rule, target: str | Path) -> Diagnostic:
+                captured["params"] = dict(rule.params)
+                return Diagnostic(
+                    rule_id=rule.id,
+                    source=rule.source,
+                    backend=Backend.EXTERNAL,
+                    status=Status.PASS,
+                    severity=rule.severity,
+                    message="ok",
+                    evidence=[Evidence(kind="capture", data={})],
+                )
+
+        external.register(_CapturingAdapter())
+        rule = _rule(tool="capture", config_path="cfg.json", strict=True)
+        external.check(rule, "x")
+        assert captured["params"] == {"tool": "capture", "config_path": "cfg.json", "strict": True}
+
+
+# ---------------------------------------------------------------------------
+# Backend registry integration
+# ---------------------------------------------------------------------------
+
+
+class TestBackendRegistryIntegration:
+    def test_external_is_registered_under_enum_value(self):
+        assert _registry.is_registered(Backend.EXTERNAL.value)
+
+    def test_registry_get_returns_dispatcher(self):
+        fn = _registry.get(Backend.EXTERNAL.value)
+        assert fn is external.check
+
+    def test_backend_names_include_external(self):
+        assert "external" in _registry.BACKEND_NAMES

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,7 +23,7 @@ FIXTURES = Path(__file__).parent / "fixtures" / "ir"
 
 
 def test_backend_members():
-    assert {m.value for m in Backend} == {"filesystem", "github", "llm-rubric"}
+    assert {m.value for m in Backend} == {"filesystem", "github", "llm-rubric", "external"}
 
 
 def test_status_members():
@@ -60,6 +60,7 @@ def test_rule_kind_members():
         "github_threads_resolved",
         "github_non_author_approval",
         "semantic_rubric",
+        "external_check",
     }
 
 


### PR DESCRIPTION
Closes #92

## Summary

Foundation for the textlint umbrella (#80, layer Y1). Introduces a single `Backend.EXTERNAL` plus `RuleKind.EXTERNAL_CHECK` that routes rules to per-tool adapters via `Rule.params[\"tool\"]`. New third-party tools (textlint, vale, eslint, ...) integrate as adapters under this one backend, keeping the IR enum stable.

## In scope (matches issue #92)

- IR additions: `Backend.EXTERNAL` and `RuleKind.EXTERNAL_CHECK` (`src/gate_keeper/models.py`, `tests/test_models.py`).
- Adapter `Protocol` + process-local registry with `register` / `unregister` / `clear_adapters` / `snapshot_adapters` / `restore_adapters` (`src/gate_keeper/backends/external.py`).
- Fail-closed dispatcher:
  - non-`external_check` kind → `UNSUPPORTED` / `backend_capability`
  - missing or non-string `params.tool` → `UNAVAILABLE` / `params_error`
  - unknown tool → `UNSUPPORTED` / `adapter_unknown` (lists registered adapters)
  - adapter raises → `UNAVAILABLE` / `adapter_error` (defence-in-depth; `PASS` only ever flows from an adapter)
- Backend registry wiring + CLI `--backend external` choice (`src/gate_keeper/backends/__init__.py`, `src/gate_keeper/cli.py`).
- ADR / contract doc (`docs/backend-external.md`) and IR-doc cross-references (`docs/rule-ir.md`).
- 22 new tests covering registry lifecycle, dispatcher fail-closed paths, params passthrough, and backend-registry integration (`tests/test_external_backend.py`).

## Out of scope (deferred to follow-ups under #80)

- Concrete adapter implementations (textlint adapter is #80-Y3).
- Subprocess runner conventions (#80-Y2).
- Classifier routing to `external_check` (rules opt in by being authored that way).
- MCP transport (deferred under D2 — see #89).

## Validation

| Command | Result |
| --- | --- |
| `uv run pytest` | 633 passed |
| `uvx ruff check .` | All checks passed |
| `uv run pyright` | 0 errors, 0 warnings, 0 informations |

## Test plan

- [x] `uv run pytest` passes (633 tests, includes 22 new external-backend tests)
- [x] `uvx ruff check .` is clean
- [x] `uv run pyright` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)