### PR TITLE
feat(llm-rubric): reproducibility metric and --reproducibility N CLI flag

### DIFF
--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -475,3 +475,79 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
         evidence=[evidence],
         remediation=parsed.suggested_action,
     )
+
+
+# ---------------------------------------------------------------------------
+# Reproducibility (#68)
+# ---------------------------------------------------------------------------
+
+
+def run_n(rule: Rule, target: str | Path, n: int) -> Diagnostic:
+    """Evaluate *rule* against *target* ``n`` times and aggregate the result.
+
+    Reproducibility metric (#68): runs ``check`` ``n`` times, then aggregates the
+    structured ``pass`` / ``fail`` outcomes via simple majority vote. Ties break
+    toward ``fail`` (fail-closed). The returned diagnostic is the first run that
+    matches the majority judgment, with an additional
+    ``Evidence(kind="reproducibility_score", ...)`` appended carrying:
+
+    - ``score``: agreement rate of the majority judgment, in ``[0.0, 1.0]``;
+    - ``n``: the requested number of runs;
+    - ``pass_count``: how many runs returned ``pass``;
+    - ``majority_judgment``: ``"pass"`` or ``"fail"``.
+
+    Behaviour rules
+    ---------------
+    - ``n == 1`` is equivalent to ``check`` (no extra evidence appended).
+    - ``n < 1`` raises ``ValueError`` (caller must validate).
+    - If *any* run returns a non-pass/fail diagnostic (``UNAVAILABLE`` /
+      ``ERROR``), aggregation is abandoned and that diagnostic is returned
+      unchanged - fail-closed for unconfigured / error states.
+    """
+    if n < 1:
+        raise ValueError(f"reproducibility n must be >= 1, got {n}")
+
+    if n == 1:
+        return check(rule, target)
+
+    diagnostics: list[Diagnostic] = []
+    for _ in range(n):
+        diag = check(rule, target)
+        # Fail-closed on non-deterministic outcomes: if any run is unavailable
+        # or errored, don't synthesise a misleading reproducibility score.
+        if diag.status not in (Status.PASS, Status.FAIL):
+            return diag
+        diagnostics.append(diag)
+
+    pass_count = sum(1 for d in diagnostics if d.status is Status.PASS)
+    fail_count = n - pass_count
+    # Tie-break toward fail (fail-closed).
+    majority_is_pass = pass_count > fail_count
+    majority_judgment = "pass" if majority_is_pass else "fail"
+    majority_count = pass_count if majority_is_pass else fail_count
+    score = majority_count / n
+
+    # Pick the first diagnostic whose status matches the majority judgment so the
+    # rendered message and llm_judgment evidence are consistent with the score.
+    target_status = Status.PASS if majority_is_pass else Status.FAIL
+    representative = next(d for d in diagnostics if d.status is target_status)
+
+    repro_evidence = Evidence(
+        kind="reproducibility_score",
+        data={
+            "score": score,
+            "n": n,
+            "pass_count": pass_count,
+            "majority_judgment": majority_judgment,
+        },
+    )
+    return Diagnostic(
+        rule_id=representative.rule_id,
+        source=representative.source,
+        backend=representative.backend,
+        status=representative.status,
+        severity=representative.severity,
+        message=representative.message,
+        evidence=[*representative.evidence, repro_evidence],
+        remediation=representative.remediation,
+    )

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -62,6 +62,17 @@ def build_parser() -> argparse.ArgumentParser:
         default="text",
         help="output format (default: text)",
     )
+    validate_parser.add_argument(
+        "--reproducibility",
+        type=int,
+        default=1,
+        metavar="N",
+        help=(
+            "evaluate each LLM-rubric rule N times and record an agreement-rate "
+            "(reproducibility_score) evidence entry (default: 1; non-LLM backends "
+            "ignore this flag)"
+        ),
+    )
 
     return parser
 
@@ -154,8 +165,16 @@ def _cmd_validate(args: argparse.Namespace) -> int:
     ruleset = parser.parse(str(doc_path), content)
     ruleset = classifier.classify(ruleset)
 
