### PR TITLE
feat(llm-rubric): reproducibility metric and --reproducibility N CLI flag (#68)

### DIFF
--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -475,3 +475,79 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
         evidence=[evidence],
         remediation=parsed.suggested_action,
     )
+
+
+# ---------------------------------------------------------------------------
+# Reproducibility (#68)
+# ---------------------------------------------------------------------------
+
+
+def run_n(rule: Rule, target: str | Path, n: int) -> Diagnostic:
+    """Evaluate *rule* against *target* ``n`` times and aggregate the result.
+
+    Reproducibility metric (#68): runs ``check`` ``n`` times, then aggregates the
+    structured ``pass`` / ``fail`` outcomes via simple majority vote. Ties break
+    toward ``fail`` (fail-closed). The returned diagnostic is the first run that
+    matches the majority judgment, with an additional
+    ``Evidence(kind="reproducibility_score", ...)`` appended carrying:
+
+    - ``score``: agreement rate of the majority judgment, in ``[0.0, 1.0]``;
+    - ``n``: the requested number of runs;
+    - ``pass_count``: how many runs returned ``pass``;
+    - ``majority_judgment``: ``"pass"`` or ``"fail"``.
+
+    Behaviour rules
+    ---------------
+    - ``n == 1`` is equivalent to ``check`` (no extra evidence appended).
+    - ``n < 1`` raises ``ValueError`` (caller must validate).
+    - If *any* run returns a non-pass/fail diagnostic (``UNAVAILABLE`` /
+      ``ERROR``), aggregation is abandoned and that diagnostic is returned
+      unchanged - fail-closed for unconfigured / error states.
+    """
+    if n < 1:
+        raise ValueError(f"reproducibility n must be >= 1, got {n}")
+
+    if n == 1:
+        return check(rule, target)
+
+    diagnostics: list[Diagnostic] = []
+    for _ in range(n):
+        diag = check(rule, target)
+        # Fail-closed on non-deterministic outcomes: if any run is unavailable
+        # or errored, don't synthesise a misleading reproducibility score.
+        if diag.status not in (Status.PASS, Status.FAIL):
+            return diag
+        diagnostics.append(diag)
+
+    pass_count = sum(1 for d in diagnostics if d.status is Status.PASS)
+    fail_count = n - pass_count
+    # Tie-break toward fail (fail-closed).
+    majority_is_pass = pass_count > fail_count
+    majority_judgment = "pass" if majority_is_pass else "fail"
+    majority_count = pass_count if majority_is_pass else fail_count
+    score = majority_count / n
+
+    # Pick the first diagnostic whose status matches the majority judgment so the
+    # rendered message and llm_judgment evidence are consistent with the score.
+    target_status = Status.PASS if majority_is_pass else Status.FAIL
+    representative = next(d for d in diagnostics if d.status is target_status)
+
+    repro_evidence = Evidence(
+        kind="reproducibility_score",
+        data={
+            "score": score,
+            "n": n,
+            "pass_count": pass_count,
+            "majority_judgment": majority_judgment,
+        },
+    )
+    return Diagnostic(
+        rule_id=representative.rule_id,
+        source=representative.source,
+        backend=representative.backend,
+        status=representative.status,
+        severity=representative.severity,
+        message=representative.message,
+        evidence=[*representative.evidence, repro_evidence],
+        remediation=representative.remediation,
+    )

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -10,6 +10,7 @@ rejected upstream — see hermes-engineering#149 and
 
 from __future__ import annotations
 
+import dataclasses
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -541,13 +542,7 @@ def run_n(rule: Rule, target: str | Path, n: int) -> Diagnostic:
             "majority_judgment": majority_judgment,
         },
     )
-    return Diagnostic(
-        rule_id=representative.rule_id,
-        source=representative.source,
-        backend=representative.backend,
-        status=representative.status,
-        severity=representative.severity,
-        message=representative.message,
+    return dataclasses.replace(
+        representative,
         evidence=[*representative.evidence, repro_evidence],
-        remediation=representative.remediation,
     )

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -69,6 +69,17 @@ def build_parser() -> argparse.ArgumentParser:
         default=False,
         help="expand structured rationale (llm-rubric) in text output",
     )
