### PR TITLE
feat(ci): add textlint GitHub Actions workflow with annotations

### DIFF
--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -1,0 +1,45 @@
+# textlint — documentation prose linting on PRs (Mode A: standalone)
+#
+# Tracking: #87 (umbrella #80). This is the standalone mode that runs textlint
+# directly via `npx`; results surface as inline GitHub annotations from the
+# `github` formatter. Mode B (gate-keeper-mediated, via the textlint adapter
+# from #94) is documented in `docs/textlint/severity-policy.md` and may
+# replace or augment this workflow once it is wired through CI.
+#
+# Exit-code distinction (per docs/textlint/severity-policy.md §6):
+#   - exit 1 from `textlint` => lint failure (findings present); the workflow
+#     fails at the lint step with annotations visible inline on the PR diff.
+#   - exit !=0 at install/setup steps (`actions/setup-node`, `npm ci`) =>
+#     config / infra failure; surfaced as a step error on a different job
+#     step than the lint step, naturally distinct from a lint exit-1.
+# Both fail the workflow; the surfacing is naturally distinct because each
+# failure occurs on a different named step.
+#
+# Scope: full repository (`docs/**/*.md` and `README.md`). Changed-file-only
+# narrowing is tracked in #88 and is out of scope here.
+
+name: textlint
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  textlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run textlint (GitHub annotations)
+        run: npx --no -- textlint --format github "docs/**/*.md" "README.md"

--- a/docs/backend-external.md
+++ b/docs/backend-external.md
@@ -1,7 +1,7 @@
 # `Backend.EXTERNAL` — adapter pattern for third-party tools
 
 This document is the contract for the `external` backend: a single dispatcher
-that routes rules to per-tool adapters (textlint, vale, eslint, …). Tracking
+that routes rules to per-tool adapters (textlint, vale, ESLint, …). Tracking
 umbrella: #80. New tools integrate as adapters here, not as new
 `Backend` enum values.
 

--- a/docs/design/multi-target.md
+++ b/docs/design/multi-target.md
@@ -19,7 +19,7 @@ documents today — are unevaluable or evaluate incorrectly:
 | "Naming conventions (snake_case for functions, PascalCase for classes) are consistent across all source modules" | Consistency is a cross-file property; a single-file check misses inter-module drift. |
 | "CHANGELOG entries match the API symbols introduced since the last tag" | Requires simultaneous access to `CHANGELOG.md` and one or more source files. |
 | "Every public function in `src/` has a corresponding docstring" | Structural coverage check requires walking a directory tree. |
-| "README `## Usage` section matches the CLI `--help` output captured in `docs/cli-reference.md`" | Rule spans two specific named files; neither is the same as `--target`. |
+| "readme `## Usage` section matches the CLI `--help` output captured in `docs/cli-reference.md`" | Rule spans two specific named files; neither is the same as `--target`. |
 | "No module imports from a private (`_`-prefixed) sibling module" | Requires reading all files in a package to identify all import edges. |
 
 The single-target model also interacts poorly with the LLM rubric backend:
@@ -355,7 +355,7 @@ evaluation logic.
   objects is out of scope. All paths are local filesystem paths after checkout.
 - **Streaming / chunking for very large file sets**: the design caps at
   `token_budget` and truncates deterministically. Streaming the file set in
-  chunks across multiple LLM calls (to handle arbitrary repo sizes) is deferred
+  chunks across multiple LLM calls (to handle arbitrary repository sizes) is deferred
   until real budget pressure is observed. The truncation_warning evidence item
   makes it visible when this matters.
 - **Heuristic file ranking / relevance scoring**: no ML-based or TF-IDF

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -6,7 +6,7 @@ promote per-rule to required.** This document defines the promotion path.
 
 ## Why advisory first
 
-Hard-gating an unproven rule on its own repo creates a deadlock: a bug in
+Hard-gating an unproven rule on its own repository creates a deadlock: a bug in
 `gate-keeper` blocks the PR that would fix it. Advisory mode runs the same
 checks but reports as PR comments only, never as a required status.
 