+    # Validate reproducibility argument.
+    if args.reproducibility < 1:
+        print(
+            f"error: --reproducibility must be >= 1, got {args.reproducibility}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+
     # Run validation.
-    report = validator.validate(ruleset, args.target, backend=backend)
+    report = validator.validate(ruleset, args.target, backend=backend, reproducibility=args.reproducibility)
 
     # Render output.
     if args.format == "json":

--- a/src/gate_keeper/diagnostics.py
+++ b/src/gate_keeper/diagnostics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Sequence
+from typing import Any, Sequence
 
 from gate_keeper.models import Diagnostic, DiagnosticReport, Rule, Status
 
@@ -12,6 +12,18 @@ EXIT_FAIL = 1
 EXIT_USAGE = 2
 
 _NON_PASS = frozenset({Status.FAIL, Status.UNAVAILABLE, Status.UNSUPPORTED, Status.ERROR})
+
+# Evidence kinds whose data is expanded into a human-readable phrase rather than
+# raw key=value pairs in the compact text renderer.
+_HUMAN_READABLE_KINDS = frozenset(
+    {
+        "backend_capability",
+        "provider_unconfigured",
+        "provider_error",
+        "adapter_unknown",
+        "params_error",
+    }
+)
 
 
 def compute_exit_code(diagnostics: Sequence[Diagnostic]) -> int:
@@ -31,10 +43,41 @@ def _safe_value(v: object) -> str:
     return str(v).replace("\r", "\\r").replace("\n", "\\n")
 
 
+def _human_readable_evidence(kind: str, data: dict[str, Any]) -> str:
+    """Return a concise human-readable string for well-known failure-mode evidence kinds.
+
+    Falls back to the raw key=value form for unrecognised kinds.
+    """
+    if kind == "backend_capability":
+        backend = data.get("backend", "?")
+        rule_kind = data.get("kind", "?")
+        return f"{backend} backend does not support rule kind '{rule_kind}'"
+    if kind == "provider_unconfigured":
+        return "LLM provider not configured (see docs/llm-rubric.md)"
+    if kind == "provider_error":
+        failure_mode = data.get("failure_mode", "unknown")
+        provider = data.get("provider", "?")
+        detail = _safe_value(data.get("detail", ""))
+        return f"LLM provider error ({provider}): {failure_mode} — {detail}"
+    if kind == "adapter_unknown":
+        tool = _safe_value(data.get("tool", "?"))
+        registered = data.get("registered_adapters", [])
+        if registered:
+            return f"adapter '{tool}' not registered (known: {', '.join(str(a) for a in registered)})"
+        return f"adapter '{tool}' not registered"
+    if kind == "params_error":
+        missing = _safe_value(data.get("missing", "?"))
+        return f"rule params missing required field '{missing}'"
+    # Generic fallback: key=value pairs
+    return ", ".join(f"{k}={_safe_value(v)}" for k, v in data.items())
+
+
 def _compact_evidence(diagnostic: Diagnostic) -> str:
     parts = []
     for e in diagnostic.evidence:
-        if e.data:
+        if e.kind in _HUMAN_READABLE_KINDS:
+            parts.append(_human_readable_evidence(e.kind, e.data))
+        elif e.data:
             pairs = ", ".join(f"{k}={_safe_value(v)}" for k, v in e.data.items())
             parts.append(f"{e.kind}({pairs})")
         else:
@@ -42,10 +85,41 @@ def _compact_evidence(diagnostic: Diagnostic) -> str:
     return "; ".join(parts)
 
 
+def _derive_failure_mode(diagnostic: Diagnostic) -> str | None:
+    """Derive a short failure_mode tag from a diagnostic's evidence, or None for pass.
+
+    Used by ``render_json`` to add a ``failure_mode`` field (#71).
+    """
+    if diagnostic.status is Status.PASS:
+        return None
+    for e in diagnostic.evidence:
+        if e.kind == "backend_capability":
+            return "unsupported_rule_kind"
+        if e.kind == "provider_unconfigured":
+            return "provider_unconfigured"
+        if e.kind == "provider_error":
+            return str(e.data.get("failure_mode", "provider_error"))
+        if e.kind == "adapter_unknown":
+            return "adapter_unknown"
+        if e.kind == "params_error":
+            return "params_error"
+        if e.kind == "llm_judgment":
+            judgment = e.data.get("judgment", "")
+            return f"llm_{judgment}" if judgment else "llm_fail"
+        if e.kind in ("exception", "io_error"):
+            return e.kind
+    # Fall back to status value if no specific evidence kind matched
+    return diagnostic.status.value
+
+
 def render_text(diagnostics: Sequence[Diagnostic]) -> str:
     """Render diagnostics as compiler-style text lines.
 
     Each line: path:line: severity: [backend/status] rule_id: message [evidence]
+
+    Known failure-mode evidence kinds (backend_capability, provider_unconfigured,
+    provider_error, adapter_unknown, params_error) are rendered as concise
+    human-readable phrases rather than raw key=value pairs.
     """
     lines = []
     for d in diagnostics:
@@ -56,7 +130,7 @@ def render_text(diagnostics: Sequence[Diagnostic]) -> str:
             f"{d.severity.value}: "
             f"[{d.backend.value}/{d.status.value}] "
             f"{d.rule_id}: "
-            f"{d.message}"
+            f"{_safe_value(d.message)}"
             f"{evidence_part}"
         )
     return "\n".join(lines)
