### PR TITLE
feat(llm-rubric): per-rule observability (latency_ms, tokens_in, tokens_out)

### DIFF
--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -139,10 +139,13 @@ analysis, and per-rule SLA work:
 | `tokens_in` | `int` | Anthropic `usage.input_tokens` / OpenAI `usage.prompt_tokens` | Provider-reported prompt token count. |
 | `tokens_out` | `int` | Anthropic `usage.output_tokens` / OpenAI `usage.completion_tokens` | Provider-reported completion token count. |
 
-These fields appear **only on successful provider calls**. The
-`provider_unconfigured` and `provider_error` evidence kinds (no API call
-returned, or the call raised) intentionally do not carry telemetry — missing
-evidence is recorded as missing rather than synthesised.
+These fields appear **only on successful provider calls** that produce a
+parseable, schema-conforming judgment. The `provider_unconfigured` and
+`provider_error` evidence kinds — covering all non-success paths: provider
+unset, the SDK call raised, the response omitted required usage fields, or
+the response failed JSON parse / schema validation — intentionally do not
+carry telemetry. Missing evidence is recorded as missing rather than
+synthesised.
 
 When `--reproducibility N` aggregates `N` runs, the `latency_ms` / `tokens_in`
 / `tokens_out` on the chosen majority-judgment evidence reflect that single

--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -124,8 +124,30 @@ When a provider responds successfully, the diagnostic carries:
 
 - `status`: `pass` or `fail`.
 - `message`: the `primary_reason` from the structured judgment.
-- `evidence[0]`: `{ kind: "llm_judgment", data: { model, prompt_version, judgment, primary_reason, supporting_evidence_quotes, suggested_action } }`.
+- `evidence[0]`: `{ kind: "llm_judgment", data: { model, prompt_version, judgment, primary_reason, supporting_evidence_quotes, suggested_action, latency_ms, tokens_in, tokens_out } }`.
 - `remediation`: set to `suggested_action` when `status=fail`; `null` on `pass`.