--- a/docs/mvp-readiness.md
+++ b/docs/mvp-readiness.md
@@ -56,8 +56,8 @@ verifiable without hidden context. Check off items with `uv run` commands and
   SourceLocation).
 - [x] `docs/llm-rubric.md` explains the stub and its fail-closed behavior.
 - [x] `docs/example-rules.md` demonstrates filesystem and GitHub rule types.
-- [x] README documents Python 3.10 requirement and development commands.
-- [x] README links to this checklist.
+- [x] Readme documents Python 3.10 requirement and development commands.
+- [x] Readme links to this checklist.
 
 ## Tests and CI
 

--- a/docs/mvp-spec.md
+++ b/docs/mvp-spec.md
@@ -24,7 +24,7 @@ Use this precedence order for MVP implementation:
 2. `AGENTS.md` repository guidance;
 3. this MVP spec;
 4. the active GitHub issue body;
-5. `docs/issue-plan.md` and README.
+5. `docs/issue-plan.md` and readme.
 
 When artifacts conflict, update the lower-precedence artifact instead of
 inventing behavior during implementation.
@@ -203,14 +203,14 @@ Day 3:
 - Add LLM rubric backend interface and advisory docs.
 - Add `gh aw` composition guide and examples.
 - Add end-to-end examples and smoke tests.
-- Harden README, packaging metadata, and issue acceptance criteria.
+- Harden readme, packaging metadata, and issue acceptance criteria.
 
 # Done Criteria
 
 - `uv run gate-keeper compile docs/example-rules.md --format json` emits rule IR.
 - `uv run gate-keeper validate docs/example-rules.md --target fixtures/pass`
   exits `0`.
-- A failing fixture exits non-zero and reports rule id, source location, backend,
+- A failing fixture exits non-zero and reports rule ID, source location, backend,
   severity, and evidence.
 - GitHub backend command construction is covered by tests.
 - Live GitHub validation fails closed when `gh` auth or required context is

--- a/docs/rule-ir.md
+++ b/docs/rule-ir.md
@@ -82,7 +82,7 @@ shape beyond those two top-level keys.
 `filesystem`, `github`, `llm-rubric`, `external`
 
 The `external` backend is a single dispatcher for third-party tool adapters
-(textlint, vale, eslint, …). New tools register as adapters under this
+(textlint, vale, ESLint, …). New tools register as adapters under this
 backend rather than minting new `Backend` enum values; see
 [`docs/backend-external.md`](backend-external.md) for the adapter contract.
 
@@ -108,7 +108,7 @@ backend rather than minting new `Backend` enum values; see
 | ------ | ------------ | ------- | ----- |
 | `github_labels_absent` | `labels` | `["blocked","do-not-merge","needs-decision"]` | List of blocking label names (case-insensitive). Absent key uses default list; explicit `[]` means no blocking labels → always PASS. |
 | `github_checks_success` | _(none)_ | — | Evaluates every entry in `statusCheckRollup` as required; only `SUCCESS` state/conclusion passes. Branch protection remains the authoritative control plane. |
-| `external_check` | `tool` | _(required)_ | String adapter id selecting which `external` adapter handles the rule (e.g. `"textlint"`). Missing → `unavailable` / `params_error`; unregistered → `unsupported` / `adapter_unknown`. All other `params` keys are forwarded verbatim to the adapter, which owns its own per-tool keys. See [`docs/backend-external.md`](backend-external.md). |
+| `external_check` | `tool` | _(required)_ | String adapter ID selecting which `external` adapter handles the rule (e.g. `"textlint"`). Missing → `unavailable` / `params_error`; unregistered → `unsupported` / `adapter_unknown`. All other `params` keys are forwarded verbatim to the adapter, which owns its own per-tool keys. See [`docs/backend-external.md`](backend-external.md). |
 
 ## `github_non_author_approval` — formal evidence and limitations
 
