### PR TITLE
feat(llm-rubric): add cost_estimate_usd evidence field

### DIFF
--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -124,20 +124,28 @@ When a provider responds successfully, the diagnostic carries:
 
 - `status`: `pass` or `fail`.
 - `message`: the `primary_reason` from the structured judgment.
-- `evidence[0]`: `{ kind: "llm_judgment", data: { model, prompt_version, judgment, primary_reason, supporting_evidence_quotes, suggested_action, latency_ms, tokens_in, tokens_out } }`.
+- `evidence[0]`: `{ kind: "llm_judgment", data: { model, prompt_version, judgment, primary_reason, supporting_evidence_quotes, suggested_action, latency_ms, tokens_in, tokens_out, cost_estimate_usd } }`.
 - `remediation`: set to `suggested_action` when `status=fail`; `null` on `pass`.
 
 ### Per-rule observability fields
 
-Issue #76 adds three observability fields to every successful `llm_judgment`
-evidence entry, providing the data substrate for drift detection, cost
-analysis, and per-rule SLA work:
+Issue #76 adds three observability fields and issue #133 adds cost estimation to every
+successful `llm_judgment` evidence entry, providing the data substrate for drift
+detection, cost analysis, and per-rule SLA work:
 
 | Field | Type | Source | Semantics |
 | --- | --- | --- | --- |
 | `latency_ms` | `int` (milliseconds) | `time.perf_counter()` around the SDK call | Wall-clock duration of the provider call, integer-rounded. |
 | `tokens_in` | `int` | Anthropic `usage.input_tokens` / OpenAI `usage.prompt_tokens` | Provider-reported prompt token count. |
 | `tokens_out` | `int` | Anthropic `usage.output_tokens` / OpenAI `usage.completion_tokens` | Provider-reported completion token count. |
+| `cost_estimate_usd` | `float \| null` | Static `_MODEL_PRICING` table (snapshot 2026-05-08) | Estimated USD cost for this call; `null` for unknown models (fail-closed). |
+
+Pricing snapshot (2026-05-08) used for `cost_estimate_usd`:
+
+| Model | Input (per 1M tokens) | Output (per 1M tokens) |
+| --- | --- | --- |
+| `gpt-4o-mini` | $0.15 | $0.60 |
+| `claude-haiku-4-5` | $0.80 | $4.00 |
 
 These fields appear **only on successful provider calls** that produce a
 parseable, schema-conforming judgment. The `provider_unconfigured` and
@@ -148,8 +156,8 @@ carry telemetry. Missing evidence is recorded as missing rather than
 synthesised.
 
 When `--reproducibility N` aggregates `N` runs, the `latency_ms` / `tokens_in`
