### PR TITLE
docs: audience-separated README TOC and internal artifact banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,39 @@ runtime. The intended shape is:
 4. fall back to an LLM rubric backend for semantic checks;
 5. emit compiler-style pass/fail output with enough evidence to stop safely.
 
+## Documentation
+
+### For users
+
+- [docs/llm-rubric.md](docs/llm-rubric.md) — LLM rubric backend: configuration, evidence shape, and credential setup
+- [docs/gh-aw.md](docs/gh-aw.md) — GitHub Agentic Workflows (`gh aw`) integration guide
+- [docs/example-rules.md](docs/example-rules.md) — annotated rule examples across all backends
+
+### Reference
+
+- [docs/rule-ir.md](docs/rule-ir.md) — rule intermediate representation schema
+- [docs/backend-external.md](docs/backend-external.md) — external tool adapter contract (`Backend.EXTERNAL`)
+- [docs/semantic-rules.md](docs/semantic-rules.md) — semantic rubric rule authoring guide
+
+### Internal (process artifacts)
+
+These files record design decisions and planning context. They are not
+user-facing reference material.
+
+- [docs/mvp-spec.md](docs/mvp-spec.md) — original MVP task specification
+- [docs/mvp-readiness.md](docs/mvp-readiness.md) — MVP completion checklist
+- [docs/issue-plan.md](docs/issue-plan.md) — 3-day MVP issue structure
+- [docs/dogfooding.md](docs/dogfooding.md) — self-gating policy and advisory rules
+- [docs/dogfooding-rules.md](docs/dogfooding-rules.md) — seed semantic rule pool
+- [docs/design/hybrid-rule.md](docs/design/hybrid-rule.md) — hybrid rule kind design (#73)
+- [docs/design/multi-target.md](docs/design/multi-target.md) — multi-target evaluation design (#74)
+- [docs/textlint/severity-policy.md](docs/textlint/severity-policy.md) — textlint severity mapping decision record (#85)
+- [docs/textlint/per-doc-type-policy.md](docs/textlint/per-doc-type-policy.md) — per-doc-type textlint config policy (#91)
+- [docs/textlint/package-set.md](docs/textlint/package-set.md) — textlint initial package set decision record (#81)
+- [docs/textlint/ja-preset-evaluation.md](docs/textlint/ja-preset-evaluation.md) — Japanese preset evaluation decision record (#83)
+- [docs/textlint/exception-policy.md](docs/textlint/exception-policy.md) — false-positive handling and exception policy (#90)
+- [docs/textlint/prh-process.md](docs/textlint/prh-process.md) — `prh.yml` contribution process (#84)
+
 ## MVP
 
 The 3-day MVP is intentionally narrow:

--- a/docs/design/hybrid-rule.md
+++ b/docs/design/hybrid-rule.md
@@ -1,5 +1,7 @@
 # Design: Hybrid Rule Kind — Deterministic Precheck + Semantic Judgment
 
+> Status: internal process artifact — not user-facing reference.
+
 Tracking: #73 (design phase). Implementation tracked under umbrella #63.
 
 ---

--- a/docs/design/multi-target.md
+++ b/docs/design/multi-target.md
@@ -1,5 +1,7 @@
 # Design: Multi-Target Evaluation (Directory / Multi-File Context)
 
+> Status: internal process artifact — not user-facing reference.
+
 Tracking issue: #74. Design phase only — no IR or backend changes in this doc.
 
 ---

--- a/docs/dogfooding-rules.md
+++ b/docs/dogfooding-rules.md
@@ -1,5 +1,7 @@
 # Dogfooding rules — semantic advisory pool
 
+> Status: internal process artifact — not user-facing reference.
+
 Seed pool of semantic rules that `gate-keeper` evaluates against its own
 pull requests as advisory input. Complements
 [`example-rules.md`](example-rules.md), which holds the deterministic

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -1,5 +1,7 @@
 # Dogfooding gate-keeper on itself
 
+> Status: internal process artifact — not user-facing reference.
+
 `gate-keeper` is exercised against its own PRs to surface compiler/backend gaps
 early. The rule of thumb in `AGENTS.md` is: **self-gating is advisory by default;
 promote per-rule to required.** This document defines the promotion path.

--- a/docs/issue-plan.md
+++ b/docs/issue-plan.md
@@ -1,5 +1,7 @@
 # Issue Plan
 
+> Status: internal process artifact — not user-facing reference.
+
 This is the intended GitHub issue structure for the 3-day MVP.
 
 Project: https://github.com/users/t-uda/projects/2

--- a/docs/mvp-readiness.md
+++ b/docs/mvp-readiness.md
@@ -1,5 +1,7 @@
 # MVP Readiness Checklist
 
+> Status: internal process artifact — not user-facing reference.
+
 This checklist defines the three-day MVP completion line. Every item must be
 verifiable without hidden context. Check off items with `uv run` commands and
 `gh pr view` output.

--- a/docs/mvp-spec.md
+++ b/docs/mvp-spec.md
@@ -1,5 +1,7 @@
 # Task
 
+> Status: internal process artifact — not user-facing reference.
+
 Build `gate-keeper`, a small rule compiler that turns natural-language rule
 documents into machine-verifiable checks for local files and GitHub pull
 requests.

--- a/docs/textlint/exception-policy.md
+++ b/docs/textlint/exception-policy.md
@@ -1,5 +1,7 @@
 # textlint false-positive handling and exception policy (#90)
 
+> Status: internal process artifact — not user-facing reference.
+
 Tracking umbrella: #80. This document defines how contributors handle textlint
 false positives and propose project-level exceptions. It is policy-only;
 concrete exception entries belong in their respective files

--- a/docs/textlint/ja-preset-evaluation.md
+++ b/docs/textlint/ja-preset-evaluation.md
@@ -1,5 +1,7 @@
 # textlint Japanese preset evaluation — decision record (#83)
 
+> Status: internal process artifact — not user-facing reference.
+
 Tracking umbrella: #80. This evaluation informs future additions to `.textlintrc`
 when Japanese prose is added to the corpus. Configuration file authoring is #82;
 severity policy is #85.

--- a/docs/textlint/package-set.md
+++ b/docs/textlint/package-set.md
@@ -1,5 +1,7 @@
 # textlint initial package set — decision record (#81)
 
+> Status: internal process artifact — not user-facing reference.
+
 Tracking umbrella: #80. Configuration, severity policy, prh dictionary,
 and CI workflow are deferred to #82, #85, #84, and #87 respectively.
 

--- a/docs/textlint/per-doc-type-policy.md
+++ b/docs/textlint/per-doc-type-policy.md
@@ -1,5 +1,7 @@
 # textlint per-doc-type config policy
 
+> Status: internal process artifact — not user-facing reference.
+
 **Issue:** #91 | **Parent umbrella:** #80
 
 ## Question

--- a/docs/textlint/prh-process.md
+++ b/docs/textlint/prh-process.md
@@ -1,5 +1,7 @@
 # `prh.yml` contribution process — issue #84
 
+> Status: internal process artifact — not user-facing reference.
+
 Tracking umbrella: #80. The dictionary itself lives at `prh.yml` in the
 repository root and is wired through `.textlintrc.json` via
 `textlint-rule-prh`. Rule severity, package selection, and the broader

--- a/docs/textlint/severity-policy.md
+++ b/docs/textlint/severity-policy.md
@@ -1,5 +1,7 @@
 # textlint severity policy — decision record (#85)
 
+> Status: internal process artifact — not user-facing reference.
+
 Tracking umbrella: #80. This document defines the mapping from textlint
 severity levels to gate-keeper severity levels, and the fail-closed criteria
 per document type.


### PR DESCRIPTION
Closes #123

## Summary

- Added `## Documentation` section to `README.md` immediately before `## MVP`, with three audience-labeled subsections:
  - **For users**: `docs/llm-rubric.md`, `docs/gh-aw.md`, `docs/example-rules.md`
  - **Reference**: `docs/rule-ir.md`, `docs/backend-external.md`, `docs/semantic-rules.md`
  - **Internal (process artifacts)**: all 13 internal docs
- Prepended `> Status: internal process artifact — not user-facing reference.` banner directly after the H1 in each of the 13 internal docs (banner-only addition, no body rewrites)

## Acceptance

- [x] README has a top-level TOC with 3 audience-labeled sections.
- [x] All 13 internal-artifact files carry the status banner directly after their H1.
- [x] `npx --no textlint README.md "docs/**/*.md"` clean.
- [x] No file content rewrites beyond the banner addition.

## Validation

```
npx --no textlint README.md "docs/**/*.md"
# exit 0 — no output

uv run pytest
# passed

uvx ruff check .
# All checks passed!

uvx pyright
# 13 pre-existing import-resolution errors (pytest/dotenv/openai/anthropic not in pyright path)
# same baseline as main — no new errors introduced
```