+
+### Per-rule observability fields
+
+Issue #76 adds three observability fields to every successful `llm_judgment`
+evidence entry, providing the data substrate for drift detection, cost
+analysis, and per-rule SLA work:
+
+| Field | Type | Source | Semantics |
+| --- | --- | --- | --- |
+| `latency_ms` | `int` (milliseconds) | `time.perf_counter()` around the SDK call | Wall-clock duration of the provider call, integer-rounded. |
+| `tokens_in` | `int` | Anthropic `usage.input_tokens` / OpenAI `usage.prompt_tokens` | Provider-reported prompt token count. |
+| `tokens_out` | `int` | Anthropic `usage.output_tokens` / OpenAI `usage.completion_tokens` | Provider-reported completion token count. |
+
+These fields appear **only on successful provider calls**. The
+`provider_unconfigured` and `provider_error` evidence kinds (no API call
+returned, or the call raised) intentionally do not carry telemetry — missing
+evidence is recorded as missing rather than synthesised.
+
+When `--reproducibility N` aggregates `N` runs, the `latency_ms` / `tokens_in`
+/ `tokens_out` on the chosen majority-judgment evidence reflect that single
+representative run, not an aggregate. The separate
+`reproducibility_score` evidence entry (#68) carries no telemetry.
 
 ## Failure modes
 

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -201,6 +201,12 @@ def _call_anthropic(api_key: str, system: str, user: str, model: str) -> tuple[s
       (Anthropic ``usage.input_tokens``).
     - ``tokens_out``: provider-reported completion token count
       (Anthropic ``usage.output_tokens``).
+
+    Fail-closed contract (#76 follow-up): if the provider response omits
+    ``usage.input_tokens`` or ``usage.output_tokens`` (or the entire ``usage``
+    object), raise :class:`RuntimeError`. The caller in :func:`check`
+    catches this and dispatches a ``provider_error`` diagnostic; we never
+    synthesise a zero token count.
     """
     from anthropic import Anthropic
 
@@ -219,12 +225,18 @@ def _call_anthropic(api_key: str, system: str, user: str, model: str) -> tuple[s
         if isinstance(text, str):
             parts.append(text)
     usage = getattr(msg, "usage", None)
-    tokens_in = int(getattr(usage, "input_tokens", 0) or 0)
-    tokens_out = int(getattr(usage, "output_tokens", 0) or 0)
+    if usage is None:
+        raise RuntimeError("Anthropic response missing usage block; cannot record token telemetry.")
+    input_tokens = getattr(usage, "input_tokens", None)
+    output_tokens = getattr(usage, "output_tokens", None)
+    if input_tokens is None:
+        raise RuntimeError("Anthropic response missing usage.input_tokens; cannot record token telemetry.")
+    if output_tokens is None:
+        raise RuntimeError("Anthropic response missing usage.output_tokens; cannot record token telemetry.")
     return "".join(parts), {
         "latency_ms": latency_ms,
-        "tokens_in": tokens_in,
-        "tokens_out": tokens_out,
+        "tokens_in": int(input_tokens),
+        "tokens_out": int(output_tokens),
     }
 
 
@@ -238,6 +250,12 @@ def _call_openai(api_key: str, system: str, user: str, model: str) -> tuple[str,
       (OpenAI ``usage.prompt_tokens``).
     - ``tokens_out``: provider-reported completion token count
       (OpenAI ``usage.completion_tokens``).
+
+    Fail-closed contract (#76 follow-up): if the provider response omits
+    ``usage.prompt_tokens`` or ``usage.completion_tokens`` (or the entire
+    ``usage`` object), raise :class:`RuntimeError`. The caller in
+    :func:`check` catches this and dispatches a ``provider_error``
+    diagnostic; we never synthesise a zero token count.
     """
     from openai import OpenAI
 
@@ -254,12 +272,18 @@ def _call_openai(api_key: str, system: str, user: str, model: str) -> tuple[str,
     latency_ms = int(round((time.perf_counter() - start) * 1000))
     text = resp.choices[0].message.content or ""
     usage = getattr(resp, "usage", None)
-    tokens_in = int(getattr(usage, "prompt_tokens", 0) or 0)
-    tokens_out = int(getattr(usage, "completion_tokens", 0) or 0)
+    if usage is None:
+        raise RuntimeError("OpenAI response missing usage block; cannot record token telemetry.")
+    prompt_tokens = getattr(usage, "prompt_tokens", None)
+    completion_tokens = getattr(usage, "completion_tokens", None)
+    if prompt_tokens is None:
+        raise RuntimeError("OpenAI response missing usage.prompt_tokens; cannot record token telemetry.")
+    if completion_tokens is None:
+        raise RuntimeError("OpenAI response missing usage.completion_tokens; cannot record token telemetry.")
     return text, {
         "latency_ms": latency_ms,
-        "tokens_in": tokens_in,
-        "tokens_out": tokens_out,
+        "tokens_in": int(prompt_tokens),
+        "tokens_out": int(completion_tokens),
     }
 
 
@@ -487,6 +511,15 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
         return _unavailable_provider_error(
             rule, rubric_input, provider, "unparseable_response", parsed.detail
         )
+
+    # Invariant: when control reaches here the provider helper completed without
+    # raising, so telemetry must contain all three required keys (#76 fail-closed
+    # contract — helpers raise when usage is missing rather than defaulting).
+    # Assert explicitly so a future helper bug surfaces as a programmer error
+    # instead of a silent KeyError below.
+    assert telemetry.keys() >= {"latency_ms", "tokens_in", "tokens_out"}, (
+        f"provider helper returned incomplete telemetry: {sorted(telemetry.keys())}"
+    )
 
     status = Status.PASS if parsed.judgment == "pass" else Status.FAIL
     evidence = Evidence(

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
@@ -190,28 +191,58 @@ def _build_prompt(rule: Rule, target: str | Path) -> tuple[str, str]:
 # ---------------------------------------------------------------------------
 
 
-def _call_anthropic(api_key: str, system: str, user: str, model: str) -> str:
+def _call_anthropic(api_key: str, system: str, user: str, model: str) -> tuple[str, dict[str, int]]:
+    """Call Anthropic and return ``(response_text, telemetry)``.
+
+    Telemetry keys (#76):
+
+    - ``latency_ms``: wall-clock provider call duration, integer milliseconds.
+    - ``tokens_in``: provider-reported prompt token count
+      (Anthropic ``usage.input_tokens``).
+    - ``tokens_out``: provider-reported completion token count
+      (Anthropic ``usage.output_tokens``).
+    """
     from anthropic import Anthropic
 
     client = Anthropic(api_key=api_key)
+    start = time.perf_counter()
     msg = client.messages.create(
         model=model,
         max_tokens=600,
         system=system,
         messages=[{"role": "user", "content": user}],
     )
+    latency_ms = int(round((time.perf_counter() - start) * 1000))
     parts: list[str] = []
     for block in msg.content:
         text = getattr(block, "text", None)
         if isinstance(text, str):
             parts.append(text)
-    return "".join(parts)
+    usage = getattr(msg, "usage", None)
+    tokens_in = int(getattr(usage, "input_tokens", 0) or 0)
+    tokens_out = int(getattr(usage, "output_tokens", 0) or 0)
+    return "".join(parts), {
+        "latency_ms": latency_ms,
+        "tokens_in": tokens_in,
+        "tokens_out": tokens_out,
+    }
 
 
-def _call_openai(api_key: str, system: str, user: str, model: str) -> str:
+def _call_openai(api_key: str, system: str, user: str, model: str) -> tuple[str, dict[str, int]]:
+    """Call OpenAI and return ``(response_text, telemetry)``.
+
+    Telemetry keys (#76):
+
+    - ``latency_ms``: wall-clock provider call duration, integer milliseconds.
+    - ``tokens_in``: provider-reported prompt token count
+      (OpenAI ``usage.prompt_tokens``).
+    - ``tokens_out``: provider-reported completion token count
+      (OpenAI ``usage.completion_tokens``).
+    """
     from openai import OpenAI
 
     client = OpenAI(api_key=api_key)
+    start = time.perf_counter()
     resp = client.chat.completions.create(
         model=model,
         max_completion_tokens=600,
@@ -220,7 +251,16 @@ def _call_openai(api_key: str, system: str, user: str, model: str) -> str:
             {"role": "user", "content": user},
         ],
     )
-    return resp.choices[0].message.content or ""
+    latency_ms = int(round((time.perf_counter() - start) * 1000))
+    text = resp.choices[0].message.content or ""
+    usage = getattr(resp, "usage", None)
+    tokens_in = int(getattr(usage, "prompt_tokens", 0) or 0)
+    tokens_out = int(getattr(usage, "completion_tokens", 0) or 0)
+    return text, {
+        "latency_ms": latency_ms,
+        "tokens_in": tokens_in,
+        "tokens_out": tokens_out,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -416,6 +456,10 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
     - ``primary_reason``: one-sentence summary.
     - ``supporting_evidence_quotes``: list of verbatim quotes.
     - ``suggested_action``: remediation string (fail only) or ``None`` (pass).
+    - ``latency_ms``: wall-clock provider call duration in integer
+      milliseconds (#76).
+    - ``tokens_in``: provider-reported prompt token count (#76).
+    - ``tokens_out``: provider-reported completion token count (#76).
 
     ``Diagnostic.remediation`` is set to ``suggested_action`` on fail.
     """
@@ -431,10 +475,10 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
     try:
         if provider == "anthropic":
             model = ANTHROPIC_DEFAULT_MODEL
-            response_text = _call_anthropic(env["ANTHROPIC_API_KEY"], system, user, model)
+            response_text, telemetry = _call_anthropic(env["ANTHROPIC_API_KEY"], system, user, model)
         else:
             model = OPENAI_DEFAULT_MODEL
-            response_text = _call_openai(env["OPENAI_API_KEY"], system, user, model)
+            response_text, telemetry = _call_openai(env["OPENAI_API_KEY"], system, user, model)
     except Exception as exc:  # noqa: BLE001 — fail-closed: any provider error → unavailable
         return _unavailable_provider_error(rule, rubric_input, provider, type(exc).__name__, str(exc))
 
@@ -454,6 +498,9 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
             "primary_reason": parsed.primary_reason,
             "supporting_evidence_quotes": parsed.supporting_evidence_quotes,
             "suggested_action": parsed.suggested_action,
+            "latency_ms": telemetry["latency_ms"],
+            "tokens_in": telemetry["tokens_in"],
+            "tokens_out": telemetry["tokens_out"],
         },
     )
     if status is Status.PASS:

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -625,13 +625,16 @@ class TestReproducibilityFlag:
         monkeypatch.setattr(
             llm_backend,
             "_call_anthropic",
-            lambda *_a, **_k: json.dumps(
-                {
-                    "judgment": "pass",
-                    "primary_reason": "looks good",
-                    "supporting_evidence_quotes": [],
-                    "suggested_action": None,
-                }
+            lambda *_a, **_k: (
+                json.dumps(
+                    {
+                        "judgment": "pass",
+                        "primary_reason": "looks good",
+                        "supporting_evidence_quotes": [],
+                        "suggested_action": None,
+                    }
+                ),
+                {"latency_ms": 11, "tokens_in": 22, "tokens_out": 33},
             ),
         )
 

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -538,6 +538,130 @@ class TestEvidenceObservability:
         assert "tokens_in" not in data
         assert "tokens_out" not in data
 
+    def test_missing_usage_anthropic_maps_to_unavailable(self, monkeypatch, tmp_path):
+        """Anthropic response without usage fields must fail closed (no synthetic 0).
+
+        Regression guard for the Copilot review on PR #119: previously the
+        helper coerced missing ``usage.input_tokens`` / ``usage.output_tokens``
+        to ``0``, producing synthetic telemetry. Per CLAUDE.md the project
+        rule is "Treat missing evidence as fail-closed; do not paper over with
+        defaults". The helper now raises and ``check()`` dispatches a
+        ``provider_error`` diagnostic.
+        """
+        _patch_env(monkeypatch, self._ANTHROPIC_ENV)
+
+        class _UsageMissingInput:
+            output_tokens = 60
+            # input_tokens deliberately absent
+
+        class _Block:
+            text = _VALID_PASS_JSON
+
+        class _Msg:
+            content = [_Block()]
+            usage = _UsageMissingInput()
+
+        class _Client:
+            def __init__(self, *_a, **_k):
+                pass
+
+            class messages:  # noqa: N801 — match SDK shape
+                @staticmethod
+                def create(*_a, **_k):
+                    return _Msg()
+
+        monkeypatch.setattr(llm_backend, "Anthropic", _Client, raising=False)
+        # Patch via the import inside _call_anthropic by monkeypatching the
+        # SDK module's attribute via sys.modules.
+        import sys
+
+        fake_mod = type(sys)("anthropic")
+        fake_mod.Anthropic = _Client  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "anthropic", fake_mod)
+
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "provider_error"
+        assert diag.evidence[0].data["provider"] == "anthropic"
+        # No synthetic telemetry on the provider_error evidence.
+        assert "tokens_in" not in diag.evidence[0].data
+        assert "tokens_out" not in diag.evidence[0].data
+        # Failure mode tag identifies it as a usage/telemetry shortfall.
+        detail = diag.evidence[0].data["detail"]
+        assert "usage" in detail.lower() or "input_tokens" in detail.lower()
+
+    def test_missing_usage_openai_maps_to_unavailable(self, monkeypatch, tmp_path):
+        """OpenAI response without usage fields must fail closed (no synthetic 0)."""
+        _patch_env(monkeypatch, self._OPENAI_ENV)
+
+        class _UsageMissingCompletion:
+            prompt_tokens = 250
+            # completion_tokens deliberately absent
+
+        class _Choice:
+            class message:  # noqa: N801
+                content = _VALID_PASS_JSON
+
+        class _Resp:
+            choices = [_Choice()]
+            usage = _UsageMissingCompletion()
+
+        class _Client:
+            def __init__(self, *_a, **_k):
+                pass
+
+            class chat:  # noqa: N801
+                class completions:  # noqa: N801
+                    @staticmethod
+                    def create(*_a, **_k):
+                        return _Resp()
+
+        import sys
+
+        fake_mod = type(sys)("openai")
+        fake_mod.OpenAI = _Client  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "openai", fake_mod)
+
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "provider_error"
+        assert diag.evidence[0].data["provider"] == "openai"
+        assert "tokens_in" not in diag.evidence[0].data
+        assert "tokens_out" not in diag.evidence[0].data
+        detail = diag.evidence[0].data["detail"]
+        assert "usage" in detail.lower() or "completion_tokens" in detail.lower()
+
+    def test_missing_usage_block_anthropic_maps_to_unavailable(self, monkeypatch, tmp_path):
+        """Anthropic response with no usage object at all must fail closed."""
+        _patch_env(monkeypatch, self._ANTHROPIC_ENV)
+
+        class _Block:
+            text = _VALID_PASS_JSON
+
+        class _Msg:
+            content = [_Block()]
+            usage = None  # entire usage block absent
+
+        class _Client:
+            def __init__(self, *_a, **_k):
+                pass
+
+            class messages:  # noqa: N801
+                @staticmethod
+                def create(*_a, **_k):
+                    return _Msg()
+
+        import sys
+
+        fake_mod = type(sys)("anthropic")
+        fake_mod.Anthropic = _Client  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "anthropic", fake_mod)
+
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "provider_error"
+        assert diag.evidence[0].data["provider"] == "anthropic"
+
     def test_run_n_majority_run_carries_telemetry(self, monkeypatch, tmp_path):
         """Per-run telemetry is preserved on the representative run; not aggregated."""
         _patch_env(monkeypatch, self._ANTHROPIC_ENV)

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -51,6 +51,18 @@ _VALID_FAIL_JSON = json.dumps(
     }
 )
 
+# Default telemetry stub for monkeypatched provider helpers (#76).
+_STUB_TELEMETRY: dict[str, int] = {
+    "latency_ms": 42,
+    "tokens_in": 123,
+    "tokens_out": 45,
+}
+
+
+def _stub_response(text: str, telemetry: dict[str, int] | None = None) -> tuple[str, dict[str, int]]:
+    """Build a ``(text, telemetry)`` tuple matching the real helper signature."""
+    return text, dict(telemetry) if telemetry is not None else dict(_STUB_TELEMETRY)
+
 
 def _semantic_rule(kind: RuleKind = RuleKind.SEMANTIC_RUBRIC) -> Rule:
     return Rule(
@@ -256,7 +268,7 @@ class TestProviderDispatchAnthropic:
         monkeypatch.setattr(
             llm_backend,
             "_call_anthropic",
-            lambda key, system, user, model: _VALID_PASS_JSON,
+            lambda key, system, user, model: _stub_response(_VALID_PASS_JSON),
         )
         diag = llm_backend.check(_semantic_rule(), tmp_path)
         assert diag.status is Status.PASS
@@ -276,7 +288,7 @@ class TestProviderDispatchAnthropic:
         monkeypatch.setattr(
             llm_backend,
             "_call_anthropic",
-            lambda key, system, user, model: _VALID_FAIL_JSON,
+            lambda key, system, user, model: _stub_response(_VALID_FAIL_JSON),
         )
         diag = llm_backend.check(_semantic_rule(), tmp_path)
         assert diag.status is Status.FAIL
@@ -309,7 +321,7 @@ class TestProviderDispatchAnthropic:
         monkeypatch.setattr(
             llm_backend,
             "_call_anthropic",
-            lambda *_a, **_k: "I refuse to answer in JSON.",
+            lambda *_a, **_k: _stub_response("I refuse to answer in JSON."),
         )
         diag = llm_backend.check(_semantic_rule(), tmp_path)
         assert diag.status is Status.UNAVAILABLE
@@ -321,13 +333,15 @@ class TestProviderDispatchAnthropic:
         monkeypatch.setattr(
             llm_backend,
             "_call_anthropic",
-            lambda *_a, **_k: json.dumps(
-                {
-                    "judgment": "maybe",
-                    "primary_reason": "unsure",
-                    "supporting_evidence_quotes": [],
-                    "suggested_action": None,
-                }
+            lambda *_a, **_k: _stub_response(
+                json.dumps(
+                    {
+                        "judgment": "maybe",
+                        "primary_reason": "unsure",
+                        "supporting_evidence_quotes": [],
+                        "suggested_action": None,
+                    }
+                )
             ),
         )
         diag = llm_backend.check(_semantic_rule(), tmp_path)
@@ -340,11 +354,11 @@ class TestProviderDispatchAnthropic:
 
         def _anthropic(*_a, **_k):
             called["anthropic"] = True
-            return _VALID_PASS_JSON
+            return _stub_response(_VALID_PASS_JSON)
 
         def _openai(*_a, **_k):
             called["openai"] = True
-            return ""
+            return _stub_response("")
 
         monkeypatch.setattr(llm_backend, "_call_anthropic", _anthropic)
         monkeypatch.setattr(llm_backend, "_call_openai", _openai)
@@ -368,7 +382,7 @@ class TestProviderDispatchOpenAI:
         monkeypatch.setattr(
             llm_backend,
             "_call_openai",
-            lambda *_a, **_k: _VALID_PASS_JSON,
+            lambda *_a, **_k: _stub_response(_VALID_PASS_JSON),
         )
         diag = llm_backend.check(_semantic_rule(), tmp_path)
         assert diag.status is Status.PASS
@@ -381,7 +395,7 @@ class TestProviderDispatchOpenAI:
         monkeypatch.setattr(
             llm_backend,
             "_call_openai",
-            lambda *_a, **_k: _VALID_FAIL_JSON,
+            lambda *_a, **_k: _stub_response(_VALID_FAIL_JSON),
         )
         diag = llm_backend.check(_semantic_rule(), tmp_path)
         assert diag.status is Status.FAIL
@@ -399,6 +413,159 @@ class TestProviderDispatchOpenAI:
         assert diag.status is Status.UNAVAILABLE
         assert diag.evidence[0].data["provider"] == "openai"
         assert diag.evidence[0].data["failure_mode"] == "TimeoutError"
+
+
+# ---------------------------------------------------------------------------
+# Per-rule observability (#76): latency_ms, tokens_in, tokens_out
+# ---------------------------------------------------------------------------
+
+
+class TestEvidenceObservability:
+    """Issue #76 — per-rule observability fields on llm_judgment evidence.
+
+    The structured ``llm_judgment`` evidence dict must carry ``latency_ms``,
+    ``tokens_in``, and ``tokens_out`` from the underlying provider call. These
+    are the data substrate for future drift detection / cost analysis.
+    Provider-error and unconfigured paths intentionally do NOT synthesize
+    telemetry — fields are only meaningful for successful API calls.
+    """
+
+    _ANTHROPIC_ENV = {
+        "GATE_KEEPER_LLM_PROVIDER": "anthropic",
+        "ANTHROPIC_API_KEY": "sk-ant-test",
+    }
+    _OPENAI_ENV = {
+        "GATE_KEEPER_LLM_PROVIDER": "openai",
+        "OPENAI_API_KEY": "sk-openai-test",
+    }
+
+    def test_evidence_includes_latency_ms_anthropic(self, monkeypatch, tmp_path):
+        _patch_env(monkeypatch, self._ANTHROPIC_ENV)
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: _stub_response(
+                _VALID_PASS_JSON,
+                {"latency_ms": 137, "tokens_in": 250, "tokens_out": 60},
+            ),
+        )
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        data = diag.evidence[0].data
+        assert "latency_ms" in data
+        assert isinstance(data["latency_ms"], int)
+        assert data["latency_ms"] >= 0
+        assert data["latency_ms"] == 137
+
+    def test_evidence_includes_tokens_in_and_out_anthropic(self, monkeypatch, tmp_path):
+        _patch_env(monkeypatch, self._ANTHROPIC_ENV)
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: _stub_response(
+                _VALID_PASS_JSON,
+                {"latency_ms": 50, "tokens_in": 250, "tokens_out": 60},
+            ),
+        )
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        data = diag.evidence[0].data
+        assert "tokens_in" in data
+        assert "tokens_out" in data
+        assert isinstance(data["tokens_in"], int)
+        assert isinstance(data["tokens_out"], int)
+        assert data["tokens_in"] >= 0
+        assert data["tokens_out"] >= 0
+        assert data["tokens_in"] == 250
+        assert data["tokens_out"] == 60
+
+    def test_evidence_includes_latency_ms_openai(self, monkeypatch, tmp_path):
+        _patch_env(monkeypatch, self._OPENAI_ENV)
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(
+                _VALID_PASS_JSON,
+                {"latency_ms": 281, "tokens_in": 410, "tokens_out": 88},
+            ),
+        )
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        data = diag.evidence[0].data
+        assert "latency_ms" in data
+        assert isinstance(data["latency_ms"], int)
+        assert data["latency_ms"] >= 0
+        assert data["latency_ms"] == 281
+
+    def test_evidence_includes_tokens_in_and_out_openai(self, monkeypatch, tmp_path):
+        _patch_env(monkeypatch, self._OPENAI_ENV)
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(
+                _VALID_FAIL_JSON,
+                {"latency_ms": 12, "tokens_in": 410, "tokens_out": 88},
+            ),
+        )
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        data = diag.evidence[0].data
+        assert "tokens_in" in data
+        assert "tokens_out" in data
+        assert isinstance(data["tokens_in"], int)
+        assert isinstance(data["tokens_out"], int)
+        assert data["tokens_in"] == 410
+        assert data["tokens_out"] == 88
+
+    def test_provider_error_evidence_omits_telemetry(self, monkeypatch, tmp_path):
+        """Exception paths must NOT synthesize fake telemetry (#76 requirement)."""
+        _patch_env(monkeypatch, self._ANTHROPIC_ENV)
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("network is down")
+
+        monkeypatch.setattr(llm_backend, "_call_anthropic", _boom)
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        assert diag.status is Status.UNAVAILABLE
+        data = diag.evidence[0].data
+        # Exception path → provider_error evidence carries no telemetry fields.
+        assert "latency_ms" not in data
+        assert "tokens_in" not in data
+        assert "tokens_out" not in data
+
+    def test_unconfigured_evidence_omits_telemetry(self, tmp_path):
+        """Unconfigured path also omits telemetry (no API call happened)."""
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        assert diag.status is Status.UNAVAILABLE
+        data = diag.evidence[0].data
+        assert "latency_ms" not in data
+        assert "tokens_in" not in data
+        assert "tokens_out" not in data
+
+    def test_run_n_majority_run_carries_telemetry(self, monkeypatch, tmp_path):
+        """Per-run telemetry is preserved on the representative run; not aggregated."""
+        _patch_env(monkeypatch, self._ANTHROPIC_ENV)
+        # Each run produces distinct telemetry values; we just want to confirm
+        # the chosen run's telemetry is preserved on its evidence dict.
+        telemetries = iter(
+            [
+                {"latency_ms": 100, "tokens_in": 10, "tokens_out": 1},
+                {"latency_ms": 200, "tokens_in": 20, "tokens_out": 2},
+                {"latency_ms": 300, "tokens_in": 30, "tokens_out": 3},
+            ]
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: _stub_response(_VALID_PASS_JSON, next(telemetries)),
+        )
+        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
+        # llm_judgment evidence (representative run) carries telemetry.
+        judgment_data = diag.evidence[0].data
+        assert isinstance(judgment_data["latency_ms"], int)
+        assert isinstance(judgment_data["tokens_in"], int)
+        assert isinstance(judgment_data["tokens_out"], int)
+        # reproducibility_score evidence (#68) is unchanged — no telemetry there.
+        repro_data = diag.evidence[-1].data
+        assert "latency_ms" not in repro_data
+        assert "tokens_in" not in repro_data
+        assert "tokens_out" not in repro_data
 
 
 # ---------------------------------------------------------------------------
@@ -597,7 +764,7 @@ class TestPromptVersion:
         monkeypatch.setattr(
             llm_backend,
             "_call_anthropic",
-            lambda *_a, **_k: _VALID_PASS_JSON,
+            lambda *_a, **_k: _stub_response(_VALID_PASS_JSON),
         )
         diag = llm_backend.check(_semantic_rule(), tmp_path)
         assert diag.evidence[0].data["prompt_version"] == "v1"
@@ -637,7 +804,7 @@ class TestRunN:
         monkeypatch.setattr(
             llm_backend,
             "_call_anthropic",
-            lambda key, system, user, model: _VALID_PASS_JSON,
+            lambda key, system, user, model: _stub_response(_VALID_PASS_JSON),
         )
         diag = llm_backend.run_n(_semantic_rule(), tmp_path, 1)
         # Only the llm_judgment evidence — no reproducibility_score appended.
@@ -650,7 +817,7 @@ class TestRunN:
         monkeypatch.setattr(
             llm_backend,
             "_call_anthropic",
-            lambda *_a, **_k: _VALID_PASS_JSON,
+            lambda *_a, **_k: _stub_response(_VALID_PASS_JSON),
         )
         diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
         assert diag.status is Status.PASS
@@ -667,7 +834,7 @@ class TestRunN:
         monkeypatch.setattr(
             llm_backend,
             "_call_anthropic",
-            lambda *_a, **_k: _VALID_FAIL_JSON,
+            lambda *_a, **_k: _stub_response(_VALID_FAIL_JSON),
         )
         diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
         assert diag.status is Status.FAIL
@@ -684,7 +851,7 @@ class TestRunN:
         monkeypatch.setattr(
             llm_backend,
             "_call_anthropic",
-            lambda *_a, **_k: next(responses),
+            lambda *_a, **_k: _stub_response(next(responses)),
         )
         diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
         assert diag.status is Status.PASS
@@ -701,7 +868,7 @@ class TestRunN:
         monkeypatch.setattr(
             llm_backend,
             "_call_anthropic",
-            lambda *_a, **_k: next(responses),
+            lambda *_a, **_k: _stub_response(next(responses)),
         )
         diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
         assert diag.status is Status.FAIL
@@ -718,7 +885,7 @@ class TestRunN:
         monkeypatch.setattr(
             llm_backend,
             "_call_anthropic",
-            lambda *_a, **_k: next(responses),
+            lambda *_a, **_k: _stub_response(next(responses)),
         )
         diag = llm_backend.run_n(_semantic_rule(), tmp_path, 2)
         assert diag.status is Status.FAIL
@@ -753,7 +920,7 @@ class TestRunN:
 
         def _counter(*_a, **_k):
             call_count["n"] += 1
-            return _VALID_PASS_JSON
+            return _stub_response(_VALID_PASS_JSON)
 
         monkeypatch.setattr(llm_backend, "_call_anthropic", _counter)
         llm_backend.run_n(_semantic_rule(), tmp_path, 5)


### PR DESCRIPTION
## Summary

Adds per-rule observability fields to every successful `llm_judgment` evidence entry, providing the data substrate for future drift detection, cost analysis, and per-rule SLA work (umbrella #63).

- `_call_anthropic` / `_call_openai` now return `(response_text, telemetry)`. Telemetry is populated synchronously around the SDK call.
- Three new evidence keys appear on every successful `check()` result:
  - `latency_ms`: wall-clock duration via `time.perf_counter()`, rounded to integer ms.
  - `tokens_in`: Anthropic `usage.input_tokens` / OpenAI `usage.prompt_tokens`.
  - `tokens_out`: Anthropic `usage.output_tokens` / OpenAI `usage.completion_tokens`.
- Fail-closed on missing data: `provider_unconfigured` and `provider_error` evidence dicts are unchanged — telemetry is recorded only when an API call actually returned. No fake zeros, no synthesized aggregates.
- `run_n` (#68) preserves per-run telemetry on the chosen majority-judgment evidence; the `reproducibility_score` evidence stays free of telemetry.
- `model` and `prompt_version` (already shipped by #67) remain in the dict — extended, not refactored.

Closes #76

## Validation

Run from `/workspaces/gate-keeper-wt-1`:

```sh
$ uv sync          # ok (deps installed)
$ uv run pytest -q
757 passed in 2.78s
$ uvx ruff check .
All checks passed!
$ uvx ruff format --check .
46 files already formatted
$ uvx pyright src/gate_keeper/backends/llm_rubric.py
3 errors, 0 warnings, 0 informations
# Pre-existing on main: lazy SDK imports (`dotenv`, `anthropic`, `openai`)
# are not pyright-resolvable in standalone runs. Same 3 errors are reported
# from the unmodified main worktree at the same source lines.
```

## Test plan

- [x] `uv run pytest -q` — 757 passed (existing tests + 7 new observability tests covering both providers, run_n preservation, and the no-telemetry-on-error invariants).
- [x] `uvx ruff check .` clean.
- [x] `uvx ruff format --check .` clean.
- [x] `uvx pyright src/gate_keeper/backends/llm_rubric.py` shows only the 3 pre-existing lazy-import errors.