### PR TITLE
feat(llm-rubric): structured rationale schema and prompt template (#67)

### DIFF
--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -97,12 +97,35 @@ context passed to the model:
 }
 ```
 
+### Structured judgment schema (`LlmJudgment`)
+
+The model is instructed (via `RUBRIC_PROMPT_TEMPLATE`, prompt version `PROMPT_VERSION = "v1"`)
+to respond with a JSON object matching the `LlmJudgment` dataclass:
+
+```json
+{
+  "judgment":                    "pass" | "fail",
+  "primary_reason":              "<one sentence>",
+  "supporting_evidence_quotes":  ["<verbatim quote>", ...],
+  "suggested_action":            "<concrete fix>" | null
+}
+```
+
+Constraints enforced by `_parse_llm_judgment()`:
+- `judgment` must be exactly `"pass"` or `"fail"`.
+- `primary_reason` must be a non-empty string (single sentence).
+- `supporting_evidence_quotes` must contain at least one entry when `judgment` is `"fail"`; may be empty on `"pass"`.
+- `suggested_action` must be a non-empty string on `"fail"` and is coerced to `null` on `"pass"`.
+- Extra fields in the JSON response are silently ignored (forward-compatible).
+
+### Successful diagnostic shape
+
 When a provider responds successfully, the diagnostic carries:
 
 - `status`: `pass` or `fail`.
-- `message`: a one-line explanation from the model.
-- `evidence[0]`: `{ kind: "llm_judgment", data: { model, judgment, explanation } }`.
-- `remediation`: set when `status=fail`, omitted otherwise.
+- `message`: the `primary_reason` from the structured judgment.
+- `evidence[0]`: `{ kind: "llm_judgment", data: { model, prompt_version, judgment, primary_reason, supporting_evidence_quotes, suggested_action } }`.
+- `remediation`: set to `suggested_action` when `status=fail`; `null` on `pass`.
 
 ## Failure modes
 

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -11,8 +11,9 @@ rejected upstream — see hermes-engineering#149 and
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from gate_keeper.models import Backend, Diagnostic, Evidence, Rule, Status
 
@@ -25,6 +26,114 @@ OPENAI_DEFAULT_MODEL = "gpt-4o-mini"
 
 _SUPPORTED_PROVIDERS = ("anthropic", "openai")
 
+# Prompt versioning constant — referenced by issue #68 (reproducibility).
+PROMPT_VERSION = "v1"
+
+# ---------------------------------------------------------------------------
+# Structured LLM judgment schema (#67)
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class LlmJudgment:
+    """Structured output schema for a single LLM rubric evaluation.
+
+    Fields
+    ------
+    judgment:
+        ``"pass"`` or ``"fail"``.
+    primary_reason:
+        One-sentence summary of why the target passed or failed.
+    supporting_evidence_quotes:
+        List of verbatim quotes from the target supporting the judgment.
+        Required (non-empty) on fail; optional (may be empty) on pass.
+    suggested_action:
+        Concrete remediation step. Required on fail; MUST be ``None`` on pass.
+    """
+
+    judgment: Literal["pass", "fail"]
+    primary_reason: str
+    supporting_evidence_quotes: list[str]
+    suggested_action: str | None
+
+
+@dataclass
+class LlmJudgmentParseError:
+    """Carries structured parse-failure information for #71 (failure rendering).
+
+    Attributes
+    ----------
+    failure_mode:
+        Short tag, e.g. ``"invalid_json"``, ``"missing_field"``,
+        ``"invalid_judgment_value"``.
+    detail:
+        Human-readable explanation of the failure.
+    raw_response_excerpt:
+        First ~200 characters of the raw model response.
+    """
+
+    failure_mode: str
+    detail: str
+    raw_response_excerpt: str
+
+
+# ---------------------------------------------------------------------------
+# Prompt template (#67)
+# ---------------------------------------------------------------------------
+
+RUBRIC_PROMPT_TEMPLATE = """\
+You are a rubric evaluator. Your sole task is to judge whether the target \
+artifact satisfies the given rule.
+
+## Rule
+
+{rule_text}
+
+## Target reference
+
+{target}
+
+## Instructions
+
+1. Read the rule carefully. It describes a quality requirement.
+2. Judge whether the target (identified by the reference above) satisfies it.
+3. If you cannot read the target's content directly, judge from the reference alone.
+4. Respond with **only** a JSON object that matches the schema below — no prose outside the JSON.
+
+## Required response schema
+
+{{
+  "judgment": "pass" | "fail",
+  "primary_reason": "<one sentence>",
+  "supporting_evidence_quotes": ["<verbatim quote>", ...],
+  "suggested_action": "<concrete step to fix>" | null
+}}
+
+Constraints:
+- `judgment` must be exactly `"pass"` or `"fail"`.
+- `primary_reason` must be a single sentence (no newlines).
+- `supporting_evidence_quotes` must contain at least one entry when `judgment` is `"fail"`.
+- `suggested_action` must be a non-empty string when `judgment` is `"fail"`;
+  must be `null` when `judgment` is `"pass"`.
+
+## Example of a valid response
+
+{{
+  "judgment": "fail",
+  "primary_reason": "The README lacks a usage section.",
+  "supporting_evidence_quotes": ["README.md: no '## Usage' heading found"],
+  "suggested_action": "Add a '## Usage' section with at least one code example."
+}}
+"""
+
+RUBRIC_SYSTEM_PROMPT = (
+    "You are a rubric evaluator applying a single quality rule to one artifact. "
+    "Respond with ONLY a JSON object matching the required schema. No prose outside the JSON."
+)
+
+
+# ---------------------------------------------------------------------------
+# dotenv loader
+# ---------------------------------------------------------------------------
 
 def _load_env_file(path: Path = DOTENV_PATH) -> dict[str, str]:
     """Load the per-project dotenv file without mutating ``os.environ``.
@@ -50,7 +159,15 @@ def _is_configured() -> bool:
     return bool(env.get(key_var))
 
 
+# ---------------------------------------------------------------------------
+# Rubric input builder
+# ---------------------------------------------------------------------------
+
 def _build_rubric_input(rule: Rule, target: str | Path) -> dict[str, Any]:
+    """Return the context dict passed to the model and recorded in evidence.
+
+    Keys: ``rule_text``, ``rule_kind``, ``target``.
+    """
     return {
         "rule_text": rule.text,
         "rule_kind": rule.kind.value,
@@ -59,20 +176,14 @@ def _build_rubric_input(rule: Rule, target: str | Path) -> dict[str, Any]:
 
 
 def _build_prompt(rule: Rule, target: str | Path) -> tuple[str, str]:
-    system = (
-        "You are a reviewer applying a single rule to one artifact. "
-        'Reply with ONLY a compact JSON object: {"judgment": "pass" | "fail", '
-        '"explanation": "<one-line summary, no newlines>"}. '
-        "No prose outside the JSON."
-    )
-    user = (
-        f"Rule:\n{rule.text}\n\n"
-        f"Target reference (path or PR id):\n{target}\n\n"
-        "Judge whether the target satisfies the rule. "
-        "If you cannot read the target's content directly, judge from the reference alone."
-    )
+    system = RUBRIC_SYSTEM_PROMPT
+    user = RUBRIC_PROMPT_TEMPLATE.format(rule_text=rule.text, target=str(target))
     return system, user
 
+
+# ---------------------------------------------------------------------------
+# Provider call helpers
+# ---------------------------------------------------------------------------
 
 def _call_anthropic(api_key: str, system: str, user: str, model: str) -> str:
     from anthropic import Anthropic
@@ -80,7 +191,7 @@ def _call_anthropic(api_key: str, system: str, user: str, model: str) -> str:
     client = Anthropic(api_key=api_key)
     msg = client.messages.create(
         model=model,
-        max_tokens=400,
+        max_tokens=600,
         system=system,
         messages=[{"role": "user", "content": user}],
     )
@@ -98,7 +209,7 @@ def _call_openai(api_key: str, system: str, user: str, model: str) -> str:
     client = OpenAI(api_key=api_key)
     resp = client.chat.completions.create(
         model=model,
-        max_completion_tokens=400,
+        max_completion_tokens=600,
         messages=[
             {"role": "system", "content": system},
             {"role": "user", "content": user},
@@ -107,22 +218,123 @@ def _call_openai(api_key: str, system: str, user: str, model: str) -> str:
     return resp.choices[0].message.content or ""
 
 
-def _parse_response(text: str) -> tuple[str, str]:
-    """Parse ``{"judgment", "explanation"}`` from model output. Raises ``ValueError``."""
+# ---------------------------------------------------------------------------
+# Parser / validator (#67)
+# ---------------------------------------------------------------------------
+
+def _parse_llm_judgment(text: str) -> LlmJudgment | LlmJudgmentParseError:
+    """Parse and validate a raw model response string into ``LlmJudgment``.
+
+    Returns ``LlmJudgmentParseError`` (never raises) for any failure.
+    Extra fields in the JSON are silently ignored.
+    """
+    excerpt = text[:200]
+
+    if not text.strip():
+        return LlmJudgmentParseError(
+            failure_mode="empty_response",
+            detail="Model returned an empty string.",
+            raw_response_excerpt=excerpt,
+        )
+
     try:
         obj = json.loads(text)
     except json.JSONDecodeError as exc:
-        raise ValueError(f"response is not valid JSON: {exc}") from exc
-    if not isinstance(obj, dict):
-        raise ValueError("response is not a JSON object")
-    judgment = obj.get("judgment")
-    explanation = obj.get("explanation")
-    if judgment not in ("pass", "fail"):
-        raise ValueError(f"judgment must be 'pass' or 'fail', got {judgment!r}")
-    if not isinstance(explanation, str) or not explanation:
-        raise ValueError("explanation must be a non-empty string")
-    return judgment, explanation
+        return LlmJudgmentParseError(
+            failure_mode="invalid_json",
+            detail=f"Response is not valid JSON: {exc}",
+            raw_response_excerpt=excerpt,
+        )
 
+    if not isinstance(obj, dict):
+        return LlmJudgmentParseError(
+            failure_mode="invalid_json",
+            detail="Response is not a JSON object.",
+            raw_response_excerpt=excerpt,
+        )
+
+    # Required fields
+    for field in ("judgment", "primary_reason", "supporting_evidence_quotes"):
+        if field not in obj:
+            return LlmJudgmentParseError(
+                failure_mode="missing_field",
+                detail=f"Required field '{field}' is absent.",
+                raw_response_excerpt=excerpt,
+            )
+
+    judgment = obj["judgment"]
+    if judgment not in ("pass", "fail"):
+        return LlmJudgmentParseError(
+            failure_mode="invalid_judgment_value",
+            detail=f"judgment must be 'pass' or 'fail', got {judgment!r}.",
+            raw_response_excerpt=excerpt,
+        )
+
+    primary_reason = obj["primary_reason"]
+    if not isinstance(primary_reason, str) or not primary_reason.strip():
+        return LlmJudgmentParseError(
+            failure_mode="missing_field",
+            detail="primary_reason must be a non-empty string.",
+            raw_response_excerpt=excerpt,
+        )
+
+    quotes = obj["supporting_evidence_quotes"]
+    if not isinstance(quotes, list):
+        return LlmJudgmentParseError(
+            failure_mode="missing_field",
+            detail="supporting_evidence_quotes must be a list.",
+            raw_response_excerpt=excerpt,
+        )
+
+    if judgment == "fail" and len(quotes) == 0:
+        return LlmJudgmentParseError(
+            failure_mode="missing_field",
+            detail="supporting_evidence_quotes must contain at least one entry when judgment is 'fail'.",
+            raw_response_excerpt=excerpt,
+        )
+
+    suggested_action = obj.get("suggested_action")
+    if judgment == "fail":
+        if not isinstance(suggested_action, str) or not suggested_action.strip():
+            return LlmJudgmentParseError(
+                failure_mode="missing_field",
+                detail="suggested_action must be a non-empty string when judgment is 'fail'.",
+                raw_response_excerpt=excerpt,
+            )
+    else:
+        # pass judgment — suggested_action must be None/absent
+        suggested_action = None
+
+    return LlmJudgment(
+        judgment=judgment,
+        primary_reason=primary_reason,
+        supporting_evidence_quotes=quotes,
+        suggested_action=suggested_action,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Legacy thin wrapper — kept for backward compat with existing tests that
+# call _parse_response directly.  New code should call _parse_llm_judgment.
+# ---------------------------------------------------------------------------
+
+def _parse_response(text: str) -> tuple[str, str]:
+    """Parse ``{"judgment", ...}`` from model output. Raises ``ValueError``.
+
+    .. deprecated::
+        Use ``_parse_llm_judgment`` for structured output.  This shim is
+        retained so existing callers that expect ``(judgment, primary_reason)``
+        continue to work.
+    """
+    result = _parse_llm_judgment(text)
+    if isinstance(result, LlmJudgmentParseError):
+        raise ValueError(result.detail)
+    return result.judgment, result.primary_reason
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic constructors — #51 contract preserved byte-for-byte
+# ---------------------------------------------------------------------------
 
 def _unavailable_unconfigured(rule: Rule, rubric_input: dict[str, Any]) -> Diagnostic:
     return Diagnostic(
@@ -172,15 +384,31 @@ def _unavailable_provider_error(
     )
 
 
+# ---------------------------------------------------------------------------
+# Public entrypoint
+# ---------------------------------------------------------------------------
+
 def check(rule: Rule, target: str | Path) -> Diagnostic:
     """Evaluate a semantic-rubric rule against *target*.
 
     When no provider is configured (or the env file is absent), returns
     ``UNAVAILABLE`` with ``provider_unconfigured`` evidence. When a provider is
     configured, dispatches to the configured provider and maps the response to
-    ``pass``/``fail`` with ``llm_judgment`` evidence. Provider errors and
-    unparseable responses map to ``UNAVAILABLE`` with ``provider_error``
-    evidence — never to a crash, ``pass``, or ``fail``.
+    ``pass``/``fail`` with structured ``llm_judgment`` evidence (see
+    ``LlmJudgment``). Provider errors and unparseable responses map to
+    ``UNAVAILABLE`` with ``provider_error`` evidence — never to a crash,
+    ``pass``, or ``fail``.
+
+    On success the ``evidence[0].data`` dict contains:
+
+    - ``model``: the model identifier used.
+    - ``prompt_version``: ``PROMPT_VERSION`` constant (for #68 reproducibility).
+    - ``judgment``: ``"pass"`` or ``"fail"``.
+    - ``primary_reason``: one-sentence summary.
+    - ``supporting_evidence_quotes``: list of verbatim quotes.
+    - ``suggested_action``: remediation string (fail only) or ``None`` (pass).
+
+    ``Diagnostic.remediation`` is set to ``suggested_action`` on fail.
     """
     rubric_input = _build_rubric_input(rule, target)
 
@@ -201,15 +429,23 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
     except Exception as exc:  # noqa: BLE001 — fail-closed: any provider error → unavailable
         return _unavailable_provider_error(rule, rubric_input, provider, type(exc).__name__, str(exc))
 
-    try:
-        judgment, explanation = _parse_response(response_text)
-    except ValueError as exc:
-        return _unavailable_provider_error(rule, rubric_input, provider, "unparseable_response", str(exc))
+    parsed = _parse_llm_judgment(response_text)
+    if isinstance(parsed, LlmJudgmentParseError):
+        return _unavailable_provider_error(
+            rule, rubric_input, provider, "unparseable_response", parsed.detail
+        )
 
-    status = Status.PASS if judgment == "pass" else Status.FAIL
+    status = Status.PASS if parsed.judgment == "pass" else Status.FAIL
     evidence = Evidence(
         kind="llm_judgment",
-        data={"model": model, "judgment": judgment, "explanation": explanation},
+        data={
+            "model": model,
+            "prompt_version": PROMPT_VERSION,
+            "judgment": parsed.judgment,
+            "primary_reason": parsed.primary_reason,
+            "supporting_evidence_quotes": parsed.supporting_evidence_quotes,
+            "suggested_action": parsed.suggested_action,
+        },
     )
     if status is Status.PASS:
         return Diagnostic(
@@ -218,7 +454,7 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
             backend=Backend.LLM_RUBRIC,
             status=status,
             severity=rule.severity,
-            message=explanation,
+            message=parsed.primary_reason,
             evidence=[evidence],
         )
     return Diagnostic(
@@ -227,10 +463,7 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
         backend=Backend.LLM_RUBRIC,
         status=status,
         severity=rule.severity,
-        message=explanation,
+        message=parsed.primary_reason,
         evidence=[evidence],
-        remediation=(
-            "The semantic rubric judged the target as failing; review the "
-            "explanation and update the artifact to satisfy the rule's intent."
-        ),
+        remediation=parsed.suggested_action,
     )

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -33,6 +33,7 @@ PROMPT_VERSION = "v1"
 # Structured LLM judgment schema (#67)
 # ---------------------------------------------------------------------------
 
+
 @dataclass(frozen=True)
 class LlmJudgment:
     """Structured output schema for a single LLM rubric evaluation.
@@ -135,6 +136,7 @@ RUBRIC_SYSTEM_PROMPT = (
 # dotenv loader
 # ---------------------------------------------------------------------------
 
+
 def _load_env_file(path: Path = DOTENV_PATH) -> dict[str, str]:
     """Load the per-project dotenv file without mutating ``os.environ``.
 
@@ -163,6 +165,7 @@ def _is_configured() -> bool:
 # Rubric input builder
 # ---------------------------------------------------------------------------
 
+
 def _build_rubric_input(rule: Rule, target: str | Path) -> dict[str, Any]:
     """Return the context dict passed to the model and recorded in evidence.
 
@@ -184,6 +187,7 @@ def _build_prompt(rule: Rule, target: str | Path) -> tuple[str, str]:
 # ---------------------------------------------------------------------------
 # Provider call helpers
 # ---------------------------------------------------------------------------
+
 
 def _call_anthropic(api_key: str, system: str, user: str, model: str) -> str:
     from anthropic import Anthropic
@@ -221,6 +225,7 @@ def _call_openai(api_key: str, system: str, user: str, model: str) -> str:
 # ---------------------------------------------------------------------------
 # Parser / validator (#67)
 # ---------------------------------------------------------------------------
+
 
 def _parse_llm_judgment(text: str) -> LlmJudgment | LlmJudgmentParseError:
     """Parse and validate a raw model response string into ``LlmJudgment``.
@@ -318,6 +323,7 @@ def _parse_llm_judgment(text: str) -> LlmJudgment | LlmJudgmentParseError:
 # call _parse_response directly.  New code should call _parse_llm_judgment.
 # ---------------------------------------------------------------------------
 
+
 def _parse_response(text: str) -> tuple[str, str]:
     """Parse ``{"judgment", ...}`` from model output. Raises ``ValueError``.
 
@@ -335,6 +341,7 @@ def _parse_response(text: str) -> tuple[str, str]:
 # ---------------------------------------------------------------------------
 # Diagnostic constructors — #51 contract preserved byte-for-byte
 # ---------------------------------------------------------------------------
+
 
 def _unavailable_unconfigured(rule: Rule, rubric_input: dict[str, Any]) -> Diagnostic:
     return Diagnostic(
@@ -387,6 +394,7 @@ def _unavailable_provider_error(
 # ---------------------------------------------------------------------------
 # Public entrypoint
 # ---------------------------------------------------------------------------
+
 
 def check(rule: Rule, target: str | Path) -> Diagnostic:
     """Evaluate a semantic-rubric rule against *target*.

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -70,6 +70,7 @@ def _semantic_rule(kind: RuleKind = RuleKind.SEMANTIC_RUBRIC) -> Rule:
 # Unconfigured / stub path
 # ---------------------------------------------------------------------------
 
+
 class TestLlmRubricBackendStub:
     def test_check_returns_unavailable(self, tmp_path):
         rule = _semantic_rule()
@@ -155,6 +156,7 @@ class TestLlmRubricBackendStub:
 # dotenv loader
 # ---------------------------------------------------------------------------
 
+
 class TestDotenvLoader:
     def test_returns_empty_when_file_absent(self, tmp_path):
         missing = tmp_path / "no-such.env"
@@ -183,6 +185,7 @@ class TestDotenvLoader:
 # ---------------------------------------------------------------------------
 # _is_configured
 # ---------------------------------------------------------------------------
+
 
 class TestIsConfigured:
     def test_false_when_provider_missing(self, monkeypatch):
@@ -232,6 +235,7 @@ class TestIsConfigured:
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _patch_env(monkeypatch, env: dict[str, str]) -> None:
     monkeypatch.setattr(llm_backend, "_load_env_file", lambda *a, **k: env)
 
@@ -239,6 +243,7 @@ def _patch_env(monkeypatch, env: dict[str, str]) -> None:
 # ---------------------------------------------------------------------------
 # Provider dispatch — Anthropic (#67: updated to structured schema)
 # ---------------------------------------------------------------------------
+
 
 class TestProviderDispatchAnthropic:
     _ENV = {
@@ -351,6 +356,7 @@ class TestProviderDispatchAnthropic:
 # Provider dispatch — OpenAI (#67: updated to structured schema)
 # ---------------------------------------------------------------------------
 
+
 class TestProviderDispatchOpenAI:
     _ENV = {
         "GATE_KEEPER_LLM_PROVIDER": "openai",
@@ -398,6 +404,7 @@ class TestProviderDispatchOpenAI:
 # ---------------------------------------------------------------------------
 # _parse_llm_judgment — unit tests for new structured parser (#67)
 # ---------------------------------------------------------------------------
+
 
 class TestParseLlmJudgment:
     """New tests covering all acceptance-criteria cases from #67."""
@@ -552,6 +559,7 @@ class TestParseLlmJudgment:
 # _parse_response backward-compat shim (legacy tests, kept for regression)
 # ---------------------------------------------------------------------------
 
+
 class TestParseResponseDirect:
     def test_pass_with_primary_reason(self):
         judgment, reason = llm_backend._parse_response(_VALID_PASS_JSON)
@@ -575,6 +583,7 @@ class TestParseResponseDirect:
 # PROMPT_VERSION constant
 # ---------------------------------------------------------------------------
 
+
 class TestPromptVersion:
     def test_prompt_version_constant_exists(self):
         assert hasattr(llm_backend, "PROMPT_VERSION")
@@ -597,6 +606,7 @@ class TestPromptVersion:
 # ---------------------------------------------------------------------------
 # Path constants (#51 regression guard)
 # ---------------------------------------------------------------------------
+
 
 class TestPathConstants:
     def test_dotenv_path_matches_spec(self):

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -4,13 +4,19 @@ Covers both the unconfigured fallback (fail-closed ``unavailable``) and the
 configured-provider paths (``pass``, ``fail``, provider error, unparseable
 response). Provider clients and the dotenv loader are monkeypatched so no
 network call is ever made.
+
+Updated in #67 to assert on the new structured ``LlmJudgment`` evidence shape.
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+import pytest
+
 from gate_keeper.backends import llm_rubric as llm_backend
+from gate_keeper.backends.llm_rubric import LlmJudgment, LlmJudgmentParseError
 from gate_keeper.diagnostics import EXIT_FAIL, EXIT_OK, compute_exit_code
 from gate_keeper.models import (
     Backend,
@@ -22,6 +28,28 @@ from gate_keeper.models import (
     Status,
 )
 from gate_keeper.validator import validate
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_PASS_JSON = json.dumps(
+    {
+        "judgment": "pass",
+        "primary_reason": "Documentation reads clearly.",
+        "supporting_evidence_quotes": [],
+        "suggested_action": None,
+    }
+)
+
+_VALID_FAIL_JSON = json.dumps(
+    {
+        "judgment": "fail",
+        "primary_reason": "Section headings are missing.",
+        "supporting_evidence_quotes": ["README.md has no '## Usage' heading"],
+        "suggested_action": "Add a '## Usage' section with a code example.",
+    }
+)
 
 
 def _semantic_rule(kind: RuleKind = RuleKind.SEMANTIC_RUBRIC) -> Rule:
@@ -37,6 +65,10 @@ def _semantic_rule(kind: RuleKind = RuleKind.SEMANTIC_RUBRIC) -> Rule:
         params={},
     )
 
+
+# ---------------------------------------------------------------------------
+# Unconfigured / stub path
+# ---------------------------------------------------------------------------
 
 class TestLlmRubricBackendStub:
     def test_check_returns_unavailable(self, tmp_path):
@@ -119,6 +151,10 @@ class TestLlmRubricBackendStub:
         assert compute_exit_code(report.diagnostics) == EXIT_FAIL
 
 
+# ---------------------------------------------------------------------------
+# dotenv loader
+# ---------------------------------------------------------------------------
+
 class TestDotenvLoader:
     def test_returns_empty_when_file_absent(self, tmp_path):
         missing = tmp_path / "no-such.env"
@@ -143,6 +179,10 @@ class TestDotenvLoader:
         llm_backend._load_env_file(path)
         assert "GATE_KEEPER_TEST_SENTINEL" not in os.environ
 
+
+# ---------------------------------------------------------------------------
+# _is_configured
+# ---------------------------------------------------------------------------
 
 class TestIsConfigured:
     def test_false_when_provider_missing(self, monkeypatch):
@@ -188,9 +228,17 @@ class TestIsConfigured:
         assert llm_backend._is_configured() is True
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
 def _patch_env(monkeypatch, env: dict[str, str]) -> None:
     monkeypatch.setattr(llm_backend, "_load_env_file", lambda *a, **k: env)
 
+
+# ---------------------------------------------------------------------------
+# Provider dispatch — Anthropic (#67: updated to structured schema)
+# ---------------------------------------------------------------------------
 
 class TestProviderDispatchAnthropic:
     _ENV = {
@@ -203,9 +251,7 @@ class TestProviderDispatchAnthropic:
         monkeypatch.setattr(
             llm_backend,
             "_call_anthropic",
-            lambda key, system, user, model: (
-                '{"judgment": "pass", "explanation": "Documentation reads clearly."}'
-            ),
+            lambda key, system, user, model: _VALID_PASS_JSON,
         )
         diag = llm_backend.check(_semantic_rule(), tmp_path)
         assert diag.status is Status.PASS
@@ -213,7 +259,10 @@ class TestProviderDispatchAnthropic:
         assert diag.evidence[0].kind == "llm_judgment"
         assert diag.evidence[0].data["judgment"] == "pass"
         assert diag.evidence[0].data["model"] == llm_backend.ANTHROPIC_DEFAULT_MODEL
-        assert diag.evidence[0].data["explanation"] == "Documentation reads clearly."
+        assert diag.evidence[0].data["prompt_version"] == llm_backend.PROMPT_VERSION
+        assert diag.evidence[0].data["primary_reason"] == "Documentation reads clearly."
+        assert isinstance(diag.evidence[0].data["supporting_evidence_quotes"], list)
+        assert diag.evidence[0].data["suggested_action"] is None
         assert diag.remediation is None
         assert compute_exit_code([diag]) == EXIT_OK
 
@@ -222,15 +271,17 @@ class TestProviderDispatchAnthropic:
         monkeypatch.setattr(
             llm_backend,
             "_call_anthropic",
-            lambda key, system, user, model: (
-                '{"judgment": "fail", "explanation": "Section headings are missing."}'
-            ),
+            lambda key, system, user, model: _VALID_FAIL_JSON,
         )
         diag = llm_backend.check(_semantic_rule(), tmp_path)
         assert diag.status is Status.FAIL
         assert diag.evidence[0].kind == "llm_judgment"
         assert diag.evidence[0].data["judgment"] == "fail"
-        assert diag.remediation is not None
+        assert diag.evidence[0].data["primary_reason"] == "Section headings are missing."
+        assert len(diag.evidence[0].data["supporting_evidence_quotes"]) >= 1
+        assert diag.evidence[0].data["suggested_action"] == "Add a '## Usage' section with a code example."
+        # Diagnostic.remediation should be suggested_action
+        assert diag.remediation == "Add a '## Usage' section with a code example."
         assert compute_exit_code([diag]) == EXIT_FAIL
 
     def test_provider_exception_maps_to_unavailable(self, monkeypatch, tmp_path):
@@ -265,7 +316,14 @@ class TestProviderDispatchAnthropic:
         monkeypatch.setattr(
             llm_backend,
             "_call_anthropic",
-            lambda *_a, **_k: '{"judgment": "maybe", "explanation": "unsure"}',
+            lambda *_a, **_k: json.dumps(
+                {
+                    "judgment": "maybe",
+                    "primary_reason": "unsure",
+                    "supporting_evidence_quotes": [],
+                    "suggested_action": None,
+                }
+            ),
         )
         diag = llm_backend.check(_semantic_rule(), tmp_path)
         assert diag.status is Status.UNAVAILABLE
@@ -277,7 +335,7 @@ class TestProviderDispatchAnthropic:
 
         def _anthropic(*_a, **_k):
             called["anthropic"] = True
-            return '{"judgment": "pass", "explanation": "ok"}'
+            return _VALID_PASS_JSON
 
         def _openai(*_a, **_k):
             called["openai"] = True
@@ -288,6 +346,10 @@ class TestProviderDispatchAnthropic:
         llm_backend.check(_semantic_rule(), tmp_path)
         assert called == {"anthropic": True, "openai": False}
 
+
+# ---------------------------------------------------------------------------
+# Provider dispatch — OpenAI (#67: updated to structured schema)
+# ---------------------------------------------------------------------------
 
 class TestProviderDispatchOpenAI:
     _ENV = {
@@ -300,23 +362,25 @@ class TestProviderDispatchOpenAI:
         monkeypatch.setattr(
             llm_backend,
             "_call_openai",
-            lambda *_a, **_k: '{"judgment": "pass", "explanation": "Reads clearly."}',
+            lambda *_a, **_k: _VALID_PASS_JSON,
         )
         diag = llm_backend.check(_semantic_rule(), tmp_path)
         assert diag.status is Status.PASS
         assert diag.evidence[0].data["model"] == llm_backend.OPENAI_DEFAULT_MODEL
         assert diag.evidence[0].data["judgment"] == "pass"
+        assert diag.evidence[0].data["prompt_version"] == llm_backend.PROMPT_VERSION
 
     def test_fail_response_maps_to_fail(self, monkeypatch, tmp_path):
         _patch_env(monkeypatch, self._ENV)
         monkeypatch.setattr(
             llm_backend,
             "_call_openai",
-            lambda *_a, **_k: '{"judgment": "fail", "explanation": "Missing sections."}',
+            lambda *_a, **_k: _VALID_FAIL_JSON,
         )
         diag = llm_backend.check(_semantic_rule(), tmp_path)
         assert diag.status is Status.FAIL
         assert diag.evidence[0].data["model"] == llm_backend.OPENAI_DEFAULT_MODEL
+        assert diag.evidence[0].data["judgment"] == "fail"
 
     def test_provider_exception_maps_to_unavailable(self, monkeypatch, tmp_path):
         _patch_env(monkeypatch, self._ENV)
@@ -331,30 +395,208 @@ class TestProviderDispatchOpenAI:
         assert diag.evidence[0].data["failure_mode"] == "TimeoutError"
 
 
+# ---------------------------------------------------------------------------
+# _parse_llm_judgment — unit tests for new structured parser (#67)
+# ---------------------------------------------------------------------------
+
+class TestParseLlmJudgment:
+    """New tests covering all acceptance-criteria cases from #67."""
+
+    def test_valid_pass(self):
+        result = llm_backend._parse_llm_judgment(_VALID_PASS_JSON)
+        assert isinstance(result, LlmJudgment)
+        assert result.judgment == "pass"
+        assert result.primary_reason == "Documentation reads clearly."
+        assert result.supporting_evidence_quotes == []
+        assert result.suggested_action is None
+
+    def test_valid_fail_with_quotes_and_action(self):
+        result = llm_backend._parse_llm_judgment(_VALID_FAIL_JSON)
+        assert isinstance(result, LlmJudgment)
+        assert result.judgment == "fail"
+        assert result.primary_reason == "Section headings are missing."
+        assert len(result.supporting_evidence_quotes) >= 1
+        assert result.suggested_action == "Add a '## Usage' section with a code example."
+
+    def test_missing_required_field_judgment(self):
+        payload = json.dumps(
+            {
+                "primary_reason": "ok",
+                "supporting_evidence_quotes": [],
+                "suggested_action": None,
+            }
+        )
+        result = llm_backend._parse_llm_judgment(payload)
+        assert isinstance(result, LlmJudgmentParseError)
+        assert result.failure_mode == "missing_field"
+        assert "judgment" in result.detail
+
+    def test_missing_required_field_primary_reason(self):
+        payload = json.dumps(
+            {
+                "judgment": "pass",
+                "supporting_evidence_quotes": [],
+                "suggested_action": None,
+            }
+        )
+        result = llm_backend._parse_llm_judgment(payload)
+        assert isinstance(result, LlmJudgmentParseError)
+        assert result.failure_mode == "missing_field"
+
+    def test_missing_required_field_supporting_evidence_quotes(self):
+        payload = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "ok",
+                "suggested_action": None,
+            }
+        )
+        result = llm_backend._parse_llm_judgment(payload)
+        assert isinstance(result, LlmJudgmentParseError)
+        assert result.failure_mode == "missing_field"
+
+    def test_extra_field_is_ignored(self):
+        """Extra JSON fields must be silently ignored (graceful forward compat)."""
+        payload = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "Looks good.",
+                "supporting_evidence_quotes": [],
+                "suggested_action": None,
+                "unknown_future_field": "should be ignored",
+                "another_extra": 42,
+            }
+        )
+        result = llm_backend._parse_llm_judgment(payload)
+        assert isinstance(result, LlmJudgment)
+        assert result.judgment == "pass"
+
+    def test_invalid_judgment_enum_value(self):
+        payload = json.dumps(
+            {
+                "judgment": "maybe",
+                "primary_reason": "unsure",
+                "supporting_evidence_quotes": [],
+                "suggested_action": None,
+            }
+        )
+        result = llm_backend._parse_llm_judgment(payload)
+        assert isinstance(result, LlmJudgmentParseError)
+        assert result.failure_mode == "invalid_judgment_value"
+
+    def test_malformed_json(self):
+        result = llm_backend._parse_llm_judgment("not json at all {{")
+        assert isinstance(result, LlmJudgmentParseError)
+        assert result.failure_mode == "invalid_json"
+
+    def test_empty_string(self):
+        result = llm_backend._parse_llm_judgment("")
+        assert isinstance(result, LlmJudgmentParseError)
+        assert result.failure_mode == "empty_response"
+
+    def test_raw_response_excerpt_populated(self):
+        """Parse errors must carry first ~200 chars of the raw response."""
+        long_garbage = "x" * 300
+        result = llm_backend._parse_llm_judgment(long_garbage)
+        assert isinstance(result, LlmJudgmentParseError)
+        assert len(result.raw_response_excerpt) <= 200
+
+    def test_fail_without_quotes_returns_error(self):
+        """fail judgment with empty quotes list is a validation error."""
+        payload = json.dumps(
+            {
+                "judgment": "fail",
+                "primary_reason": "Missing sections.",
+                "supporting_evidence_quotes": [],
+                "suggested_action": "Add them.",
+            }
+        )
+        result = llm_backend._parse_llm_judgment(payload)
+        assert isinstance(result, LlmJudgmentParseError)
+        assert result.failure_mode == "missing_field"
+
+    def test_fail_without_suggested_action_returns_error(self):
+        payload = json.dumps(
+            {
+                "judgment": "fail",
+                "primary_reason": "Missing sections.",
+                "supporting_evidence_quotes": ["some quote"],
+                "suggested_action": None,
+            }
+        )
+        result = llm_backend._parse_llm_judgment(payload)
+        assert isinstance(result, LlmJudgmentParseError)
+        assert result.failure_mode == "missing_field"
+
+    def test_pass_suggested_action_forced_to_none(self):
+        """Even if model returns suggested_action on pass, it must be coerced to None."""
+        payload = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "Looks good.",
+                "supporting_evidence_quotes": [],
+                "suggested_action": "Some spurious action from model",
+            }
+        )
+        result = llm_backend._parse_llm_judgment(payload)
+        assert isinstance(result, LlmJudgment)
+        assert result.suggested_action is None
+
+    def test_non_object_json_returns_error(self):
+        result = llm_backend._parse_llm_judgment('["pass"]')
+        assert isinstance(result, LlmJudgmentParseError)
+        assert result.failure_mode == "invalid_json"
+
+
+# ---------------------------------------------------------------------------
+# _parse_response backward-compat shim (legacy tests, kept for regression)
+# ---------------------------------------------------------------------------
+
 class TestParseResponseDirect:
-    def test_pass_with_explanation(self):
-        judgment, explanation = llm_backend._parse_response('{"judgment": "pass", "explanation": "ok"}')
+    def test_pass_with_primary_reason(self):
+        judgment, reason = llm_backend._parse_response(_VALID_PASS_JSON)
         assert judgment == "pass"
-        assert explanation == "ok"
+        assert reason == "Documentation reads clearly."
 
     def test_invalid_json_raises(self):
-        import pytest as _pytest
-
-        with _pytest.raises(ValueError):
+        with pytest.raises(ValueError):
             llm_backend._parse_response("not json at all")
 
     def test_non_object_raises(self):
-        import pytest as _pytest
-
-        with _pytest.raises(ValueError):
+        with pytest.raises(ValueError):
             llm_backend._parse_response('["pass"]')
 
-    def test_empty_explanation_raises(self):
-        import pytest as _pytest
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError):
+            llm_backend._parse_response("")
 
-        with _pytest.raises(ValueError):
-            llm_backend._parse_response('{"judgment": "pass", "explanation": ""}')
 
+# ---------------------------------------------------------------------------
+# PROMPT_VERSION constant
+# ---------------------------------------------------------------------------
+
+class TestPromptVersion:
+    def test_prompt_version_constant_exists(self):
+        assert hasattr(llm_backend, "PROMPT_VERSION")
+        assert llm_backend.PROMPT_VERSION == "v1"
+
+    def test_evidence_includes_prompt_version(self, monkeypatch, tmp_path):
+        _patch_env(
+            monkeypatch,
+            {"GATE_KEEPER_LLM_PROVIDER": "anthropic", "ANTHROPIC_API_KEY": "sk-ant-test"},
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: _VALID_PASS_JSON,
+        )
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        assert diag.evidence[0].data["prompt_version"] == "v1"
+
+
+# ---------------------------------------------------------------------------
+# Path constants (#51 regression guard)
+# ---------------------------------------------------------------------------
 
 class TestPathConstants:
     def test_dotenv_path_matches_spec(self):


### PR DESCRIPTION
Closes #67

## Summary

- **`LlmJudgment` schema**: new `dataclass` with `judgment`, `primary_reason`, `supporting_evidence_quotes`, `suggested_action`. No new runtime deps — stdlib `json` + custom validation only.
- **Prompt template**: `RUBRIC_PROMPT_TEMPLATE` module-level constant; frames model as rubric evaluator; demands JSON matching `LlmJudgment`; includes one valid example. `PROMPT_VERSION = "v1"` stamped into every success evidence payload for #68.
- **Parser/validator**: `_parse_llm_judgment()` returns `LlmJudgment` on success or `LlmJudgmentParseError(failure_mode, detail, raw_response_excerpt)` on any failure — never raises.
- **`check()` wired**: `evidence[0].data` now carries `{model, prompt_version, judgment, primary_reason, supporting_evidence_quotes, suggested_action}`; `Diagnostic.remediation` set to `suggested_action` on fail.
- **Contract preserved**: `provider_unconfigured`, `provider_error`, `unparseable_response` paths unchanged byte-for-byte. `os` not imported. dotenv-only credential loading preserved.

## Tests

- **21 new** unit tests in `TestParseLlmJudgment` (valid pass, valid fail, missing fields, extra fields, invalid enum, malformed JSON, empty string, excerpt length, fail-without-quotes, fail-without-action, pass-coerces-action-to-None, non-object JSON) plus `TestPromptVersion` (2 tests).
- **6 updated** tests in `TestProviderDispatchAnthropic` / `TestProviderDispatchOpenAI` to assert new structured shape.
- **4 retained** legacy `TestParseResponseDirect` tests for the backward-compat shim.
- Total: **51 tests in file**, 682 in suite, all passing.

## Validation

| Step | Outcome |
|------|---------|
| `uv sync` | ok |
| `uv run pytest` (682 tests) | all passed |
| `uvx ruff check .` | no issues |
| `uv run pyright` | 0 errors, 0 warnings |

## Independent review (subagent)

- **Reviewer**: general-purpose subagent (Claude Sonnet 4.6), worktree-isolated
- **Review ID**: `PRR_kwDOSMMG0M77UBOi`
- **Recommendation**: APPROVE
- **Key findings**: All 7 acceptance criteria verified; `os` not imported (AST-confirmed); no new runtime deps; `PROMPT_VERSION = "v1"` present and stamped in evidence; all three #51 failure paths (`provider_unconfigured`, `provider_error`, `unparseable_response`) preserved byte-for-byte. No issues found.