+    validate_parser.add_argument(
+        "--reproducibility",
+        type=int,
+        default=1,
+        metavar="N",
+        help=(
+            "evaluate each LLM-rubric rule N times and record an agreement-rate "
+            "(reproducibility_score) evidence entry (default: 1; non-LLM backends "
+            "ignore this flag)"
+        ),
+    )
 
     return parser
 
@@ -161,8 +172,16 @@ def _cmd_validate(args: argparse.Namespace) -> int:
     ruleset = parser.parse(str(doc_path), content)
     ruleset = classifier.classify(ruleset)
 
+    # Validate reproducibility argument.
+    if args.reproducibility < 1:
+        print(
+            f"error: --reproducibility must be >= 1, got {args.reproducibility}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+
     # Run validation.
-    report = validator.validate(ruleset, args.target, backend=backend)
+    report = validator.validate(ruleset, args.target, backend=backend, reproducibility=args.reproducibility)
 
     # Render output.
     if args.format == "json":

--- a/src/gate_keeper/validator.py
+++ b/src/gate_keeper/validator.py
@@ -13,9 +13,10 @@ Dispatch policy
 
 Error policy
 ------------
-The validator never raises.  Unexpected exceptions from a backend call are
-caught here and converted into ``Status.ERROR`` diagnostics so the pipeline
-always produces a report.
+``validate`` raises ``ValueError`` for invalid arguments (unknown backend name,
+``reproducibility < 1``).  Unexpected exceptions from backend calls are caught
+and converted into ``Status.ERROR`` diagnostics so the pipeline always produces
+a report for valid inputs.
 
 Rule ordering
 -------------
@@ -24,7 +25,9 @@ Diagnostics are emitted in the same order as ``ruleset.rules``.
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
+from typing import Callable
 
 from gate_keeper import backends as _registry
 from gate_keeper.models import (
@@ -80,6 +83,54 @@ def _resolve_backend_name(rule: Rule, backend_name: str) -> str:
     return backend_name
 
 
+def _run_n(
+    check_fn: Callable,
+    rule: Rule,
+    target: str | Path,
+    n: int,
+) -> Diagnostic:
+    """Run *check_fn* ``n`` times and aggregate via majority vote.
+
+    Mirrors ``llm_rubric.run_n`` semantics but calls *check_fn* (the registry
+    entry) instead of the backend module directly so stubs work correctly in
+    tests and future backend overrides.
+
+    Ties break toward fail (fail-closed). Returns early on the first
+    non-pass/fail diagnostic (UNAVAILABLE / ERROR) without synthesising a
+    reproducibility score (fail-closed for unconfigured states).
+    """
+    diags: list[Diagnostic] = []
+    for _ in range(n):
+        d = check_fn(rule, target)
+        if d.status not in (Status.PASS, Status.FAIL):
+            return d
+        diags.append(d)
+
+    pass_count = sum(1 for d in diags if d.status is Status.PASS)
+    fail_count = n - pass_count
+    majority_is_pass = pass_count > fail_count
+    majority_judgment = "pass" if majority_is_pass else "fail"
+    majority_count = pass_count if majority_is_pass else fail_count
+    score = majority_count / n
+
+    target_status = Status.PASS if majority_is_pass else Status.FAIL
+    representative = next(d for d in diags if d.status is target_status)
+
+    repro_evidence = Evidence(
+        kind="reproducibility_score",
+        data={
+            "score": score,
+            "n": n,
+            "pass_count": pass_count,
+            "majority_judgment": majority_judgment,
+        },
+    )
+    return dataclasses.replace(
+        representative,
+        evidence=[*representative.evidence, repro_evidence],
+    )
+
+
 def validate(
     ruleset: RuleSet,
     target: str | Path,
@@ -106,7 +157,15 @@ def validate(
     Returns
     -------
     DiagnosticReport
-        One ``Diagnostic`` per rule, in source order.  Never raises.
+        One ``Diagnostic`` per rule, in source order.
+
+    Raises
+    ------
+    ValueError
+        If *backend* is not ``"auto"`` and is not a registered backend name,
+        or if *reproducibility* is less than 1.  All other exceptions from
+        backend calls are caught and converted to ``Status.ERROR`` diagnostics
+        so the pipeline always produces a report.
     """
     if backend != "auto" and not _registry.is_registered(backend):
         raise ValueError(f"unknown backend {backend!r}; registered names: {_registry.BACKEND_NAMES}")
@@ -142,12 +201,11 @@ def validate(
             )
         else:
             try:
-                # #68: only the llm-rubric backend has a meaningful reproducibility
-                # path; for other backends an N>1 setting is silently ignored.
+                # #68: apply multi-run reproducibility for llm-rubric rules via
+                # the registry check_fn so stubs/overrides work in tests.
+                # Non-LLM backends silently ignore N>1.
                 if reproducibility > 1 and resolved_name == "llm-rubric":
-                    from gate_keeper.backends import llm_rubric as _llm_mod
-
-                    diag = _llm_mod.run_n(rule, target, reproducibility)
+                    diag = _run_n(check_fn, rule, target, reproducibility)
                 else:
                     diag = check_fn(rule, target)
             except Exception as exc:  # noqa: BLE001

--- a/src/gate_keeper/validator.py
+++ b/src/gate_keeper/validator.py
@@ -84,6 +84,7 @@ def validate(
     ruleset: RuleSet,
     target: str | Path,
     backend: str = "auto",
+    reproducibility: int = 1,
 ) -> DiagnosticReport:
     """Validate *ruleset* against *target* using *backend*.
 
@@ -96,6 +97,11 @@ def validate(
     backend:
         ``"auto"`` dispatches each rule by its ``backend_hint``; any other
         registered name sends all rules to that single backend.
+    reproducibility:
+        Number of times to evaluate each LLM-rubric rule (#68). The default ``1``
+        preserves the original behaviour. Values ``> 1`` apply only to rules
+        dispatched to the ``llm-rubric`` backend; non-LLM backends ignore this
+        parameter. Must be ``>= 1``.
 
     Returns
     -------
@@ -104,6 +110,8 @@ def validate(
     """
     if backend != "auto" and not _registry.is_registered(backend):
         raise ValueError(f"unknown backend {backend!r}; registered names: {_registry.BACKEND_NAMES}")
+    if reproducibility < 1:
+        raise ValueError(f"reproducibility must be >= 1, got {reproducibility}")
 
     diagnostics: list[Diagnostic] = []
     for rule in ruleset.rules:
@@ -134,7 +142,14 @@ def validate(
             )
         else:
             try:
-                diag = check_fn(rule, target)
+                # #68: only the llm-rubric backend has a meaningful reproducibility
+                # path; for other backends an N>1 setting is silently ignored.
+                if reproducibility > 1 and resolved_name == "llm-rubric":
+                    from gate_keeper.backends import llm_rubric as _llm_mod
+
+                    diag = _llm_mod.run_n(rule, target, reproducibility)
+                else:
+                    diag = check_fn(rule, target)
             except Exception as exc:  # noqa: BLE001
                 diag = _error_diagnostic(rule, exc, _backend_for(resolved_name))
         diagnostics.append(diag)

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -529,3 +529,142 @@ class TestVerboseFlag:
         captured = capsys.readouterr()
         lines = captured.out.strip().splitlines()
         assert len(lines) > 1, "-v must expand llm-rubric output just like --verbose"
+
+
+# ---------------------------------------------------------------------------
+# --reproducibility flag (#68)
+# ---------------------------------------------------------------------------
+
+
+class TestReproducibilityFlag:
+    """CLI plumbing for ``--reproducibility N`` (#68)."""
+
+    def test_default_reproducibility_is_one(self, capsys):
+        """Without --reproducibility the default is 1 (existing behaviour)."""
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+                "--format",
+                "text",
+            ]
+        )
+        assert rc == EXIT_OK
+
+    def test_reproducibility_zero_rejected(self, capsys):
+        """N < 1 is rejected as a usage error."""
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+                "--reproducibility",
+                "0",
+            ]
+        )
+        assert rc == EXIT_USAGE
+        captured = capsys.readouterr()
+        assert "--reproducibility" in captured.err
+
+    def test_reproducibility_negative_rejected(self, capsys):
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+                "--reproducibility",
+                "-3",
+            ]
+        )
+        assert rc == EXIT_USAGE
+
+    def test_non_llm_backend_ignores_reproducibility(self, capsys):
+        """File-system backend ignores --reproducibility (no-op, no extra evidence)."""
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+                "--reproducibility",
+                "5",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == EXIT_OK
+        captured = capsys.readouterr()
+        report = json.loads(captured.out)
+        # No reproducibility_score evidence on file-system rules.
+        for diag in report["diagnostics"]:
+            for ev in diag["evidence"]:
+                assert ev["kind"] != "reproducibility_score"
+
+    def test_llm_backend_reproducibility_records_score(self, monkeypatch, tmp_path, capsys):
+        """LLM-rubric backend with N>1 records reproducibility_score evidence."""
+        from gate_keeper.backends import llm_rubric as llm_backend
+
+        # Configure provider via patched env, mock provider call.
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "anthropic",
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+        }
+        monkeypatch.setattr(llm_backend, "_load_env_file", lambda *a, **k: env)
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: json.dumps(
+                {
+                    "judgment": "pass",
+                    "primary_reason": "looks good",
+                    "supporting_evidence_quotes": [],
+                    "suggested_action": None,
+                }
+            ),
+        )
+
+        # Build a minimal semantic rule document.
+        rules_doc = tmp_path / "semantic-rules.md"
+        rules_doc.write_text(
+            "# Rules\n\n## R1\n\nThe documentation should be clear and comprehensive.\n",
+            encoding="utf-8",
+        )
+
+        rc = main(
+            [
+                "validate",
+                str(rules_doc),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "auto",
+                "--reproducibility",
+                "3",
+                "--format",
+                "json",
+            ]
+        )
+        captured = capsys.readouterr()
+        report = json.loads(captured.out)
+        # At least one diagnostic must carry the reproducibility_score evidence.
+        repro_count = 0
+        for diag in report["diagnostics"]:
+            for ev in diag["evidence"]:
+                if ev["kind"] == "reproducibility_score":
+                    repro_count += 1
+                    assert ev["data"]["n"] == 3
+                    assert 0.0 <= ev["data"]["score"] <= 1.0
+        assert repro_count >= 1, "expected at least one reproducibility_score evidence in JSON output"
+        assert rc == EXIT_OK

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -612,3 +612,149 @@ class TestPathConstants:
     def test_dotenv_path_matches_spec(self):
         """Issue #51 hard-codes the host-side dotenv path; do not regress it."""
         assert llm_backend.DOTENV_PATH == Path("/home/vscode/.config/hermes-projects/gate-keeper.env")