@@ -87,6 +161,12 @@ def render_json(diagnostics: Sequence[Diagnostic]) -> str:
     """Render diagnostics as deterministic JSON for CI consumers.
 
     The status field is preserved exactly — unavailable is distinct from fail.
+    A ``failure_mode`` field is added to each diagnostic: ``null`` for pass,
+    a short descriptive tag for fail/unavailable/unsupported/error (#71).
+    Existing fields are unchanged (backwards-compatible addition).
     """
     report = DiagnosticReport(diagnostics=list(diagnostics))
-    return json.dumps(report.to_dict(), sort_keys=True, indent=2)
+    data = report.to_dict()
+    for diag_dict, diag in zip(data["diagnostics"], diagnostics):
+        diag_dict["failure_mode"] = _derive_failure_mode(diag)
+    return json.dumps(data, sort_keys=True, indent=2)

--- a/src/gate_keeper/validator.py
+++ b/src/gate_keeper/validator.py
@@ -84,6 +84,7 @@ def validate(
     ruleset: RuleSet,
     target: str | Path,
     backend: str = "auto",
+    reproducibility: int = 1,
 ) -> DiagnosticReport:
     """Validate *ruleset* against *target* using *backend*.
 
@@ -96,6 +97,11 @@ def validate(
     backend:
         ``"auto"`` dispatches each rule by its ``backend_hint``; any other
         registered name sends all rules to that single backend.
+    reproducibility:
+        Number of times to evaluate each LLM-rubric rule (#68). The default ``1``
+        preserves the original behaviour. Values ``> 1`` apply only to rules
+        dispatched to the ``llm-rubric`` backend; non-LLM backends ignore this
+        parameter. Must be ``>= 1``.
 
     Returns
     -------
@@ -104,6 +110,8 @@ def validate(
     """
     if backend != "auto" and not _registry.is_registered(backend):
         raise ValueError(f"unknown backend {backend!r}; registered names: {_registry.BACKEND_NAMES}")
+    if reproducibility < 1:
+        raise ValueError(f"reproducibility must be >= 1, got {reproducibility}")
 
     diagnostics: list[Diagnostic] = []
     for rule in ruleset.rules:
@@ -134,7 +142,14 @@ def validate(
             )
         else:
             try:
-                diag = check_fn(rule, target)
+                # #68: only the llm-rubric backend has a meaningful reproducibility
+                # path; for other backends an N>1 setting is silently ignored.
+                if reproducibility > 1 and resolved_name == "llm-rubric":
+                    from gate_keeper.backends import llm_rubric as _llm_mod
+
+                    diag = _llm_mod.run_n(rule, target, reproducibility)
+                else:
+                    diag = check_fn(rule, target)
             except Exception as exc:  # noqa: BLE001
                 diag = _error_diagnostic(rule, exc, _backend_for(resolved_name))
         diagnostics.append(diag)

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -345,3 +345,142 @@ class TestDiagnosticFields:
         captured = capsys.readouterr()
         # text format: [backend/status] in every line
         assert "[filesystem/" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# --reproducibility flag (#68)