-/ `tokens_out` on the chosen majority-judgment evidence reflect that single
-representative run, not an aggregate. The separate
+/ `tokens_out` / `cost_estimate_usd` on the chosen majority-judgment evidence
+reflect that single representative run, not an aggregate. The separate
 `reproducibility_score` evidence entry (#68) carries no telemetry.
 
 ## Failure modes

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -32,6 +32,46 @@ _SUPPORTED_PROVIDERS = ("anthropic", "openai")
 PROMPT_VERSION = "v1"
 
 # ---------------------------------------------------------------------------
+# Per-model pricing table (#133)
+#
+# Snapshot date: 2026-05-08.
+# Source: https://openai.com/api/pricing/ (gpt-4o-mini) and
+#         https://www.anthropic.com/pricing#anthropic-api (claude-haiku-4-5).
+# Units: USD per 1 million tokens.
+# Update this dict when pricing changes; add ``snapshot_date`` to docs/llm-rubric.md.
+# ---------------------------------------------------------------------------
+
+_MODEL_PRICING: dict[str, dict[str, float]] = {
+    # OpenAI — https://openai.com/api/pricing/
+    "gpt-4o-mini": {"input_per_1m": 0.15, "output_per_1m": 0.60},
+    # Anthropic — https://www.anthropic.com/pricing#anthropic-api
+    "claude-haiku-4-5": {"input_per_1m": 0.80, "output_per_1m": 4.00},
+}
+
+
+def _estimate_cost(model: str, tokens_in: int, tokens_out: int) -> float | None:
+    """Return estimated USD cost for *model* given token counts.
+
+    Uses the static ``_MODEL_PRICING`` snapshot (2026-05-08).  Returns ``None``
+    for any model not in the table — fail-closed: unknown cost is not guessed.
+
+    Parameters
+    ----------
+    model:
+        Model identifier as reported by the provider (e.g. ``"gpt-4o-mini"``).
+    tokens_in:
+        Provider-reported prompt / input token count.
+    tokens_out:
+        Provider-reported completion / output token count.
+    """
+    pricing = _MODEL_PRICING.get(model)
+    if pricing is None:
+        return None
+    cost = (tokens_in * pricing["input_per_1m"] + tokens_out * pricing["output_per_1m"]) / 1_000_000
+    return cost
+
+
+# ---------------------------------------------------------------------------
 # Structured LLM judgment schema (#67)
 # ---------------------------------------------------------------------------
 
@@ -484,6 +524,8 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
       milliseconds (#76).
     - ``tokens_in``: provider-reported prompt token count (#76).
     - ``tokens_out``: provider-reported completion token count (#76).
+    - ``cost_estimate_usd``: estimated USD cost based on static per-model
+      pricing snapshot (#133); ``None`` for unknown models.
 
     ``Diagnostic.remediation`` is set to ``suggested_action`` on fail.
     """
@@ -522,6 +564,7 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
     )
 
     status = Status.PASS if parsed.judgment == "pass" else Status.FAIL
+    cost = _estimate_cost(model, telemetry["tokens_in"], telemetry["tokens_out"])
     evidence = Evidence(
         kind="llm_judgment",
         data={
@@ -534,6 +577,7 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
             "latency_ms": telemetry["latency_ms"],
             "tokens_in": telemetry["tokens_in"],
             "tokens_out": telemetry["tokens_out"],
+            "cost_estimate_usd": cost,
         },
     )
     if status is Status.PASS:

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -1065,16 +1065,18 @@ class TestEstimateCost:
     """
 
     def test_gpt4o_mini_known_tokens(self):
-        """1000 tokens_in + 200 tokens_out at gpt-4o-mini pricing."""
-        # cost = (1000 * 0.15 + 200 * 0.60) / 1_000_000
-        #      = (150 + 120) / 1_000_000
-        #      = 270 / 1_000_000
-        #      = 0.00000027  ... wait: 0.15/1M per token => 1000 * 0.15 / 1_000_000
-        # cost = (1000 * 0.15 + 200 * 0.60) / 1_000_000 = 0.000270
+        """1000 tokens_in + 200 tokens_out at gpt-4o-mini pricing.
+
+        cost = (1000 * $0.15 + 200 * $0.60) / 1,000,000
+             = (150 + 120) / 1,000,000
+             = 270 / 1,000,000
+             = $0.00027
+        """
         expected = (1000 * 0.15 + 200 * 0.60) / 1_000_000
         result = llm_backend._estimate_cost("gpt-4o-mini", 1000, 200)
         assert result is not None
         assert abs(result - expected) < 1e-12
+        assert abs(result - 0.00027) < 1e-9
 
     def test_claude_haiku_known_tokens(self):
         """500 tokens_in + 100 tokens_out at claude-haiku-4-5 pricing."""
@@ -1133,3 +1135,54 @@ class TestEstimateCost:
         assert "cost_estimate_usd" in data
         expected = (500 * 0.80 + 100 * 4.00) / 1_000_000
         assert abs(data["cost_estimate_usd"] - expected) < 1e-12
+
+    def test_cost_estimate_is_none_for_unknown_model_openai(self, monkeypatch, tmp_path):
+        """check() emits cost_estimate_usd: None when the resolved model is unknown.
+
+        Fail-closed evidence contract (#133): when the provider model is not in
+        ``_MODEL_PRICING`` the field must still be present in the evidence dict
+        with value ``None`` — never absent, never a guessed default.
+        """
+        _patch_env(
+            monkeypatch,
+            {"GATE_KEEPER_LLM_PROVIDER": "openai", "OPENAI_API_KEY": "sk-test"},
+        )
+        # Force the OpenAI dispatch branch to use a model that's not in the
+        # pricing table.
+        monkeypatch.setattr(llm_backend, "OPENAI_DEFAULT_MODEL", "gpt-future-unknown")
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(
+                _VALID_PASS_JSON,
+                {"latency_ms": 100, "tokens_in": 1000, "tokens_out": 200},
+            ),
+        )
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        data = diag.evidence[0].data
+        # Field must be present but null.
+        assert "cost_estimate_usd" in data
+        assert data["cost_estimate_usd"] is None
+        # Telemetry fields are still present (this is the success path).
+        assert data["tokens_in"] == 1000
+        assert data["tokens_out"] == 200
+
+    def test_cost_estimate_is_none_for_unknown_model_anthropic(self, monkeypatch, tmp_path):
+        """check() emits cost_estimate_usd: None for unknown Anthropic model."""
+        _patch_env(
+            monkeypatch,
+            {"GATE_KEEPER_LLM_PROVIDER": "anthropic", "ANTHROPIC_API_KEY": "sk-ant-test"},
+        )
+        monkeypatch.setattr(llm_backend, "ANTHROPIC_DEFAULT_MODEL", "claude-future-unknown")
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: _stub_response(
+                _VALID_PASS_JSON,
+                {"latency_ms": 150, "tokens_in": 500, "tokens_out": 100},
+            ),
+        )
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        data = diag.evidence[0].data
+        assert "cost_estimate_usd" in data
+        assert data["cost_estimate_usd"] is None

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -1049,3 +1049,87 @@ class TestRunN:
         monkeypatch.setattr(llm_backend, "_call_anthropic", _counter)
         llm_backend.run_n(_semantic_rule(), tmp_path, 5)
         assert call_count["n"] == 5
+
+
+# ---------------------------------------------------------------------------
+# _estimate_cost (#133)
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateCost:
+    """Unit tests for ``_estimate_cost`` — per-model static pricing table.
+
+    Snapshot date: 2026-05-08.
+    - gpt-4o-mini: $0.15/1M input, $0.60/1M output
+    - claude-haiku-4-5: $0.80/1M input, $4.00/1M output
+    """
+
+    def test_gpt4o_mini_known_tokens(self):
+        """1000 tokens_in + 200 tokens_out at gpt-4o-mini pricing."""
+        # cost = (1000 * 0.15 + 200 * 0.60) / 1_000_000
+        #      = (150 + 120) / 1_000_000
+        #      = 270 / 1_000_000
+        #      = 0.00000027  ... wait: 0.15/1M per token => 1000 * 0.15 / 1_000_000
+        # cost = (1000 * 0.15 + 200 * 0.60) / 1_000_000 = 0.000270
+        expected = (1000 * 0.15 + 200 * 0.60) / 1_000_000
+        result = llm_backend._estimate_cost("gpt-4o-mini", 1000, 200)
+        assert result is not None
+        assert abs(result - expected) < 1e-12
+
+    def test_claude_haiku_known_tokens(self):
+        """500 tokens_in + 100 tokens_out at claude-haiku-4-5 pricing."""
+        expected = (500 * 0.80 + 100 * 4.00) / 1_000_000
+        result = llm_backend._estimate_cost("claude-haiku-4-5", 500, 100)
+        assert result is not None
+        assert abs(result - expected) < 1e-12
+
+    def test_unknown_model_returns_none(self):
+        """Unknown model must return None (fail-closed: no cost guessing)."""
+        assert llm_backend._estimate_cost("gpt-5-turbo-ultra", 1000, 200) is None
+
+    def test_unknown_model_empty_string_returns_none(self):
+        assert llm_backend._estimate_cost("", 0, 0) is None
+
+    def test_zero_tokens_returns_zero_cost(self):
+        result = llm_backend._estimate_cost("gpt-4o-mini", 0, 0)
+        assert result == 0.0
+
+    def test_cost_estimate_in_evidence_openai(self, monkeypatch, tmp_path):
+        """check() emits cost_estimate_usd in llm_judgment evidence (OpenAI)."""
+        _patch_env(
+            monkeypatch,
+            {"GATE_KEEPER_LLM_PROVIDER": "openai", "OPENAI_API_KEY": "sk-test"},
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(
+                _VALID_PASS_JSON,
+                {"latency_ms": 100, "tokens_in": 1000, "tokens_out": 200},
+            ),
+        )
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        data = diag.evidence[0].data
+        assert "cost_estimate_usd" in data
+        expected = (1000 * 0.15 + 200 * 0.60) / 1_000_000
+        assert abs(data["cost_estimate_usd"] - expected) < 1e-12
+
+    def test_cost_estimate_in_evidence_anthropic(self, monkeypatch, tmp_path):
+        """check() emits cost_estimate_usd in llm_judgment evidence (Anthropic)."""
+        _patch_env(
+            monkeypatch,
+            {"GATE_KEEPER_LLM_PROVIDER": "anthropic", "ANTHROPIC_API_KEY": "sk-ant-test"},
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_anthropic",
+            lambda *_a, **_k: _stub_response(
+                _VALID_PASS_JSON,
+                {"latency_ms": 150, "tokens_in": 500, "tokens_out": 100},
+            ),
+        )
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        data = diag.evidence[0].data
+        assert "cost_estimate_usd" in data
+        expected = (500 * 0.80 + 100 * 4.00) / 1_000_000
+        assert abs(data["cost_estimate_usd"] - expected) < 1e-12


### PR DESCRIPTION
## Summary

- Add `_MODEL_PRICING` static dict (snapshot 2026-05-08) with `gpt-4o-mini` and `claude-haiku-4-5` pricing.
- Add `_estimate_cost(model, tokens_in, tokens_out) -> float | None` — returns `None` for unknown models (fail-closed).
- Emit `cost_estimate_usd` into `llm_judgment` evidence dict in `check()` for every successful provider call.
- Update `docs/llm-rubric.md` output shape section and add per-model pricing table.
- Add `TestEstimateCost` class (7 tests) to `tests/test_llm_rubric_backend.py`.

Closes #133

## Validation

```
uv run pytest tests/test_llm_rubric_backend.py::TestEstimateCost -v
# 7 passed in 0.14s

uvx ruff check .
# All checks passed!

uvx pyright
# 13 errors (all pre-existing pytest import resolution — same count as main)

npx --no textlint docs/llm-rubric.md
# clean
```

## Acceptance checklist

- [x] `_estimate_cost` works for `claude-haiku-4-5` and `gpt-4o-mini`
- [x] Unknown model returns `None`, evidence carries `cost_estimate_usd: null`
- [x] Test coverage: known tokens → known cost, unknown model → None, evidence emitted from `check()`
- [x] `docs/llm-rubric.md` updated with `cost_estimate_usd` field and pricing snapshot table