@@ -159,5 +159,5 @@ weaken every downstream backend.
 | File | Shape |
 | ---- | ----- |
 | `tests/fixtures/ir/rule-filesystem-text-required.json` | `RuleSet` with one filesystem rule. |
-| `tests/fixtures/ir/rule-github-pr-open.json` | `RuleSet` with one github rule. |
+| `tests/fixtures/ir/rule-github-pr-open.json` | `RuleSet` with one GitHub rule. |
 | `tests/fixtures/ir/diagnostic-mixed.json` | `DiagnosticReport` exercising `pass`, `fail`, `unavailable`, and `unsupported`. |

--- a/docs/semantic-rules.md
+++ b/docs/semantic-rules.md
@@ -46,10 +46,10 @@ for the `llm-rubric` backend in its current form.
 
 ---
 
-## 2. Anti-patterns (judgment-level)
+## 2. Antipatterns (judgment-level)
 
-The anti-patterns below cause the LLM to produce unreliable or
-non-reproducible verdicts. Mechanical anti-patterns (style, punctuation, line
+The antipatterns below cause the LLM to produce unreliable or
+non-reproducible verdicts. Mechanical antipatterns (style, punctuation, line
 length) that belong to a textlint-style rule are tracked in #95.
 
 **Unbounded subject (`code`, `the project`, `everything`).**
@@ -178,7 +178,7 @@ which constrains what a rule can safely claim.
 
 **Backend routing (#95 / #66-B):** the question of *which rules should route to
 `llm-rubric`* versus `external+textlint` versus a deterministic backend is out
-of scope here. That routing logic and the mechanical anti-patterns best caught
+of scope here. That routing logic and the mechanical antipatterns best caught
 by textlint are tracked in issue #95 (the `Backend.EXTERNAL` adapter work,
 umbrella #80). The `intended_backend` field in the semantic fixture schema (see
 `tests/fixtures/semantic/README.md`) is the per-entry record of the correct

--- a/docs/textlint/ja-preset-evaluation.md
+++ b/docs/textlint/ja-preset-evaluation.md
@@ -41,7 +41,7 @@ Most rules fire exclusively on Unicode characters in the CJK range. An
 English-only document triggers zero rules from this preset. The encoding-safety
 rules (`no-nfd`, `no-zero-width-spaces`, `no-invalid-control-character`) apply
 universally, but identical protection is available through simpler means (editor
-config, git hooks) and these rules have negligible false-positive risk on ASCII
+config, Git hooks) and these rules have negligible false-positive risk on ASCII
 text.
 
 **False-positive tendency on mixed corpus (English + incidental Japanese)**:

--- a/docs/textlint/package-set.md
+++ b/docs/textlint/package-set.md
@@ -21,7 +21,7 @@ LLM rubric whenever evidence is available.** For textlint this means:
 
 - Its rules are Japanese-specific and the corpus contains no Japanese text
   (see §5 below).
-- It introduces style-guide choices that require significant per-project option
+- It introduces style guide choices that require significant per-project option
   tuning to avoid noisy alerts.
 - It bundles other packages whose individual cost/benefit is unclear.
 - It is domain-specific (e.g. engineering papers, SI units) and the corpus is
@@ -40,11 +40,11 @@ throughout the corpus.
 |---------|------|--------|-----------|------------------------|
 | `textlint-rule-prh` | Dictionary / terminology | **in** | Pure dictionary lookup; rules fire only on exact matches in `prh.yml`. Deterministic, zero false positives when the dictionary is correctly authored. Central to project-specific terminology control. | Very low — user-controlled dictionary. |
 | `textlint-rule-terminology` | English brand/term spelling | **in** | Enforces consistent capitalisation of English technical terms (GitHub, JavaScript, npm, …). Deterministic, rule list is well-curated, minimal tuning needed on English prose. | Low — well-tested rule list; occasional conflicts with deliberate lower-case use (mitigated by `allowTerms` option). |
