### PR TITLE
docs(textlint): document local textlint usage (#86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,37 @@ uvx pyright
 
 CI runs the same `uv sync` and `uv run pytest` steps on Python 3.10.
 
+## Optional: textlint for documentation prose
+
+`gate-keeper` ships a textlint configuration (`.textlintrc.json`,
+`.textlintignore`) that lints repository Markdown for terminology
+consistency. textlint runs on Node, which `gate-keeper` does not bundle —
+mirrors the `gh aw` stance: install Node yourself, the CLI does not vend it.
+
+Requirements:
+
+- Node 20 or later (declared in `package.json` `engines`);
+- `npm install` once at the repository root to fetch textlint and its
+  rule packages.
+
+Run:
+
+```bash
+npm run textlint                  # lint docs/**/*.md and README.md
+npm run textlint -- README.md     # lint a specific file
+```
+
+The corpus has known terminology findings today; failures from
+`npm run textlint` against the existing corpus are expected and tracked
+separately. New documentation should not introduce additional findings.
+
+Once `gate-keeper`'s textlint adapter (#94) is registered, `gate-keeper
+validate` can invoke the same textlint installation against `external_check`
+rules — the adapter shells out to `npx textlint --format json` and maps each
+finding to a structured Diagnostic. See
+[docs/backend-external.md](docs/backend-external.md) for the adapter
+contract.
+
 ## Optional: LLM rubric backend
 
 `gate-keeper` ships with an `llm-rubric` backend that handles `semantic_rubric`

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Run:
 
 ```bash
 npm run textlint                  # lint docs/**/*.md and README.md
-npm run textlint -- README.md     # lint a specific file
+npx --no textlint path/to/file.md # lint a specific file (refuses to install)
 ```
 
 The corpus has known terminology findings today; failures from

--- a/docs/textlint/per-doc-type-policy.md
+++ b/docs/textlint/per-doc-type-policy.md
@@ -97,6 +97,16 @@ This decision should be revisited when **any** of the following occurs:
 
 ---
 
+## Developer entry points
+
+Local developer tooling for running textlint directly is documented in the
+project [Readme](../../README.md#optional-textlint-for-documentation-prose):
+Node install, `npm install`, and `npm run textlint`. Once the adapter (#94)
+lands, `gate-keeper validate --backend external` invokes the same textlint
+installation through `npx textlint --format json`.
+
+---
+
 ## What this decision does NOT settle
 
 - **#82** — which specific global rules go into `.textlintrc.json` (package set and


### PR DESCRIPTION
## Summary

- Add a 'Optional: textlint for documentation prose' section to the README covering the Node 20 prerequisite, `npm install`, and `npm run textlint`. Mirrors the `gh aw` stance documented in CLAUDE.md: the CLI does not bundle Node, install is the developer's responsibility.
- Forward-reference the gate-keeper-mediated invocation flow once #94 lands. The forward-reference uses the issue number `#94` (not a PR number) so it stays stable regardless of merge order.
- Cross-link from `docs/textlint/per-doc-type-policy.md` § Developer entry points so the textlint doc cluster points at the developer entry points.
- The `npm run textlint` script already exists (added in #82 / #111); no `textlint:fix` script is added because the issue body does not request one.

## Test plan

- [x] `uvx ruff check .` clean
- [x] `uvx ruff format --check .` clean
- [x] textlint runs locally against the modified README and per-doc-type-policy show no new findings introduced by this PR (existing baseline unchanged)
- [x] No Python changes; full pytest baseline unchanged

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)