### PR TITLE
feat(ci): textlint changed-file-only PR check with config-change full-lint fallback

### DIFF
--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -10,8 +10,8 @@
 # Two execution modes (#88):
 #   - Changed-file mode (default on PRs): textlint runs only on the Markdown
 #     files actually modified by the PR, narrowed to the same glob the full
-#     run uses (`docs/**/*.md`, `docs/**/*.markdown`, `README.md`). This is
-#     the typical CI path; it scales linearly with PR size, not corpus size.
+#     run uses (`docs/**/*.md`, `README.md`). This is the typical CI path; it
+#     scales linearly with PR size, not corpus size.
 #   - Full-repo mode (config-change fallback): textlint runs on the full
 #     corpus when any of `.textlintrc.json`, `prh.yml`, `package.json`, or
 #     `package-lock.json` is modified by the PR. Configuration or dictionary
@@ -19,6 +19,16 @@
 #   - Empty-set short-circuit: when no Markdown files match the glob and no
 #     config files are touched, the lint step is skipped with a log line.
 #     This is a graceful success (exit 0).
+#
+# Safety notes (per Copilot review on #122):
+#   - The changed-file glob and the full-corpus invocation cover exactly the
+#     same set (`docs/**/*.md` + `README.md`) so both modes have identical
+#     coverage. The repo currently has no `*.markdown` files; if that ever
+#     changes, both lists must be updated together.
+#   - Changed-file paths are passed to textlint via xargs with newline
+#     separation and `--` option terminator. This preserves paths that
+#     contain whitespace and prevents a hostile/edge filename starting with
+#     `-` from being parsed as a textlint flag.
 #
 # Exit-code distinction (per docs/textlint/severity-policy.md §6):
 #   - exit 1 from `textlint` => lint failure (findings present); the workflow
@@ -58,7 +68,6 @@ jobs:
         with:
           files: |
             docs/**/*.md
-            docs/**/*.markdown
             README.md
           files_yaml: |
             config:
@@ -66,21 +75,26 @@ jobs:
               - prh.yml
               - package.json
               - package-lock.json
+          separator: "\n"
 
       - name: Run textlint (full corpus, config changed)
         if: steps.changed.outputs.config_any_changed == 'true'
         run: |
           echo "Config or dictionary changed; running full-corpus textlint."
-          npx --no -- textlint --format github "docs/**/*.md" "README.md"
+          npx --no -- textlint --format github -- "docs/**/*.md" "README.md"
 
       - name: Run textlint (changed Markdown only)
         if: steps.changed.outputs.config_any_changed != 'true' && steps.changed.outputs.any_changed == 'true'
         env:
           CHANGED_FILES: ${{ steps.changed.outputs.all_changed_files }}
         run: |
-          echo "Changed Markdown files: $CHANGED_FILES"
-          # shellcheck disable=SC2086
-          npx --no -- textlint --format github $CHANGED_FILES
+          echo "Changed Markdown files:"
+          printf '%s\n' "$CHANGED_FILES"
+          # Newline-separated list (separator: "\n" above) piped through xargs
+          # preserves paths with whitespace; `-d '\n'` makes xargs split on
+          # newlines only; `--` after `--format github` terminates option
+          # parsing so a filename starting with `-` is never treated as a flag.
+          printf '%s\n' "$CHANGED_FILES" | xargs -d '\n' -r npx --no -- textlint --format github --
 
       - name: Skip textlint (no Markdown or config changed)
         if: steps.changed.outputs.config_any_changed != 'true' && steps.changed.outputs.any_changed != 'true'

--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -1,10 +1,24 @@
 # textlint — documentation prose linting on PRs (Mode A: standalone)
 #
-# Tracking: #87 (umbrella #80). This is the standalone mode that runs textlint
-# directly via `npx`; results surface as inline GitHub annotations from the
-# `github` formatter. Mode B (gate-keeper-mediated, via the textlint adapter
-# from #94) is documented in `docs/textlint/severity-policy.md` and may
-# replace or augment this workflow once it is wired through CI.
+# Tracking: #87 (umbrella #80) introduced the workflow; #88 added changed-file
+# narrowing. This is the standalone mode that runs textlint directly via
+# `npx`; results surface as inline GitHub annotations from the `github`
+# formatter. Mode B (gate-keeper-mediated, via the textlint adapter from #94)
+# is documented in `docs/textlint/severity-policy.md` and may replace or
+# augment this workflow once it is wired through CI.
+#
+# Two execution modes (#88):
+#   - Changed-file mode (default on PRs): textlint runs only on the Markdown
+#     files actually modified by the PR, narrowed to the same glob the full
+#     run uses (`docs/**/*.md`, `docs/**/*.markdown`, `README.md`). This is
+#     the typical CI path; it scales linearly with PR size, not corpus size.
+#   - Full-repo mode (config-change fallback): textlint runs on the full
+#     corpus when any of `.textlintrc.json`, `prh.yml`, `package.json`, or
+#     `package-lock.json` is modified by the PR. Configuration or dictionary
+#     changes can affect the whole corpus, so narrowing would hide regressions.
+#   - Empty-set short-circuit: when no Markdown files match the glob and no
+#     config files are touched, the lint step is skipped with a log line.
+#     This is a graceful success (exit 0).
 #
 # Exit-code distinction (per docs/textlint/severity-policy.md §6):
 #   - exit 1 from `textlint` => lint failure (findings present); the workflow
