### PR TITLE
feat(diagnostics): failure-mode evidence rendering and JSON failure_mode field

### DIFF
--- a/src/gate_keeper/diagnostics.py
+++ b/src/gate_keeper/diagnostics.py
@@ -13,6 +13,18 @@ EXIT_USAGE = 2
 
 _NON_PASS = frozenset({Status.FAIL, Status.UNAVAILABLE, Status.UNSUPPORTED, Status.ERROR})
 
+# Evidence kinds whose data is expanded into a human-readable phrase rather than
+# raw key=value pairs in the compact text renderer.
+_HUMAN_READABLE_KINDS = frozenset(
+    {
+        "backend_capability",
+        "provider_unconfigured",
+        "provider_error",
+        "adapter_unknown",
+        "params_error",
+    }
+)
+
 
 def compute_exit_code(diagnostics: Sequence[Diagnostic]) -> int:
     """Return EXIT_OK if all diagnostics pass, EXIT_FAIL if any do not."""
@@ -31,6 +43,35 @@ def _safe_value(v: object) -> str:
     return str(v).replace("\r", "\\r").replace("\n", "\\n")
 
 
+def _human_readable_evidence(kind: str, data: dict[str, Any]) -> str:
+    """Return a concise human-readable string for well-known failure-mode evidence kinds.
+
+    Falls back to the raw key=value form for unrecognised kinds.
+    """
+    if kind == "backend_capability":
+        backend = data.get("backend", "?")
+        rule_kind = data.get("kind", "?")
+        return f"{backend} backend does not support rule kind '{rule_kind}'"
+    if kind == "provider_unconfigured":
+        return "LLM provider not configured (see docs/llm-rubric.md)"
+    if kind == "provider_error":
+        failure_mode = data.get("failure_mode", "unknown")
+        provider = data.get("provider", "?")
+        detail = _safe_value(data.get("detail", ""))
+        return f"LLM provider error ({provider}): {failure_mode} — {detail}"
+    if kind == "adapter_unknown":
+        tool = _safe_value(data.get("tool", "?"))
+        registered = data.get("registered_adapters", [])
+        if registered:
+            return f"adapter '{tool}' not registered (known: {', '.join(str(a) for a in registered)})"
+        return f"adapter '{tool}' not registered"
+    if kind == "params_error":
+        missing = _safe_value(data.get("missing", "?"))
+        return f"rule params missing required field '{missing}'"
+    # Generic fallback: key=value pairs
+    return ", ".join(f"{k}={_safe_value(v)}" for k, v in data.items())
+
+
 def _compact_evidence(diagnostic: Diagnostic) -> str:
     parts = []
     for e in diagnostic.evidence:
@@ -40,12 +81,41 @@ def _compact_evidence(diagnostic: Diagnostic) -> str:
         # that might coincidentally use the same kind name.
         if e.kind == "llm_judgment" and diagnostic.backend == Backend.LLM_RUBRIC:
             continue
-        if e.data:
+        if e.kind in _HUMAN_READABLE_KINDS:
+            parts.append(_human_readable_evidence(e.kind, e.data))
+        elif e.data:
             pairs = ", ".join(f"{k}={_safe_value(v)}" for k, v in e.data.items())
             parts.append(f"{e.kind}({pairs})")
         else:
             parts.append(e.kind)
     return "; ".join(parts)
+
+
+def _derive_failure_mode(diagnostic: Diagnostic) -> str | None:
+    """Derive a short failure_mode tag from a diagnostic's evidence, or None for pass.
+
+    Used by ``render_json`` to add a ``failure_mode`` field (#71).
+    """
+    if diagnostic.status is Status.PASS:
+        return None
+    for e in diagnostic.evidence:
+        if e.kind == "backend_capability":
+            return "unsupported_rule_kind"
+        if e.kind == "provider_unconfigured":
+            return "provider_unconfigured"
+        if e.kind == "provider_error":
+            return str(e.data.get("failure_mode", "provider_error"))
+        if e.kind == "adapter_unknown":
+            return "adapter_unknown"
+        if e.kind == "params_error":
+            return "params_error"
+        if e.kind == "llm_judgment":
+            judgment = e.data.get("judgment", "")
+            return f"llm_{judgment}" if judgment else "llm_fail"
+        if e.kind in ("exception", "io_error"):
+            return e.kind
+    # Fall back to status value if no specific evidence kind matched
+    return diagnostic.status.value
 
 
 def _render_llm_judgment_verbose(data: dict[str, Any]) -> list[str]:
@@ -74,6 +144,10 @@ def render_text(diagnostics: Sequence[Diagnostic], *, verbose: bool = False) -> 
     """Render diagnostics as compiler-style text lines.
 
     Each line: path:line: severity: [backend/status] rule_id: message [evidence]
+
+    Known failure-mode evidence kinds (backend_capability, provider_unconfigured,
+    provider_error, adapter_unknown, params_error) are rendered as concise
+    human-readable phrases rather than raw key=value pairs.
 
     When *verbose* is True and a diagnostic carries ``llm_judgment`` evidence,
     the structured rationale is expanded as indented lines below the main line.
@@ -122,6 +196,12 @@ def render_json(diagnostics: Sequence[Diagnostic]) -> str:
     """Render diagnostics as deterministic JSON for CI consumers.
 
     The status field is preserved exactly — unavailable is distinct from fail.
+    A ``failure_mode`` field is added to each diagnostic: ``null`` for pass,
+    a short descriptive tag for fail/unavailable/unsupported/error (#71).
+    Existing fields are unchanged (backwards-compatible addition).
     """
     report = DiagnosticReport(diagnostics=list(diagnostics))
-    return json.dumps(report.to_dict(), sort_keys=True, indent=2)
+    data = report.to_dict()
+    for diag_dict, diag in zip(data["diagnostics"], diagnostics):
+        diag_dict["failure_mode"] = _derive_failure_mode(diag)
+    return json.dumps(data, sort_keys=True, indent=2)

--- a/src/gate_keeper/diagnostics.py
+++ b/src/gate_keeper/diagnostics.py
@@ -61,7 +61,9 @@ def _human_readable_evidence(kind: str, data: dict[str, Any]) -> str:
         return f"LLM provider error ({provider}): {failure_mode} — {detail}"
     if kind == "adapter_unknown":
         tool = _safe_value(data.get("tool", "?"))
-        registered = data.get("registered_adapters", [])
+        # Accept both "registered" (current external backend key) and the older
+        # "registered_adapters" key for backwards compatibility.
+        registered = data.get("registered") or data.get("registered_adapters") or []
         if registered:
             return f"adapter '{tool}' not registered (known: {', '.join(str(a) for a in registered)})"
         return f"adapter '{tool}' not registered"
@@ -200,8 +202,10 @@ def render_json(diagnostics: Sequence[Diagnostic]) -> str:
     a short descriptive tag for fail/unavailable/unsupported/error (#71).
     Existing fields are unchanged (backwards-compatible addition).
     """
-    report = DiagnosticReport(diagnostics=list(diagnostics))
+    # Materialise once so we can iterate twice (DiagnosticReport + zip).
+    diagnostics_list = list(diagnostics)
+    report = DiagnosticReport(diagnostics=diagnostics_list)
     data = report.to_dict()
-    for diag_dict, diag in zip(data["diagnostics"], diagnostics):
+    for diag_dict, diag in zip(data["diagnostics"], diagnostics_list):
         diag_dict["failure_mode"] = _derive_failure_mode(diag)
     return json.dumps(data, sort_keys=True, indent=2)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -486,12 +486,16 @@ def test_provider_error_renders_human_readable():
 
 
 def test_adapter_unknown_renders_human_readable():
-    """unavailable via adapter_unknown: renders adapter name."""
+    """unsupported via adapter_unknown: renders adapter name.
+
+    Uses the production evidence shape from external.check(): key "registered"
+    and Status.UNSUPPORTED (not UNAVAILABLE).
+    """
     ev = Evidence(
         kind="adapter_unknown",
-        data={"tool": "textlint", "registered_adapters": ["eslint", "shellcheck"]},
+        data={"tool": "textlint", "registered": ["eslint", "shellcheck"]},
     )
-    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.EXTERNAL)]
+    diags = [_diag(status=Status.UNSUPPORTED, evidence=[ev], backend=Backend.EXTERNAL)]
     text = render_text(diags)
     assert "textlint" in text
     assert "not registered" in text
@@ -500,8 +504,8 @@ def test_adapter_unknown_renders_human_readable():
 
 def test_adapter_unknown_no_registered_renders_without_error():
     """adapter_unknown with no registered adapters must not crash."""