+# ---------------------------------------------------------------------------
+
+
+class TestReproducibilityFlag:
+    """CLI plumbing for ``--reproducibility N`` (#68)."""
+
+    def test_default_reproducibility_is_one(self, capsys):
+        """Without --reproducibility the default is 1 (existing behaviour)."""
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+                "--format",
+                "text",
+            ]
+        )
+        assert rc == EXIT_OK
+
+    def test_reproducibility_zero_rejected(self, capsys):
+        """N < 1 is rejected as a usage error."""
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+                "--reproducibility",
+                "0",
+            ]
+        )
+        assert rc == EXIT_USAGE
+        captured = capsys.readouterr()
+        assert "--reproducibility" in captured.err
+
+    def test_reproducibility_negative_rejected(self, capsys):
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+                "--reproducibility",
+                "-3",
+            ]
+        )
+        assert rc == EXIT_USAGE
+
+    def test_non_llm_backend_ignores_reproducibility(self, capsys):
+        """File-system backend ignores --reproducibility (no-op, no extra evidence)."""
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+                "--reproducibility",
+                "5",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == EXIT_OK
+        captured = capsys.readouterr()
+        report = json.loads(captured.out)
+        # No reproducibility_score evidence on file-system rules.
+        for diag in report["diagnostics"]:
+            for ev in diag["evidence"]:
+                assert ev["kind"] != "reproducibility_score"
+
+    def test_llm_backend_reproducibility_records_score(self, monkeypatch, tmp_path, capsys):
+        """LLM-rubric backend with N>1 records reproducibility_score evidence."""
+        from gate_keeper.backends import llm_rubric as llm_backend
+
+        # Configure provider via patched env, mock provider call.
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "anthropic",
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+        }
+        monkeypatch.setattr(llm_backend, "_load_env_file", lambda *a, **k: env)
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: json.dumps(
+                {
+                    "judgment": "pass",
+                    "primary_reason": "looks good",
+                    "supporting_evidence_quotes": [],
+                    "suggested_action": None,
+                }
+            ),
+        )
+
+        # Build a minimal semantic rule document.
+        rules_doc = tmp_path / "semantic-rules.md"
+        rules_doc.write_text(
+            "# Rules\n\n## R1\n\nThe documentation should be clear and comprehensive.\n",
+            encoding="utf-8",
+        )
+
+        rc = main(
+            [
+                "validate",
+                str(rules_doc),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "auto",
+                "--reproducibility",
+                "3",
+                "--format",
+                "json",
+            ]
+        )
+        captured = capsys.readouterr()
+        report = json.loads(captured.out)
+        # At least one diagnostic must carry the reproducibility_score evidence.
+        repro_count = 0
+        for diag in report["diagnostics"]:
+            for ev in diag["evidence"]:
+                if ev["kind"] == "reproducibility_score":
+                    repro_count += 1
+                    assert ev["data"]["n"] == 3
+                    assert 0.0 <= ev["data"]["score"] <= 1.0
+        assert repro_count >= 1, "expected at least one reproducibility_score evidence in JSON output"
+        assert rc == EXIT_OK

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -273,3 +273,164 @@ def test_json_keys_sorted():
     parsed = json.loads(raw)
     diag_keys = list(parsed["diagnostics"][0].keys())
     assert diag_keys == sorted(diag_keys)