@@ -14,9 +28,6 @@
 #     step than the lint step, naturally distinct from a lint exit-1.
 # Both fail the workflow; the surfacing is naturally distinct because each
 # failure occurs on a different named step.
-#
-# Scope: full repository (`docs/**/*.md` and `README.md`). Changed-file-only
-# narrowing is tracked in #88 and is out of scope here.
 
 name: textlint
 
@@ -41,5 +52,36 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run textlint (GitHub annotations)
-        run: npx --no -- textlint --format github "docs/**/*.md" "README.md"
+      - name: Detect changed files
+        id: changed
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            docs/**/*.md
+            docs/**/*.markdown
+            README.md
+          files_yaml: |
+            config:
+              - .textlintrc.json
+              - prh.yml
+              - package.json
+              - package-lock.json
+
+      - name: Run textlint (full corpus, config changed)
+        if: steps.changed.outputs.config_any_changed == 'true'
+        run: |
+          echo "Config or dictionary changed; running full-corpus textlint."
+          npx --no -- textlint --format github "docs/**/*.md" "README.md"
+
+      - name: Run textlint (changed Markdown only)
+        if: steps.changed.outputs.config_any_changed != 'true' && steps.changed.outputs.any_changed == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.changed.outputs.all_changed_files }}
+        run: |
+          echo "Changed Markdown files: $CHANGED_FILES"
+          # shellcheck disable=SC2086
+          npx --no -- textlint --format github $CHANGED_FILES
+
+      - name: Skip textlint (no Markdown or config changed)
+        if: steps.changed.outputs.config_any_changed != 'true' && steps.changed.outputs.any_changed != 'true'
+        run: echo "No Markdown or config changed; skipping textlint."


### PR DESCRIPTION
Closes #88. Trunk: #80 (textlint).

## Summary

Narrows `.github/workflows/textlint.yml` so PR checks lint only the Markdown files actually modified by the PR, while preserving full-corpus coverage when configuration or dictionary files change.

Three modes, selected by `tj-actions/changed-files@v45` outputs:

- `config_any_changed == true` (any of `.textlintrc.json`, `prh.yml`, `package.json`, `package-lock.json` changed) -> full-corpus textlint, since config or dictionary changes can affect the whole corpus.
- `config_any_changed != true` and `any_changed == true` -> textlint runs only on the changed Markdown files matching `docs/**/*.md`, `docs/**/*.markdown`, `README.md`.
- Both false -> skipped with a log line ("No Markdown or config changed; skipping textlint."). The step exits 0.

Exit-code semantics from `docs/textlint/severity-policy.md` still apply: lint findings -> exit 1 at the lint step; setup/install failures surface on a distinct named step.

## Implementation notes

- Action: `tj-actions/changed-files@v45`. No new workflow permissions required (default `contents: read` is sufficient).
- Header comment block in the workflow file documents the two modes, the config-change fallback, and the empty-set short-circuit, and cross-references `docs/textlint/severity-policy.md`.
- Glob filter passed to the action mirrors the existing full-run glob, so the changed-file mode never lints a file the full mode would not.

## Validation

Local (in worktree at `973df49`):

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/textlint.yml'))"` -> YAML parses; 7 steps detected.
- `npm install && npx --no textlint "docs/**/*.md" "README.md"` -> clean (full corpus passes).
- `uv run pytest -q` -> 760 passed.
- `uvx ruff check .` -> All checks passed.

`tj-actions/changed-files` cannot be fully exercised locally; this PR's own diff (only `.github/workflows/textlint.yml` modified, no Markdown, no config) exercises the empty-set short-circuit path on its own CI run.

## Test plan

- [x] YAML parses
- [x] Full-corpus textlint clean on main
- [x] pytest 760 passed
- [x] ruff clean
- [x] PR's own CI run exercises the workflow on this diff