+
+
+# ---------------------------------------------------------------------------
+# Reproducibility metric (#68): run_n
+# ---------------------------------------------------------------------------
+
+
+class TestRunN:
+    """Tests for ``llm_rubric.run_n`` — reproducibility aggregation (#68)."""
+
+    _ENV = {
+        "GATE_KEEPER_LLM_PROVIDER": "anthropic",
+        "ANTHROPIC_API_KEY": "sk-ant-test",
+    }
+
+    def test_n_must_be_at_least_one(self, tmp_path):
+        with pytest.raises(ValueError):
+            llm_backend.run_n(_semantic_rule(), tmp_path, 0)
+
+    def test_n_one_is_equivalent_to_check(self, monkeypatch, tmp_path):
+        """n=1 returns the same diagnostic as ``check`` (no extra evidence)."""
+        _patch_env(monkeypatch, self._ENV)
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda key, system, user, model: _VALID_PASS_JSON,
+        )
+        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 1)
+        # Only the llm_judgment evidence — no reproducibility_score appended.
+        assert len(diag.evidence) == 1
+        assert diag.evidence[0].kind == "llm_judgment"
+        assert diag.status is Status.PASS
+
+    def test_unanimous_pass_score_is_one(self, monkeypatch, tmp_path):
+        _patch_env(monkeypatch, self._ENV)
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: _VALID_PASS_JSON,
+        )
+        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
+        assert diag.status is Status.PASS
+        # last evidence is the reproducibility entry
+        repro = diag.evidence[-1]
+        assert repro.kind == "reproducibility_score"
+        assert repro.data["score"] == 1.0
+        assert repro.data["n"] == 3
+        assert repro.data["pass_count"] == 3
+        assert repro.data["majority_judgment"] == "pass"
+
+    def test_unanimous_fail_score_is_one(self, monkeypatch, tmp_path):
+        _patch_env(monkeypatch, self._ENV)
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: _VALID_FAIL_JSON,
+        )
+        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
+        assert diag.status is Status.FAIL
+        repro = diag.evidence[-1]
+        assert repro.kind == "reproducibility_score"
+        assert repro.data["score"] == 1.0
+        assert repro.data["pass_count"] == 0
+        assert repro.data["majority_judgment"] == "fail"
+
+    def test_mixed_majority_pass(self, monkeypatch, tmp_path):
+        """2 pass + 1 fail in 3 runs -> pass with score 2/3."""
+        _patch_env(monkeypatch, self._ENV)
+        responses = iter([_VALID_PASS_JSON, _VALID_FAIL_JSON, _VALID_PASS_JSON])
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: next(responses),
+        )
+        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
+        assert diag.status is Status.PASS
+        repro = diag.evidence[-1]
+        assert repro.kind == "reproducibility_score"
+        assert repro.data["pass_count"] == 2
+        assert abs(repro.data["score"] - 2 / 3) < 1e-9
+        assert repro.data["majority_judgment"] == "pass"
+
+    def test_mixed_majority_fail(self, monkeypatch, tmp_path):
+        """1 pass + 2 fail in 3 runs -> fail with score 2/3."""
+        _patch_env(monkeypatch, self._ENV)
+        responses = iter([_VALID_FAIL_JSON, _VALID_PASS_JSON, _VALID_FAIL_JSON])
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: next(responses),
+        )
+        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
+        assert diag.status is Status.FAIL
+        repro = diag.evidence[-1]
+        assert repro.kind == "reproducibility_score"
+        assert repro.data["pass_count"] == 1
+        assert abs(repro.data["score"] - 2 / 3) < 1e-9
+        assert repro.data["majority_judgment"] == "fail"
+
+    def test_tie_breaks_toward_fail(self, monkeypatch, tmp_path):
+        """Even N with 50/50 split -> fail-closed."""
+        _patch_env(monkeypatch, self._ENV)
+        responses = iter([_VALID_PASS_JSON, _VALID_FAIL_JSON])
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: next(responses),
+        )
+        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 2)
+        assert diag.status is Status.FAIL
+        repro = diag.evidence[-1]
+        assert repro.data["pass_count"] == 1
+        assert repro.data["score"] == 0.5
+        assert repro.data["majority_judgment"] == "fail"
+
+    def test_unconfigured_returns_unavailable_without_aggregation(self, tmp_path):
+        """When provider is unconfigured, run_n short-circuits to UNAVAILABLE."""
+        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 5)
+        assert diag.status is Status.UNAVAILABLE
+        # No reproducibility_score evidence (aggregation aborted).
+        assert all(e.kind != "reproducibility_score" for e in diag.evidence)
+
+    def test_provider_error_short_circuits(self, monkeypatch, tmp_path):
+        """If any single run errors, return that diagnostic without aggregating."""
+        _patch_env(monkeypatch, self._ENV)
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("transient 503")
+
+        monkeypatch.setattr(llm_backend, "_call_anthropic", _boom)
+        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "provider_error"
+        assert all(e.kind != "reproducibility_score" for e in diag.evidence)
+
+    def test_calls_provider_n_times(self, monkeypatch, tmp_path):
+        _patch_env(monkeypatch, self._ENV)
+        call_count = {"n": 0}
+
+        def _counter(*_a, **_k):
+            call_count["n"] += 1
+            return _VALID_PASS_JSON
+
+        monkeypatch.setattr(llm_backend, "_call_anthropic", _counter)
+        llm_backend.run_n(_semantic_rule(), tmp_path, 5)
+        assert call_count["n"] == 5


### PR DESCRIPTION
## Summary

- Adds `run_n(rule, target, n)` to the `llm-rubric` backend that evaluates a rule `n` times and aggregates via majority vote (tie-breaks toward fail, fail-closed).
- Appends `Evidence(kind="reproducibility_score", data={score, n, pass_count, majority_judgment})` to the representative diagnostic.
- Adds `--reproducibility N` CLI flag to `gate-keeper validate` (default: 1, preserving existing behaviour); non-LLM backends silently ignore it.
- Validates `N >= 1` at CLI layer (exits 2 on violation).

## Validation

```
uv run pytest          # 725 passed
uvx ruff check .       # All checks passed
uvx pyright            # (pre-existing errors only, unchanged from main)
```

Closes #68