-    ev = Evidence(kind="adapter_unknown", data={"tool": "missing-tool", "registered_adapters": []})
-    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.EXTERNAL)]
+    ev = Evidence(kind="adapter_unknown", data={"tool": "missing-tool", "registered": []})
+    diags = [_diag(status=Status.UNSUPPORTED, evidence=[ev], backend=Backend.EXTERNAL)]
     text = render_text(diags)
     assert "missing-tool" in text
     assert "not registered" in text
@@ -543,10 +547,13 @@ def test_json_unavailable_provider_unconfigured_failure_mode():
     assert parsed["diagnostics"][0]["failure_mode"] == "provider_unconfigured"
 
 
-def test_json_unavailable_adapter_unknown_failure_mode():
-    """Unavailable via adapter_unknown sets failure_mode to 'adapter_unknown'."""
-    ev = Evidence(kind="adapter_unknown", data={"tool": "textlint", "registered_adapters": []})
-    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.EXTERNAL)]
+def test_json_unsupported_adapter_unknown_failure_mode():
+    """Unsupported via adapter_unknown sets failure_mode to 'adapter_unknown'.
+
+    Uses production evidence shape: key "registered" and Status.UNSUPPORTED.
+    """
+    ev = Evidence(kind="adapter_unknown", data={"tool": "textlint", "registered": []})
+    diags = [_diag(status=Status.UNSUPPORTED, evidence=[ev], backend=Backend.EXTERNAL)]
     parsed = json.loads(render_json(diags))
     assert parsed["diagnostics"][0]["failure_mode"] == "adapter_unknown"
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -432,3 +432,164 @@ def test_json_includes_llm_judgment_evidence():
     assert ev_out["data"]["judgment"] == "fail"
     assert ev_out["data"]["primary_reason"] == "Missing usage section."
     assert isinstance(ev_out["data"]["supporting_evidence_quotes"], list)