+
+
+# ---------------------------------------------------------------------------
+# Failure-mode evidence rendering (issue #71)
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# _compact_evidence — human-readable failure kinds in render_text
+# ---------------------------------------------------------------------------
+
+
+def test_backend_capability_renders_human_readable():
+    """unsupported status: backend_capability evidence must read as a human sentence."""
+    ev = Evidence(
+        kind="backend_capability",
+        data={"backend": "filesystem", "kind": "semantic_rubric"},
+    )
+    diags = [_diag(status=Status.UNSUPPORTED, evidence=[ev])]
+    text = render_text(diags)
+    assert "filesystem backend does not support rule kind" in text
+    assert "semantic_rubric" in text
+    # Must NOT render raw key=value pairs
+    assert "backend=filesystem" not in text
+
+
+def test_provider_unconfigured_renders_human_readable():
+    """unavailable via provider_unconfigured: renders as human sentence."""
+    ev = Evidence(
+        kind="provider_unconfigured",
+        data={"provider": "none", "rule": "r1"},
+    )
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.LLM_RUBRIC)]
+    text = render_text(diags)
+    assert "LLM provider not configured" in text
+
+
+def test_provider_error_renders_human_readable():
+    """unavailable via provider_error: renders provider name and failure mode."""
+    ev = Evidence(
+        kind="provider_error",
+        data={
+            "provider": "anthropic",
+            "failure_mode": "rate_limit",
+            "detail": "429 Too Many Requests",
+        },
+    )
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.LLM_RUBRIC)]
+    text = render_text(diags)
+    assert "anthropic" in text
+    assert "rate_limit" in text
+
+
+def test_adapter_unknown_renders_human_readable():
+    """unavailable via adapter_unknown: renders adapter name."""
+    ev = Evidence(
+        kind="adapter_unknown",
+        data={"tool": "textlint", "registered_adapters": ["eslint", "shellcheck"]},
+    )
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.EXTERNAL)]
+    text = render_text(diags)
+    assert "textlint" in text
+    assert "not registered" in text
+    assert "eslint" in text
+
+
+def test_adapter_unknown_no_registered_renders_without_error():
+    """adapter_unknown with no registered adapters must not crash."""
+    ev = Evidence(kind="adapter_unknown", data={"tool": "missing-tool", "registered_adapters": []})
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.EXTERNAL)]
+    text = render_text(diags)
+    assert "missing-tool" in text
+    assert "not registered" in text
+
+
+def test_params_error_renders_human_readable():
+    """error status via params_error: renders the missing field."""
+    ev = Evidence(kind="params_error", data={"missing": "pattern"})
+    diags = [_diag(status=Status.ERROR, evidence=[ev])]
+    text = render_text(diags)
+    assert "missing required field" in text
+    assert "pattern" in text
+
+
+# ---------------------------------------------------------------------------
+# render_json — failure_mode field (backwards-compat addition)
+# ---------------------------------------------------------------------------
+
+
+def test_json_pass_has_failure_mode_null():
+    """Pass diagnostics must have failure_mode: null."""
+    diags = [_diag(status=Status.PASS)]
+    parsed = json.loads(render_json(diags))
+    assert parsed["diagnostics"][0]["failure_mode"] is None
+
+
+def test_json_fail_has_failure_mode():
+    """Fail diagnostics must have a non-null failure_mode."""
+    diags = [_diag(status=Status.FAIL)]
+    parsed = json.loads(render_json(diags))
+    assert parsed["diagnostics"][0]["failure_mode"] is not None
+
+
+def test_json_unavailable_provider_unconfigured_failure_mode():
+    """Unavailable via provider_unconfigured sets failure_mode to 'provider_unconfigured'."""
+    ev = Evidence(kind="provider_unconfigured", data={"provider": "none"})
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.LLM_RUBRIC)]
+    parsed = json.loads(render_json(diags))
+    assert parsed["diagnostics"][0]["failure_mode"] == "provider_unconfigured"
+
+
+def test_json_unavailable_adapter_unknown_failure_mode():
+    """Unavailable via adapter_unknown sets failure_mode to 'adapter_unknown'."""
+    ev = Evidence(kind="adapter_unknown", data={"tool": "textlint", "registered_adapters": []})
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.EXTERNAL)]
+    parsed = json.loads(render_json(diags))
+    assert parsed["diagnostics"][0]["failure_mode"] == "adapter_unknown"
+
+
+def test_json_unsupported_backend_capability_failure_mode():
+    """Unsupported status with backend_capability evidence sets failure_mode to
+    'unsupported_rule_kind'."""
+    ev = Evidence(
+        kind="backend_capability",
+        data={"backend": "filesystem", "kind": "semantic_rubric"},
+    )
+    diags = [_diag(status=Status.UNSUPPORTED, evidence=[ev])]
+    parsed = json.loads(render_json(diags))
+    assert parsed["diagnostics"][0]["failure_mode"] == "unsupported_rule_kind"
+
+
+def test_json_failure_mode_does_not_alter_existing_fields():
+    """Adding failure_mode must not change any existing JSON fields (backwards-compat)."""
+    ev = _ev("text_match", path="AGENTS.md", match_count=0)
+    diags = [_diag(status=Status.FAIL, evidence=[ev])]
+    parsed = json.loads(render_json(diags))
+    diag = parsed["diagnostics"][0]
+    # Pre-existing fields must still be present
+    assert "rule_id" in diag
+    assert "status" in diag
+    assert "backend" in diag
+    assert "severity" in diag
+    assert "message" in diag
+    assert "evidence" in diag
+    # New field added
+    assert "failure_mode" in diag
+
+
+def test_json_provider_error_failure_mode_from_evidence():
+    """provider_error evidence carries its own failure_mode tag; render_json should use it."""
+    ev = Evidence(
+        kind="provider_error",
+        data={
+            "provider": "openai",
+            "failure_mode": "invalid_json",
+            "detail": "No JSON found",
+        },
+    )
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.LLM_RUBRIC)]
+    parsed = json.loads(render_json(diags))
+    assert parsed["diagnostics"][0]["failure_mode"] == "invalid_json"

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -612,3 +612,149 @@ class TestPathConstants:
     def test_dotenv_path_matches_spec(self):
         """Issue #51 hard-codes the host-side dotenv path; do not regress it."""
         assert llm_backend.DOTENV_PATH == Path("/home/vscode/.config/hermes-projects/gate-keeper.env")
