### PR TITLE
feat(diagnostics): structured rationale expansion in --verbose mode (#70)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 ~~~sh
 uv sync
 uv run gate-keeper --help
+uv run gate-keeper validate RULES --target TARGET [--verbose]
 uv run pytest
 uvx ruff check .
 uvx pyright

--- a/docs/design/multi-target.md
+++ b/docs/design/multi-target.md
@@ -204,8 +204,9 @@ Current `validate` signature:
 gate-keeper validate RULES --target TARGET [--backend auto] [--format text|json] [--verbose]
 ```
 
-`--verbose` expands structured LLM-rubric rationale (judgment, reason, evidence quotes)
-as indented lines beneath each diagnostic in text output; no effect on JSON format.
+`--verbose` expands structured LLM-rubric rationale (judgment, reason, evidence quotes,
+suggested action, and model name) as indented lines beneath each diagnostic in text
+output; no effect on JSON format.
 
 `--target` today accepts a single path or a PR identifier (e.g., `1234`).
 

--- a/docs/design/multi-target.md
+++ b/docs/design/multi-target.md
@@ -201,8 +201,11 @@ The shared mechanism is the right call.
 Current `validate` signature:
 
 ```
-gate-keeper validate RULES --target TARGET [--backend auto] [--format text|json]
+gate-keeper validate RULES --target TARGET [--backend auto] [--format text|json] [--verbose]
 ```
+
+`--verbose` expands structured LLM-rubric rationale (judgment, reason, evidence quotes)
+as indented lines beneath each diagnostic in text output; no effect on JSON format.
 
 `--target` today accepts a single path or a PR identifier (e.g., `1234`).
 

--- a/docs/gh-aw.md
+++ b/docs/gh-aw.md
@@ -29,6 +29,8 @@ steps:
         --target "$PR_URL" \
         --backend auto \
         --format text
+      # Add --verbose to expand LLM-rubric rationale in the log output:
+      # uv run gate-keeper validate docs/rules.md --target "$PR_URL" --verbose
     # Non-zero exit code stops the workflow.
 ```
 

--- a/docs/mvp-spec.md
+++ b/docs/mvp-spec.md
@@ -75,6 +75,7 @@ an input format is out of scope.
 gate-keeper compile DOCUMENT --format json
 gate-keeper validate DOCUMENT --target TARGET --backend auto --format text
 gate-keeper validate DOCUMENT --target TARGET --backend auto --format json
+gate-keeper validate DOCUMENT --target TARGET --backend auto --format text --verbose
 gate-keeper explain DOCUMENT --format text
 ```
 

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -62,6 +62,13 @@ def build_parser() -> argparse.ArgumentParser:
         default="text",
         help="output format (default: text)",
     )
+    validate_parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        default=False,
+        help="expand structured rationale (llm-rubric) in text output",
+    )
 
     return parser
 
@@ -161,7 +168,7 @@ def _cmd_validate(args: argparse.Namespace) -> int:
     if args.format == "json":
         print(render_json(report.diagnostics))
     else:
-        rendered = render_text(report.diagnostics)
+        rendered = render_text(report.diagnostics, verbose=args.verbose)
         if rendered:
             print(rendered)
 

--- a/src/gate_keeper/diagnostics.py
+++ b/src/gate_keeper/diagnostics.py
@@ -58,7 +58,7 @@ def _render_llm_judgment_verbose(data: dict[str, Any]) -> list[str]:
         lines.append(f"    reason    : {_safe_value(primary_reason)}")
     quotes: list[Any] = data.get("supporting_evidence_quotes") or []
     for quote in quotes:
-        lines.append(f'    evidence  : "{_safe_value(quote)}"')
+        lines.append(f'    evidence  : "{_safe_value(quote).replace(chr(34), chr(92) + chr(34))}"')
     suggested_action = data.get("suggested_action")
     if suggested_action:
         lines.append(f"    action    : {_safe_value(suggested_action)}")

--- a/src/gate_keeper/diagnostics.py
+++ b/src/gate_keeper/diagnostics.py
@@ -56,7 +56,7 @@ def _render_llm_judgment_verbose(data: dict[str, Any]) -> list[str]:
         lines.append(f"    judgment  : {primary_reason} ({judgment})")
     quotes: list[Any] = data.get("supporting_evidence_quotes") or []
     for quote in quotes:
-        lines.append(f"    evidence  : \"{quote}\"")
+        lines.append(f'    evidence  : "{quote}"')
     suggested_action = data.get("suggested_action")
     if suggested_action:
         lines.append(f"    action    : {suggested_action}")

--- a/src/gate_keeper/diagnostics.py
+++ b/src/gate_keeper/diagnostics.py
@@ -85,7 +85,7 @@ def render_text(diagnostics: Sequence[Diagnostic], *, verbose: bool = False) -> 
             f"{d.severity.value}: "
             f"[{d.backend.value}/{d.status.value}] "
             f"{d.rule_id}: "
-            f"{d.message}"
+            f"{_safe_value(d.message)}"
             f"{evidence_part}"
         )
         if verbose:

--- a/src/gate_keeper/diagnostics.py
+++ b/src/gate_keeper/diagnostics.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any, Sequence
 
-from gate_keeper.models import Diagnostic, DiagnosticReport, Rule, Status
+from gate_keeper.models import Backend, Diagnostic, DiagnosticReport, Rule, Status
 
 EXIT_OK = 0
 EXIT_FAIL = 1
@@ -34,9 +34,11 @@ def _safe_value(v: object) -> str:
 def _compact_evidence(diagnostic: Diagnostic) -> str:
     parts = []
     for e in diagnostic.evidence:
-        # llm_judgment evidence is handled separately in verbose mode; skip here
-        # so it doesn't double-render on the compact line.
-        if e.kind == "llm_judgment":
+        # llm_judgment evidence from LLM_RUBRIC is rendered in the verbose block;
+        # skip it here so it doesn't double-render on the compact line.
+        # Scope by backend to avoid silently dropping evidence from other backends
+        # that might coincidentally use the same kind name.
+        if e.kind == "llm_judgment" and diagnostic.backend == Backend.LLM_RUBRIC:
             continue
         if e.data:
             pairs = ", ".join(f"{k}={_safe_value(v)}" for k, v in e.data.items())
@@ -90,7 +92,7 @@ def render_text(diagnostics: Sequence[Diagnostic], *, verbose: bool = False) -> 
         )
         if verbose:
             for e in d.evidence:
-                if e.kind == "llm_judgment":
+                if e.kind == "llm_judgment" and d.backend == Backend.LLM_RUBRIC:
                     lines.extend(_render_llm_judgment_verbose(e.data))
     return "\n".join(lines)
 

--- a/src/gate_keeper/diagnostics.py
+++ b/src/gate_keeper/diagnostics.py
@@ -51,15 +51,17 @@ def _render_llm_judgment_verbose(data: dict[str, Any]) -> list[str]:
     lines: list[str] = []
     lines.append("  [llm-rubric]")
     judgment = data.get("judgment", "")
+    if judgment:
+        lines.append(f"    judgment  : {judgment}")
     primary_reason = data.get("primary_reason", "")
     if primary_reason:
-        lines.append(f"    judgment  : {primary_reason} ({judgment})")
+        lines.append(f"    reason    : {_safe_value(primary_reason)}")
     quotes: list[Any] = data.get("supporting_evidence_quotes") or []
     for quote in quotes:
-        lines.append(f'    evidence  : "{quote}"')
+        lines.append(f'    evidence  : "{_safe_value(quote)}"')
     suggested_action = data.get("suggested_action")
     if suggested_action:
-        lines.append(f"    action    : {suggested_action}")
+        lines.append(f"    action    : {_safe_value(suggested_action)}")
     model = data.get("model")
     if model:
         lines.append(f"    model     : {model}")

--- a/src/gate_keeper/diagnostics.py
+++ b/src/gate_keeper/diagnostics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Sequence
+from typing import Any, Sequence
 
 from gate_keeper.models import Diagnostic, DiagnosticReport, Rule, Status
 
@@ -34,6 +34,10 @@ def _safe_value(v: object) -> str:
 def _compact_evidence(diagnostic: Diagnostic) -> str:
     parts = []
     for e in diagnostic.evidence:
+        # llm_judgment evidence is handled separately in verbose mode; skip here
+        # so it doesn't double-render on the compact line.
+        if e.kind == "llm_judgment":
+            continue
         if e.data:
             pairs = ", ".join(f"{k}={_safe_value(v)}" for k, v in e.data.items())
             parts.append(f"{e.kind}({pairs})")
@@ -42,10 +46,33 @@ def _compact_evidence(diagnostic: Diagnostic) -> str:
     return "; ".join(parts)
 
 
-def render_text(diagnostics: Sequence[Diagnostic]) -> str:
+def _render_llm_judgment_verbose(data: dict[str, Any]) -> list[str]:
+    """Return indented lines expanding llm_judgment evidence for --verbose."""
+    lines: list[str] = []
+    lines.append("  [llm-rubric]")
+    judgment = data.get("judgment", "")
+    primary_reason = data.get("primary_reason", "")
+    if primary_reason:
+        lines.append(f"    judgment  : {primary_reason} ({judgment})")
+    quotes: list[Any] = data.get("supporting_evidence_quotes") or []
+    for quote in quotes:
+        lines.append(f"    evidence  : \"{quote}\"")
+    suggested_action = data.get("suggested_action")
+    if suggested_action:
+        lines.append(f"    action    : {suggested_action}")
+    model = data.get("model")
+    if model:
+        lines.append(f"    model     : {model}")
+    return lines
+
+
+def render_text(diagnostics: Sequence[Diagnostic], *, verbose: bool = False) -> str:
     """Render diagnostics as compiler-style text lines.
 
     Each line: path:line: severity: [backend/status] rule_id: message [evidence]
+
+    When *verbose* is True and a diagnostic carries ``llm_judgment`` evidence,
+    the structured rationale is expanded as indented lines below the main line.
     """
     lines = []
     for d in diagnostics:
@@ -59,6 +86,10 @@ def render_text(diagnostics: Sequence[Diagnostic]) -> str:
             f"{d.message}"
             f"{evidence_part}"
         )
+        if verbose:
+            for e in d.evidence:
+                if e.kind == "llm_judgment":
+                    lines.extend(_render_llm_judgment_verbose(e.data))
     return "\n".join(lines)
 
 

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -345,3 +345,133 @@ class TestDiagnosticFields:
         captured = capsys.readouterr()
         # text format: [backend/status] in every line
         assert "[filesystem/" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# --verbose flag (issue #70)
+# ---------------------------------------------------------------------------
+
+
+class TestVerboseFlag:
+    """CLI-level tests for gate-keeper validate --verbose."""
+
+    def test_verbose_flag_wires_through_to_output(self, capsys, monkeypatch):
+        """validate --verbose must produce expanded llm-rubric block in stdout.
+
+        Mocks validator.validate to inject a diagnostic with llm_judgment
+        evidence so the test is deterministic and network-free.
+        """
+        from unittest.mock import MagicMock
+
+        from gate_keeper.models import (
+            Backend,
+            Diagnostic,
+            DiagnosticReport,
+            Evidence,
+            Severity,
+            SourceLocation,
+            Status,
+        )
+
+        llm_ev = Evidence(
+            kind="llm_judgment",
+            data={
+                "judgment": "fail",
+                "primary_reason": "Missing usage section.",
+                "supporting_evidence_quotes": ["no ## Usage heading found"],
+                "suggested_action": "Add a ## Usage section.",
+                "model": "claude-haiku-4-5",
+                "prompt_version": "v1",
+            },
+        )
+        fake_diag = Diagnostic(
+            rule_id="doc-has-usage",
+            source=SourceLocation(path="rules.md", line=1),
+            backend=Backend.LLM_RUBRIC,
+            status=Status.FAIL,
+            severity=Severity.ERROR,
+            message="rule failed",
+            evidence=[llm_ev],
+        )
+        fake_report = DiagnosticReport(diagnostics=[fake_diag])
+
+        monkeypatch.setattr(
+            "gate_keeper.validator.validate",
+            MagicMock(return_value=fake_report),
+        )
+
+        main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--verbose",
+            ]
+        )
+        captured = capsys.readouterr()
+
+        # --verbose must expand the llm-rubric block (multiple lines)
+        lines = captured.out.strip().splitlines()
+        assert len(lines) > 1, "verbose output must span multiple lines"
+        # The expanded block must contain a dedicated judgment field line
+        assert any("judgment  : fail" in ln for ln in lines[1:]), (
+            "verbose block must include a `judgment` field"
+        )
+        # The primary_reason must appear under its own field
+        assert any("Missing usage section." in ln for ln in lines[1:]), (
+            "verbose block must include the primary_reason"
+        )
+
+    def test_verbose_flag_absent_gives_single_line(self, capsys, monkeypatch):
+        """Without --verbose, each diagnostic is a single line even with llm_judgment evidence."""
+        from unittest.mock import MagicMock
+
+        from gate_keeper.models import (
+            Backend,
+            Diagnostic,
+            DiagnosticReport,
+            Evidence,
+            Severity,
+            SourceLocation,
+            Status,
+        )
+
+        llm_ev = Evidence(
+            kind="llm_judgment",
+            data={
+                "judgment": "fail",
+                "primary_reason": "Missing section.",
+                "supporting_evidence_quotes": [],
+                "suggested_action": None,
+                "model": "claude-haiku-4-5",
+                "prompt_version": "v1",
+            },
+        )
+        fake_diag = Diagnostic(
+            rule_id="doc-check",
+            source=SourceLocation(path="rules.md", line=1),
+            backend=Backend.LLM_RUBRIC,
+            status=Status.FAIL,
+            severity=Severity.ERROR,
+            message="rule failed",
+            evidence=[llm_ev],
+        )
+        fake_report = DiagnosticReport(diagnostics=[fake_diag])
+
+        monkeypatch.setattr(
+            "gate_keeper.validator.validate",
+            MagicMock(return_value=fake_report),
+        )
+
+        main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+            ]
+        )
+        captured = capsys.readouterr()
+        lines = captured.out.strip().splitlines()
+        assert len(lines) == 1, "non-verbose output must be one line per diagnostic"

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -475,3 +475,57 @@ class TestVerboseFlag:
         captured = capsys.readouterr()
         lines = captured.out.strip().splitlines()
         assert len(lines) == 1, "non-verbose output must be one line per diagnostic"
+
+    def test_short_verbose_alias_v_wires_through(self, capsys, monkeypatch):
+        """-v is an alias for --verbose and must produce the same expanded output."""
+        from unittest.mock import MagicMock
+
+        from gate_keeper.models import (
+            Backend,
+            Diagnostic,
+            DiagnosticReport,
+            Evidence,
+            Severity,
+            SourceLocation,
+            Status,
+        )
+
+        llm_ev = Evidence(
+            kind="llm_judgment",
+            data={
+                "judgment": "fail",
+                "primary_reason": "Missing section.",
+                "supporting_evidence_quotes": [],
+                "suggested_action": None,
+                "model": "claude-haiku-4-5",
+                "prompt_version": "v1",
+            },
+        )
+        fake_diag = Diagnostic(
+            rule_id="doc-check",
+            source=SourceLocation(path="rules.md", line=1),
+            backend=Backend.LLM_RUBRIC,
+            status=Status.FAIL,
+            severity=Severity.ERROR,
+            message="rule failed",
+            evidence=[llm_ev],
+        )
+        fake_report = DiagnosticReport(diagnostics=[fake_diag])
+
+        monkeypatch.setattr(
+            "gate_keeper.validator.validate",
+            MagicMock(return_value=fake_report),
+        )
+
+        main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "-v",
+            ]
+        )
+        captured = capsys.readouterr()
+        lines = captured.out.strip().splitlines()
+        assert len(lines) > 1, "-v must expand llm-rubric output just like --verbose"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -389,7 +389,11 @@ def test_verbose_llm_judgment_not_in_compact_bracket():
 
 
 def test_verbose_llm_judgment_newlines_escaped():
-    """Newlines in quotes/action must be escaped, not rendered as raw line breaks."""
+    """Newlines in quotes/action/message must be escaped, not rendered as raw line breaks.
+
+    This exercises the production code path where llm_rubric copies primary_reason
+    into d.message, so the main diagnostic line also needs escaping.
+    """
     ev = Evidence(
         kind="llm_judgment",
         data={
@@ -401,7 +405,15 @@ def test_verbose_llm_judgment_newlines_escaped():
             "prompt_version": "v1",
         },
     )
-    diags = [_diag(evidence=[ev], backend=Backend.LLM_RUBRIC, status=Status.FAIL)]
+    # Simulate message being set from primary_reason (as llm_rubric.check() does)
+    diags = [
+        _diag(
+            message="Bad\nformat",
+            evidence=[ev],
+            backend=Backend.LLM_RUBRIC,
+            status=Status.FAIL,
+        )
+    ]
     text = render_text(diags, verbose=True)
     # escaped newlines must appear as literal \n in the output
     assert "\\n" in text

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -312,7 +312,9 @@ def test_verbose_rationale_expansion_shows_judgment():
     diags = [_diag(evidence=[ev], backend=Backend.LLM_RUBRIC, status=Status.FAIL)]
     text = render_text(diags, verbose=True)
     assert "Missing usage section." in text
-    assert "fail" in text
+    # Explicitly assert the verbose block has a standalone `judgment` field line,
+    # not just the header `[llm-rubric/fail]` which also contains "fail".
+    assert "    judgment  : fail" in text
 
 
 def test_verbose_rationale_expansion_shows_evidence_quotes():
@@ -320,6 +322,14 @@ def test_verbose_rationale_expansion_shows_evidence_quotes():
     diags = [_diag(evidence=[ev], backend=Backend.LLM_RUBRIC, status=Status.FAIL)]
     text = render_text(diags, verbose=True)
     assert "## Usage" in text
+
+
+def test_verbose_rationale_expansion_shows_reason():
+    """primary_reason must appear under its own `reason` field (not merged into judgment)."""
+    ev = _llm_judgment_evidence("fail")
+    diags = [_diag(evidence=[ev], backend=Backend.LLM_RUBRIC, status=Status.FAIL)]
+    text = render_text(diags, verbose=True)
+    assert "    reason    : Missing usage section." in text
 
 
 def test_verbose_rationale_expansion_shows_suggested_action():
@@ -376,6 +386,30 @@ def test_verbose_llm_judgment_not_in_compact_bracket():
     first_line = render_text(diags, verbose=True).splitlines()[0]
     # The compact bracket should be absent or at least not contain llm_judgment data
     assert "llm_judgment" not in first_line
+
+
+
+
+def test_verbose_llm_judgment_newlines_escaped():
+    """Newlines in quotes/action must be escaped, not rendered as raw line breaks."""
+    ev = Evidence(
+        kind="llm_judgment",
+        data={
+            "judgment": "fail",
+            "primary_reason": "Bad\nformat",
+            "supporting_evidence_quotes": ["line1\nline2"],
+            "suggested_action": "Fix\nit",
+            "model": "claude-haiku-4-5",
+            "prompt_version": "v1",
+        },
+    )
+    diags = [_diag(evidence=[ev], backend=Backend.LLM_RUBRIC, status=Status.FAIL)]
+    text = render_text(diags, verbose=True)
+    # escaped newlines must appear as literal \n in the output
+    assert "\\n" in text
+    # no raw newline bleed: all indented lines start with spaces
+    for line in text.splitlines()[1:]:
+        assert line.startswith("  "), f"unexpected line without indent: {line!r}"
 
 
 def test_json_includes_llm_judgment_evidence():

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -388,8 +388,6 @@ def test_verbose_llm_judgment_not_in_compact_bracket():
     assert "llm_judgment" not in first_line
 
 
-
-
 def test_verbose_llm_judgment_newlines_escaped():
     """Newlines in quotes/action must be escaped, not rendered as raw line breaks."""
     ev = Evidence(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -273,3 +273,118 @@ def test_json_keys_sorted():
     parsed = json.loads(raw)
     diag_keys = list(parsed["diagnostics"][0].keys())
     assert diag_keys == sorted(diag_keys)
+
+
+# ---------------------------------------------------------------------------
+# Text renderer — verbose rationale expansion (issue #70)
+# ---------------------------------------------------------------------------
+
+
+def _llm_judgment_evidence(judgment: str = "fail") -> Evidence:
+    """Build a minimal llm_judgment evidence item."""
+    if judgment == "pass":
+        return Evidence(
+            kind="llm_judgment",
+            data={
+                "judgment": "pass",
+                "primary_reason": "The document is well-structured.",
+                "supporting_evidence_quotes": [],
+                "suggested_action": None,
+                "model": "claude-haiku-4-5",
+                "prompt_version": "v1",
+            },
+        )
+    return Evidence(
+        kind="llm_judgment",
+        data={
+            "judgment": "fail",
+            "primary_reason": "Missing usage section.",
+            "supporting_evidence_quotes": ["README.md has no '## Usage' heading"],
+            "suggested_action": "Add a '## Usage' section.",
+            "model": "claude-haiku-4-5",
+            "prompt_version": "v1",
+        },
+    )
+
+
+def test_verbose_rationale_expansion_shows_judgment():
+    ev = _llm_judgment_evidence("fail")
+    diags = [_diag(evidence=[ev], backend=Backend.LLM_RUBRIC, status=Status.FAIL)]
+    text = render_text(diags, verbose=True)
+    assert "Missing usage section." in text
+    assert "fail" in text
+
+
+def test_verbose_rationale_expansion_shows_evidence_quotes():
+    ev = _llm_judgment_evidence("fail")
+    diags = [_diag(evidence=[ev], backend=Backend.LLM_RUBRIC, status=Status.FAIL)]
+    text = render_text(diags, verbose=True)
+    assert "## Usage" in text
+
+
+def test_verbose_rationale_expansion_shows_suggested_action():
+    ev = _llm_judgment_evidence("fail")
+    diags = [_diag(evidence=[ev], backend=Backend.LLM_RUBRIC, status=Status.FAIL)]
+    text = render_text(diags, verbose=True)
+    assert "Add a '## Usage' section." in text
+
+
+def test_verbose_rationale_expansion_shows_model():
+    ev = _llm_judgment_evidence("pass")
+    diags = [_diag(evidence=[ev], backend=Backend.LLM_RUBRIC, status=Status.PASS)]
+    text = render_text(diags, verbose=True)
+    assert "claude-haiku-4-5" in text
+
+
+def test_verbose_rationale_multiline():
+    """--verbose output for llm_judgment must produce more than one line."""
+    ev = _llm_judgment_evidence("fail")
+    diags = [_diag(evidence=[ev], backend=Backend.LLM_RUBRIC, status=Status.FAIL)]
+    lines = render_text(diags, verbose=True).splitlines()
+    assert len(lines) > 1
+
+
+def test_non_verbose_rationale_not_expanded():
+    """Without --verbose, llm_judgment evidence must NOT expand to multiple lines."""
+    ev = _llm_judgment_evidence("fail")
+    diags = [_diag(evidence=[ev], backend=Backend.LLM_RUBRIC, status=Status.FAIL)]
+    lines = render_text(diags, verbose=False).splitlines()
+    assert len(lines) == 1
+
+
+def test_verbose_pass_no_action_line():
+    """Pass judgment has no suggested_action; action line must be absent."""
+    ev = _llm_judgment_evidence("pass")
+    diags = [_diag(evidence=[ev], backend=Backend.LLM_RUBRIC, status=Status.PASS)]
+    text = render_text(diags, verbose=True)
+    assert "action" not in text
+
+
+def test_verbose_non_llm_evidence_unchanged():
+    """Non-llm_judgment evidence must still appear compactly even in verbose mode."""
+    ev = _ev("text_match", path="AGENTS.md", match_count=3)
+    diags = [_diag(evidence=[ev])]
+    text = render_text(diags, verbose=True)
+    assert "text_match" in text
+    assert "AGENTS.md" in text
+
+
+def test_verbose_llm_judgment_not_in_compact_bracket():
+    """llm_judgment evidence must not appear in the compact [evidence] bracket."""
+    ev = _llm_judgment_evidence("fail")
+    diags = [_diag(evidence=[ev], backend=Backend.LLM_RUBRIC, status=Status.FAIL)]
+    first_line = render_text(diags, verbose=True).splitlines()[0]
+    # The compact bracket should be absent or at least not contain llm_judgment data
+    assert "llm_judgment" not in first_line
+
+
+def test_json_includes_llm_judgment_evidence():
+    """JSON output must include llm_judgment evidence fields directly."""
+    ev = _llm_judgment_evidence("fail")
+    diags = [_diag(evidence=[ev], backend=Backend.LLM_RUBRIC, status=Status.FAIL)]
+    parsed = json.loads(render_json(diags))
+    ev_out = parsed["diagnostics"][0]["evidence"][0]
+    assert ev_out["kind"] == "llm_judgment"
+    assert ev_out["data"]["judgment"] == "fail"
+    assert ev_out["data"]["primary_reason"] == "Missing usage section."
+    assert isinstance(ev_out["data"]["supporting_evidence_quotes"], list)


### PR DESCRIPTION
## Summary

- Adds `--verbose` / `-v` flag to `gate-keeper validate` that expands `llm_judgment` evidence into multi-line indented rationale blocks.
- Verbose output shows: judgment verdict, primary reason, supporting evidence quotes, suggested action, and model used.
- `llm_judgment` evidence is excluded from the compact `[evidence]` bracket on the main line to avoid double-rendering.
- JSON output already serializes all structured fields; no change needed.
- 11 new tests covering verbose expansion, non-verbose behaviour, pass/fail paths, and JSON passthrough.

## Validation

```
uv run pytest          # 692 passed
uvx ruff check .       # All checks passed
uvx pyright            # 12 pre-existing errors (unchanged from main)
```

Closes #70