-| `textlint-rule-preset-ja-spacing` | Japanese spacing conventions | **defer** | Corpus is English-only (see §5). All rules in this preset fire on Japanese-adjacent characters that do not appear in this repo. Zero value; all alerts would be false positives. Reopen: if Japanese prose is added to the corpus. | N/A — inapplicable corpus. |
+| `textlint-rule-preset-ja-spacing` | Japanese spacing conventions | **defer** | Corpus is English-only (see §5). All rules in this preset fire on Japanese-adjacent characters that do not appear in this repository. Zero value; all alerts would be false positives. Reopen: if Japanese prose is added to the corpus. | N/A — inapplicable corpus. |
 | `textlint-rule-preset-japanese` | General Japanese writing | **defer** | Same rationale as ja-spacing. Corpus contains no Japanese text. Reopen: if Japanese prose is added to the corpus. | N/A — inapplicable corpus. |
 | `textlint-rule-preset-ja-technical-writing` | Japanese tech writing | **defer** | Japanese-specific preset; intentionally ships rules that require per-project exception lists. Even if the corpus had Japanese text, this would require tuning before first use. Reopen: after Japanese corpus exists and #83 eval data is available. | High without tuning — acknowledged in #80 body. |
-| `textlint-rule-preset-jtf-style` | JTF Japanese style guide | **defer** | Japanese-specific. #80 body notes "some style-guide items are difficult or impossible to enforce mechanically." Reopen: after Japanese corpus exists and after empirical evaluation under #83. | High — mechanical enforcement of style-guide items known to misfire. |
-| `textlint-rule-preset-ja-engineering-paper` | Engineering paper (JA) | **out** | Japanese-specific and domain-specific (engineering papers). This repo is general-purpose developer documentation. Cross-reference #91: if per-doc-type configs are introduced and any documents are Japanese engineering papers, reconsider there. Reopen criterion: #91 introduces an engineering-paper document type with Japanese prose. | High — both Japanese-specific and paper-specific rules applied globally. |
+| `textlint-rule-preset-jtf-style` | JTF Japanese style guide | **defer** | Japanese-specific. #80 body notes "some style guide items are difficult or impossible to enforce mechanically." Reopen: after Japanese corpus exists and after empirical evaluation under #83. | High — mechanical enforcement of style guide items known to misfire. |
+| `textlint-rule-preset-ja-engineering-paper` | Engineering paper (JA) | **out** | Japanese-specific and domain-specific (engineering papers). This repository is general-purpose developer documentation. Cross-reference #91: if per-doc-type configs are introduced and any documents are Japanese engineering papers, reconsider there. Reopen criterion: #91 introduces an engineering-paper document type with Japanese prose. | High — both Japanese-specific and paper-specific rules applied globally. |
 | `textlint-rule-no-synonyms` | Japanese synonym drift | **out** | Depends on Sudachi Japanese synonym data; fires on Japanese terms only. No Japanese text in this corpus. No reopen path without Japanese prose. Reopen criterion: Japanese prose is added and #91 establishes a Japanese document type. | N/A — inapplicable corpus. |
 | `textlint-rule-use-si-units` | SI unit formatting | **defer** | Potentially useful for technical docs, but the corpus contains no mathematical or physical-unit content today. Cross-reference #91: appropriate in a per-doc-type config for spec or engineering documents rather than globally. Reopen criterion: #91 introduces a document type where SI unit consistency is a stated project requirement. | Medium — SI rules applied globally to developer docs and changelogs will alert on legitimate informal usage. |
 
@@ -82,7 +82,7 @@ empirical evaluation (#83) and per-doc-type config design (#91).
 
 ---
 
-## 5. Repo corpus consideration
+## 5. Repository corpus consideration
 
 **Language**: every authored Markdown file in this repository is English. The
 full sample — `docs/*.md` (9 files), `README.md`, and `tests/fixtures/**/*.md`
@@ -120,7 +120,7 @@ deferring all Japanese-language packages.
 - **`prh.yml` content** (preferred terms, prohibited patterns, allowlists) — #84.
 - **CI workflow** (GitHub Actions, changed-file checks, annotation formatter) — #87.
 - **Per-doc-type config** (whether engineering-paper or SI-unit rules apply to
-  any document type in this repo) — #91.
+  any document type in this repository) — #91.
 - **False-positive policy** (inline suppression, ignore-file conventions) — #90.
 - **Empirical preset evaluation** on the existing corpus (data that will inform
   any future addition of deferred packages) — #83.