+
+
+# ---------------------------------------------------------------------------
+# Failure-mode evidence rendering (issue #71)
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# _compact_evidence — human-readable failure kinds in render_text
+# ---------------------------------------------------------------------------
+
+
+def test_backend_capability_renders_human_readable():
+    """unsupported status: backend_capability evidence must read as a human sentence."""
+    ev = Evidence(
+        kind="backend_capability",
+        data={"backend": "filesystem", "kind": "semantic_rubric"},
+    )
+    diags = [_diag(status=Status.UNSUPPORTED, evidence=[ev])]
+    text = render_text(diags)
+    assert "filesystem backend does not support rule kind" in text
+    assert "semantic_rubric" in text
+    # Must NOT render raw key=value pairs
+    assert "backend=filesystem" not in text
+
+
+def test_provider_unconfigured_renders_human_readable():
+    """unavailable via provider_unconfigured: renders as human sentence."""
+    ev = Evidence(
+        kind="provider_unconfigured",
+        data={"provider": "none", "rule": "r1"},
+    )
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.LLM_RUBRIC)]
+    text = render_text(diags)
+    assert "LLM provider not configured" in text
+
+
+def test_provider_error_renders_human_readable():
+    """unavailable via provider_error: renders provider name and failure mode."""
+    ev = Evidence(
+        kind="provider_error",
+        data={
+            "provider": "anthropic",
+            "failure_mode": "rate_limit",
+            "detail": "429 Too Many Requests",
+        },
+    )
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.LLM_RUBRIC)]
+    text = render_text(diags)
+    assert "anthropic" in text
+    assert "rate_limit" in text
+
+
+def test_adapter_unknown_renders_human_readable():
+    """unavailable via adapter_unknown: renders adapter name."""
+    ev = Evidence(
+        kind="adapter_unknown",
+        data={"tool": "textlint", "registered_adapters": ["eslint", "shellcheck"]},
+    )
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.EXTERNAL)]
+    text = render_text(diags)
+    assert "textlint" in text
+    assert "not registered" in text
+    assert "eslint" in text
+
+
+def test_adapter_unknown_no_registered_renders_without_error():
+    """adapter_unknown with no registered adapters must not crash."""
+    ev = Evidence(kind="adapter_unknown", data={"tool": "missing-tool", "registered_adapters": []})
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.EXTERNAL)]
+    text = render_text(diags)
+    assert "missing-tool" in text
+    assert "not registered" in text
+
+
+def test_params_error_renders_human_readable():
+    """error status via params_error: renders the missing field."""
+    ev = Evidence(kind="params_error", data={"missing": "pattern"})
+    diags = [_diag(status=Status.ERROR, evidence=[ev])]
+    text = render_text(diags)
+    assert "missing required field" in text
+    assert "pattern" in text
+
+
+# ---------------------------------------------------------------------------
+# render_json — failure_mode field (backwards-compat addition)
+# ---------------------------------------------------------------------------
+
+
+def test_json_pass_has_failure_mode_null():
+    """Pass diagnostics must have failure_mode: null."""
+    diags = [_diag(status=Status.PASS)]
+    parsed = json.loads(render_json(diags))
+    assert parsed["diagnostics"][0]["failure_mode"] is None
+
+
+def test_json_fail_has_failure_mode():
+    """Fail diagnostics must have a non-null failure_mode."""
+    diags = [_diag(status=Status.FAIL)]
+    parsed = json.loads(render_json(diags))
+    assert parsed["diagnostics"][0]["failure_mode"] is not None
+
+
+def test_json_unavailable_provider_unconfigured_failure_mode():
+    """Unavailable via provider_unconfigured sets failure_mode to 'provider_unconfigured'."""
+    ev = Evidence(kind="provider_unconfigured", data={"provider": "none"})
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.LLM_RUBRIC)]
+    parsed = json.loads(render_json(diags))
+    assert parsed["diagnostics"][0]["failure_mode"] == "provider_unconfigured"
+
+
+def test_json_unavailable_adapter_unknown_failure_mode():
+    """Unavailable via adapter_unknown sets failure_mode to 'adapter_unknown'."""
+    ev = Evidence(kind="adapter_unknown", data={"tool": "textlint", "registered_adapters": []})
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.EXTERNAL)]
+    parsed = json.loads(render_json(diags))
+    assert parsed["diagnostics"][0]["failure_mode"] == "adapter_unknown"
+
+
+def test_json_unsupported_backend_capability_failure_mode():
+    """Unsupported status with backend_capability evidence sets failure_mode to
+    'unsupported_rule_kind'."""
+    ev = Evidence(
+        kind="backend_capability",
+        data={"backend": "filesystem", "kind": "semantic_rubric"},
+    )
+    diags = [_diag(status=Status.UNSUPPORTED, evidence=[ev])]
+    parsed = json.loads(render_json(diags))
+    assert parsed["diagnostics"][0]["failure_mode"] == "unsupported_rule_kind"
+
+
+def test_json_failure_mode_does_not_alter_existing_fields():
+    """Adding failure_mode must not change any existing JSON fields (backwards-compat)."""
+    ev = _ev("text_match", path="AGENTS.md", match_count=0)
+    diags = [_diag(status=Status.FAIL, evidence=[ev])]
+    parsed = json.loads(render_json(diags))
+    diag = parsed["diagnostics"][0]
+    # Pre-existing fields must still be present
+    assert "rule_id" in diag
+    assert "status" in diag
+    assert "backend" in diag
+    assert "severity" in diag
+    assert "message" in diag
+    assert "evidence" in diag
+    # New field added
+    assert "failure_mode" in diag
+
+
+def test_json_provider_error_failure_mode_from_evidence():
+    """provider_error evidence carries its own failure_mode tag; render_json should use it."""
+    ev = Evidence(
+        kind="provider_error",
+        data={
+            "provider": "openai",
+            "failure_mode": "invalid_json",
+            "detail": "No JSON found",
+        },
+    )
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.LLM_RUBRIC)]
+    parsed = json.loads(render_json(diags))
+    assert parsed["diagnostics"][0]["failure_mode"] == "invalid_json"


### PR DESCRIPTION
## Summary

- Add human-readable text rendering for well-known failure-mode evidence kinds (`backend_capability`, `provider_unconfigured`, `provider_error`, `adapter_unknown`, `params_error`) in `render_text()` — these produce concise, actionable phrases instead of raw `key=value` pairs.
- Add `_derive_failure_mode()` which maps diagnostic evidence to short tags (`unsupported_rule_kind`, `provider_unconfigured`, `llm_fail`, `adapter_unknown`, etc.).
- Extend `render_json()` with a backwards-compatible `failure_mode` field on every diagnostic (`null` for pass, a short tag for non-pass), making CI consumers able to branch on failure type without parsing free-form text.
- Add 13 new tests in `tests/test_diagnostics.py` covering all evidence kinds and JSON output shape.

Closes #71

## Test plan

- [x] `uv run pytest` — 695 passed
- [x] `uvx ruff check .` — clean
- [x] `uvx ruff format --check .` — no changes
- [x] `uvx pyright` — pre-existing import errors only (pytest resolution in tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)