+
+
+# ---------------------------------------------------------------------------
+# Reproducibility metric (#68): run_n
+# ---------------------------------------------------------------------------
+
+
+class TestRunN:
+    """Tests for ``llm_rubric.run_n`` — reproducibility aggregation (#68)."""
+
+    _ENV = {
+        "GATE_KEEPER_LLM_PROVIDER": "anthropic",
+        "ANTHROPIC_API_KEY": "sk-ant-test",
+    }
+
+    def test_n_must_be_at_least_one(self, tmp_path):
+        with pytest.raises(ValueError):
+            llm_backend.run_n(_semantic_rule(), tmp_path, 0)
+
+    def test_n_one_is_equivalent_to_check(self, monkeypatch, tmp_path):
+        """n=1 returns the same diagnostic as ``check`` (no extra evidence)."""
+        _patch_env(monkeypatch, self._ENV)
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda key, system, user, model: _VALID_PASS_JSON,
+        )
+        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 1)
+        # Only the llm_judgment evidence — no reproducibility_score appended.
+        assert len(diag.evidence) == 1
+        assert diag.evidence[0].kind == "llm_judgment"
+        assert diag.status is Status.PASS
+
+    def test_unanimous_pass_score_is_one(self, monkeypatch, tmp_path):
+        _patch_env(monkeypatch, self._ENV)
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: _VALID_PASS_JSON,
+        )
+        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
+        assert diag.status is Status.PASS
+        # last evidence is the reproducibility entry
+        repro = diag.evidence[-1]
+        assert repro.kind == "reproducibility_score"
+        assert repro.data["score"] == 1.0
+        assert repro.data["n"] == 3
+        assert repro.data["pass_count"] == 3
+        assert repro.data["majority_judgment"] == "pass"
+
+    def test_unanimous_fail_score_is_one(self, monkeypatch, tmp_path):
+        _patch_env(monkeypatch, self._ENV)
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: _VALID_FAIL_JSON,
+        )
+        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
+        assert diag.status is Status.FAIL
+        repro = diag.evidence[-1]
+        assert repro.kind == "reproducibility_score"
+        assert repro.data["score"] == 1.0
+        assert repro.data["pass_count"] == 0
+        assert repro.data["majority_judgment"] == "fail"
+
+    def test_mixed_majority_pass(self, monkeypatch, tmp_path):
+        """2 pass + 1 fail in 3 runs -> pass with score 2/3."""
+        _patch_env(monkeypatch, self._ENV)
+        responses = iter([_VALID_PASS_JSON, _VALID_FAIL_JSON, _VALID_PASS_JSON])
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: next(responses),
+        )
+        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
+        assert diag.status is Status.PASS
+        repro = diag.evidence[-1]
+        assert repro.kind == "reproducibility_score"
+        assert repro.data["pass_count"] == 2
+        assert abs(repro.data["score"] - 2 / 3) < 1e-9
+        assert repro.data["majority_judgment"] == "pass"
+
+    def test_mixed_majority_fail(self, monkeypatch, tmp_path):
+        """1 pass + 2 fail in 3 runs -> fail with score 2/3."""
+        _patch_env(monkeypatch, self._ENV)
+        responses = iter([_VALID_FAIL_JSON, _VALID_PASS_JSON, _VALID_FAIL_JSON])
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: next(responses),
+        )
+        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
+        assert diag.status is Status.FAIL
+        repro = diag.evidence[-1]
+        assert repro.kind == "reproducibility_score"
+        assert repro.data["pass_count"] == 1
+        assert abs(repro.data["score"] - 2 / 3) < 1e-9
+        assert repro.data["majority_judgment"] == "fail"
+
+    def test_tie_breaks_toward_fail(self, monkeypatch, tmp_path):
+        """Even N with 50/50 split -> fail-closed."""
+        _patch_env(monkeypatch, self._ENV)
+        responses = iter([_VALID_PASS_JSON, _VALID_FAIL_JSON])
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: next(responses),
+        )
+        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 2)
+        assert diag.status is Status.FAIL
+        repro = diag.evidence[-1]
+        assert repro.data["pass_count"] == 1
+        assert repro.data["score"] == 0.5
+        assert repro.data["majority_judgment"] == "fail"
+
+    def test_unconfigured_returns_unavailable_without_aggregation(self, tmp_path):
+        """When provider is unconfigured, run_n short-circuits to UNAVAILABLE."""
+        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 5)
+        assert diag.status is Status.UNAVAILABLE
+        # No reproducibility_score evidence (aggregation aborted).
+        assert all(e.kind != "reproducibility_score" for e in diag.evidence)
+
+    def test_provider_error_short_circuits(self, monkeypatch, tmp_path):
+        """If any single run errors, return that diagnostic without aggregating."""
+        _patch_env(monkeypatch, self._ENV)
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("transient 503")
+
+        monkeypatch.setattr(llm_backend, "_call_anthropic", _boom)
+        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "provider_error"
+        assert all(e.kind != "reproducibility_score" for e in diag.evidence)
+
+    def test_calls_provider_n_times(self, monkeypatch, tmp_path):
+        _patch_env(monkeypatch, self._ENV)
+        call_count = {"n": 0}
+
+        def _counter(*_a, **_k):
+            call_count["n"] += 1
+            return _VALID_PASS_JSON
+
+        monkeypatch.setattr(llm_backend, "_call_anthropic", _counter)
+        llm_backend.run_n(_semantic_rule(), tmp_path, 5)
+        assert call_count["n"] == 5


### PR DESCRIPTION
## Summary

- Add `llm_rubric.run_n(rule, target, n)`: runs `check()` n times, aggregates pass/fail via majority vote (ties → fail, fail-closed), and appends `Evidence(kind="reproducibility_score", ...)` carrying `score`, `n`, `pass_count`, and `majority_judgment`.
- Wire a `reproducibility: int = 1` parameter through `validator.validate`; values >1 dispatch llm-rubric rules through `run_n` while non-LLM backends silently ignore it.
- CLI: new `gate-keeper validate ... --reproducibility N` flag (default 1, rejects N<1 with EXIT_USAGE).
- Tests (15 new): run_n unanimous / mixed / tie-breaking / error short-circuit / call-count, plus CLI plumbing for default / invalid / non-LLM-ignored / LLM-records-score paths. All LLM calls mocked.

Note: based on `issue-71-failure-mode-evidence` so the failure-mode evidence renderer is available; once #71 lands this can be retargeted to main.

Closes #68

## Test plan

- [x] `uv run pytest` — 710 passed (was 695 before, +15 new)
- [x] `uvx ruff check .` — clean
- [x] `uvx ruff format --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)