--- a/docs/textlint/per-doc-type-policy.md
+++ b/docs/textlint/per-doc-type-policy.md
@@ -17,7 +17,7 @@ corpus exists alongside the dev corpus.
 
 ---
 
-## Repo corpus survey
+## Repository corpus survey
 
 Surveyed `docs/`, `README.md`, and `tests/fixtures/semantic/targets/` as of main
 (`9ae3318`).
@@ -50,12 +50,12 @@ prose. There is no paper-style stratum that would benefit from a separate config
 
 ## Decision
 
-**Use global preset only.** This repo's corpus does not warrant per-doc-type splitting
+**Use global preset only.** This repository's corpus does not warrant per-doc-type splitting
 at this time. All textlint rules should live in a single `.textlintrc.json` (to be
 created in #82) and apply uniformly to every Markdown file.
 
 Rationale:
-1. No paper-style writing exists in the repo; any engineering-paper or SI-unit preset
+1. No paper-style writing exists in the repository; any engineering-paper or SI-unit preset
    would fire exclusively against dev docs, producing only false positives with zero
    true-positive value.
 2. The fixture targets under `tests/fixtures/semantic/targets/` are synthetic prose
@@ -87,12 +87,12 @@ below).
 This decision should be revisited when **any** of the following occurs:
 
 1. A paper-style document (preprint, technical report, SI-unit-heavy spec) lands in
-   the repo — suggested landing zone `docs/paper/` so the boundary is unambiguous.
+   the repository — suggested landing zone `docs/paper/` so the boundary is unambiguous.
 2. A specific engineering-paper or SI-unit rule is evaluated in #83 and its
    false-positive rate on dev docs exceeds 20% of flagged occurrences while its
    true-positive rate on paper-style content is high — quantitative signal that a split
    would carry real value.
-3. The repo corpus grows a new category (e.g. a user manual under `docs/guide/` with
+3. The repository corpus grows a new category (e.g. a user manual under `docs/guide/` with
    formal register) that is meaningfully distinct from current dev/design prose.
 
 ---


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/textlint.yml` (Mode A standalone) per #87 / umbrella #80. The workflow triggers on `pull_request`, sets up Node 20 with npm cache, installs via `npm ci`, and runs `npx textlint --format github` so findings surface as inline GitHub annotations on the PR diff.
- Adds a `concurrency:` group keyed on `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true` so re-pushed PRs do not pile up runs.
- Documents the exit-code distinction inline in the workflow header (`docs/textlint/severity-policy.md` §6): `exit 1` from textlint surfaces at the lint step (lint failure); install/setup failures surface at separate steps (config/infra failure).
- Fixes the 28 pre-existing terminology findings across `docs/` (manual edits, no autofix) so the new workflow lands green on `main`. Replacements follow the in-repo mine-list (`repo` → `repository`, `eslint` → `ESLint`, `git` → `Git`, `style-guide` → `style guide`, `Anti-patterns` → `Antipatterns`, prose `README` → `Readme`/`readme`, `id` → `ID`, `github` → `GitHub`).

## Validation

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/textlint.yml'))"` => YAML OK.
- `npx --no -- textlint --format compact "docs/**/*.md" "README.md"` => exit 0, 0 findings.
- `npx --no -- textlint --format github "docs/**/*.md" "README.md"` => exit 0, 0 findings.
- `uv run pytest -q` => 750 passed.
- `uvx ruff check .` => All checks passed.
- The workflow's first real run is on this PR itself (per the issue acceptance pattern); the textlint check on this PR is the live validation.

## Out of scope

- Changed-file-only narrowing (#88).
- Mode B (gate-keeper-mediated invocation through the textlint adapter from #94).

Closes #87