### PR TITLE
feat(ci): dogfooding advisory PR comment via llm-rubric (#131)

### DIFF
--- a/.github/workflows/dogfooding.yml
+++ b/.github/workflows/dogfooding.yml
@@ -1,0 +1,148 @@
+# dogfooding — semantic self-gating advisory comment on PRs (#131)
+#
+# Trigger: `pull_request`. The job runs `gate-keeper validate` with the
+# `llm-rubric` backend against `docs/dogfooding-rules.md` and posts the JSON
+# diagnostic as a markdown table comment on the PR.
+#
+# Status: **advisory only**. Per `docs/dogfooding.md`, semantic self-gating
+# rules do not block merge. The job is wired so that any provider error,
+# secret-absent path, or formatter failure exits 0 (`continue-on-error` on
+# the validate/format/post steps); the workflow conclusion never gates merge.
+#
+# Secret handling (no log leakage):
+#   - Provider credentials live behind the `OPENAI_API_KEY` repo secret.
+#   - Job-level `if: ${{ secrets.OPENAI_API_KEY != '' }}` guards the entire
+#     job: when the secret is unregistered the job is skipped silently
+#     (no fail, no advisory comment).
+#   - Credentials are projected into the host-side dotenv path the
+#     llm-rubric backend already loads
+#     (`/home/vscode/.config/hermes-projects/gate-keeper.env`); see
+#     `docs/llm-rubric.md` "CI exception" sub-section.
+#   - The provision step uses `printf` redirected to the dotenv file. It
+#     does NOT use `echo $VAR` or `set -x`. The dotenv file is written
+#     under `umask 077` and never uploaded as a workflow artifact. The
+#     directory mode is `700`.
+#
+# Out of scope (per #131):
+#   - Sticky / edited comments — each run posts a fresh comment.
+#   - Promotion to required check — promotion path is owned by #79.
+
+name: dogfooding
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  advisory-comment:
+    # Skip silently when the provider secret is not registered. This keeps
+    # the workflow no-op on forks and pre-secret states without surfacing
+    # a red check.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check provider secret
+        id: secret_guard
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -n "${OPENAI_API_KEY:-}" ]; then
+            echo "secret_present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "secret_present=false" >> "$GITHUB_OUTPUT"
+            echo "OPENAI_API_KEY secret is not set; skipping advisory comment."
+          fi
+
+      - uses: astral-sh/setup-uv@v5
+        if: steps.secret_guard.outputs.secret_present == 'true'
+        with:
+          version: "0.11.x"
+          python-version: "3.11"
+
+      - name: Install dependencies
+        if: steps.secret_guard.outputs.secret_present == 'true'
+        run: uv sync
+
+      - name: Provision provider credentials
+        if: steps.secret_guard.outputs.secret_present == 'true'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          # NB: never `set -x` here — it would echo the API key.
+          # The llm-rubric backend reads from this absolute path
+          # (DOTENV_PATH in src/gate_keeper/backends/llm_rubric.py).
+          set +x
+          umask 077
+          sudo install -d -m 700 -o "$USER" -g "$USER" /home/vscode
+          sudo install -d -m 700 -o "$USER" -g "$USER" /home/vscode/.config
+          sudo install -d -m 700 -o "$USER" -g "$USER" /home/vscode/.config/hermes-projects
+          # printf + redirect — does not echo via `echo $VAR` and is not
+          # affected by `-x` since we explicitly disabled it. The dotenv
+          # file inherits the 077 umask (mode 600).
+          printf 'GATE_KEEPER_LLM_PROVIDER=openai\nOPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" \
+            > /home/vscode/.config/hermes-projects/gate-keeper.env
+          chmod 600 /home/vscode/.config/hermes-projects/gate-keeper.env
+
+      - name: Run gate-keeper validate (advisory)
+        if: steps.secret_guard.outputs.secret_present == 'true'
+        id: validate
+        continue-on-error: true
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set +x
+          # `--format json` so the post step can transform reliably; failures
+          # are tolerated by continue-on-error and surface as a "no advisory"
+          # log in the post step.
+          # `--target $PR_URL` matches the PR URL contract; if backend can't
+          # fetch the PR it falls back to deterministic-no-evidence path.
+          uv run gate-keeper validate docs/dogfooding-rules.md \
+            --target "$PR_URL" \
+            --backend llm-rubric \
+            --format json \
+            > /tmp/dogfood.json 2> /tmp/dogfood.err || echo "validate exited non-zero (advisory; see stderr below)"
+          echo "::group::stderr"
+          cat /tmp/dogfood.err || true
+          echo "::endgroup::"
+
+      - name: Format advisory comment
+        if: steps.secret_guard.outputs.secret_present == 'true'
+        id: format
+        continue-on-error: true
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set +x
+          python3 .github/workflows/format_dogfooding_comment.py \
+            /tmp/dogfood.json \
+            > /tmp/dogfood-comment.md
+          echo "::group::comment-preview"
+          cat /tmp/dogfood-comment.md
+          echo "::endgroup::"
+
+      - name: Post advisory comment
+        if: steps.secret_guard.outputs.secret_present == 'true' && steps.format.outcome == 'success'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set +x
+          gh pr comment "$PR_NUMBER" --body-file /tmp/dogfood-comment.md
+
+      - name: Scrub provisioned credentials
+        if: always() && steps.secret_guard.outputs.secret_present == 'true'
+        run: |
+          set +x
+          # Best-effort cleanup. The runner is ephemeral, but explicit
+          # removal documents intent.
+          rm -f /home/vscode/.config/hermes-projects/gate-keeper.env || true

--- a/.github/workflows/format_dogfooding_comment.py
+++ b/.github/workflows/format_dogfooding_comment.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Format a `gate-keeper validate --format json` report into a PR comment.
+
+Used by `.github/workflows/dogfooding.yml`. Kept as a standalone script
+(not under ``src/``) because it is workflow-glue, not part of the package
+public surface — the formatting contract is allowed to change with the
+workflow without bumping the library version.
+
+The script accepts a single positional arg (path to the JSON file produced
+by ``gate-keeper validate ... --format json``) and writes a Markdown
+comment to stdout. It prints a fallback "no advisory" body when the JSON
+cannot be parsed; the workflow tolerates that path with
+``continue-on-error`` on the validate step.
+
+Output shape (matches issue #131 acceptance criteria):
+
+  ## gate-keeper dogfooding (advisory)
+
+  | rule | status | judgment | primary_reason |
+  | --- | --- | --- | --- |
+  | <title-or-id> | PASS | pass | ... |
+
+  Tokens: in=N out=N, latency: N ms, model: <model>, prompt_version: vX
+
+  <small>This comment is advisory and does not gate merge. See
+  docs/dogfooding.md.</small>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+_FALLBACK_HEADER = "## gate-keeper dogfooding (advisory)"
+_FALLBACK_BODY = (
+    "Advisory evaluation could not be produced for this PR.\n\n"
+    "The validate step exited without a usable JSON report. This does not "
+    "block merge. See the workflow run logs for details."
+)
+_TRAILER = (
+    "<sub>This comment is advisory and does not gate merge. "
+    "See [`docs/dogfooding.md`](docs/dogfooding.md) for the promotion path.</sub>"
+)
+
+
+def _emit_fallback() -> None:
+    print(_FALLBACK_HEADER)
+    print()
+    print(_FALLBACK_BODY)
+    print()
+    print(_TRAILER)
+
+
+def _safe_truncate(text: str, limit: int = 200) -> str:
+    text = text.replace("|", "\\|").replace("\n", " ").strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "..."
+
+
+def _rule_label(diag: dict[str, Any]) -> str:
+    rule_id = diag.get("rule_id") or "<unknown>"
+    return _safe_truncate(str(rule_id), 80)
+
+
+def _judgment_for(diag: dict[str, Any]) -> str:
+    """Pull the LLM judgment string from `evidence[*].data.judgment` if present."""
+    for ev in diag.get("evidence", []) or []:
+        if not isinstance(ev, dict):
+            continue
+        if ev.get("kind") != "llm_judgment":
+            continue
+        data = ev.get("data") or {}
+        if isinstance(data, dict) and data.get("judgment"):
+            return str(data["judgment"])
+    return "-"
+
+
+def _primary_reason(diag: dict[str, Any]) -> str:
+    """Return the diagnostic's `message`, falling back to the LLM primary_reason."""
+    msg = diag.get("message")
+    if isinstance(msg, str) and msg.strip():
+        return _safe_truncate(msg, 200)
+    for ev in diag.get("evidence", []) or []:
+        if not isinstance(ev, dict):
+            continue
+        data = ev.get("data") or {}
+        if isinstance(data, dict) and data.get("primary_reason"):
+            return _safe_truncate(str(data["primary_reason"]), 200)
+    return "-"
+
+
+def _telemetry_summary(diagnostics: list[dict[str, Any]]) -> str | None:
+    """Sum tokens / latency across `llm_judgment` evidence; return one summary line.
+
+    Returns None when no telemetry is available (e.g. all rules unavailable).
+    """
+    tokens_in = 0
+    tokens_out = 0
+    latency_ms = 0
+    models: list[str] = []
+    prompt_versions: list[str] = []
+    saw_telemetry = False
+
+    for diag in diagnostics:
+        for ev in diag.get("evidence", []) or []:
+            if not isinstance(ev, dict) or ev.get("kind") != "llm_judgment":
+                continue
+            data = ev.get("data") or {}
+            if not isinstance(data, dict):
+                continue
+            ti = data.get("tokens_in")
+            to = data.get("tokens_out")
+            lt = data.get("latency_ms")
+            if isinstance(ti, int):
+                tokens_in += ti
+                saw_telemetry = True
+            if isinstance(to, int):
+                tokens_out += to
+                saw_telemetry = True
+            if isinstance(lt, int):
+                latency_ms += lt
+                saw_telemetry = True
+            mdl = data.get("model")
+            if isinstance(mdl, str) and mdl not in models:
+                models.append(mdl)
+            pv = data.get("prompt_version")
+            if isinstance(pv, str) and pv not in prompt_versions:
+                prompt_versions.append(pv)
+
+    if not saw_telemetry:
+        return None
+
+    model_str = ", ".join(models) if models else "-"
+    prompt_str = ", ".join(prompt_versions) if prompt_versions else "-"
+    return (
+        f"Tokens: in={tokens_in} out={tokens_out}, "
+        f"latency: {latency_ms} ms, "
+        f"model: {model_str}, "
+        f"prompt_version: {prompt_str}"
+    )
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {argv[0]} <path-to-json>", file=sys.stderr)
+        _emit_fallback()
+        return 0
+
+    path = argv[1]
+    try:
+        with open(path, encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"warning: could not load {path!r}: {exc}", file=sys.stderr)
+        _emit_fallback()
+        return 0
+
+    diagnostics = payload.get("diagnostics") if isinstance(payload, dict) else None
+    if not isinstance(diagnostics, list) or not diagnostics:
+        _emit_fallback()
+        return 0
+
+    print(_FALLBACK_HEADER)
+    print()
+    print("| rule | status | judgment | primary_reason |")
+    print("| --- | --- | --- | --- |")
+    for diag in diagnostics:
+        if not isinstance(diag, dict):
+            continue
+        label = _rule_label(diag)
+        status = str(diag.get("status", "-")).upper()
+        judgment = _judgment_for(diag)
+        reason = _primary_reason(diag)
+        print(f"| {label} | {status} | {judgment} | {reason} |")
+    print()
+
+    telemetry = _telemetry_summary(diagnostics)
+    if telemetry:
+        print(telemetry)
+        print()
+
+    print(_TRAILER)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -84,6 +84,53 @@ If `GATE_KEEPER_LLM_PROVIDER` is missing, set to a value other than
 `anthropic` or `openai`, or the corresponding API key is absent, behavior
 falls back to the unconfigured `unavailable` diagnostic above.
 
+### CI exception: GitHub Actions secret projection
+
+The host-side dotenv route is the only credential path the backend reads
+from. CI environments do not have a developer-managed home directory, so
+GitHub Actions workflows project the repository secret into the same
+absolute dotenv path before invoking `gate-keeper`.
+
+The advisory dogfooding workflow (`.github/workflows/dogfooding.yml`,
+introduced in #131) demonstrates the pattern:
+
+```yaml
+- name: Provision provider credentials
+  if: steps.secret_guard.outputs.secret_present == 'true'
+  env:
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  run: |
+    set +x
+    umask 077
+    sudo install -d -m 700 -o "$USER" -g "$USER" /home/vscode
+    sudo install -d -m 700 -o "$USER" -g "$USER" /home/vscode/.config
+    sudo install -d -m 700 -o "$USER" -g "$USER" /home/vscode/.config/hermes-projects
+    printf 'GATE_KEEPER_LLM_PROVIDER=openai\nOPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" \
+      > /home/vscode/.config/hermes-projects/gate-keeper.env
+    chmod 600 /home/vscode/.config/hermes-projects/gate-keeper.env
+```
+
+Constraints to preserve when adopting this pattern in another workflow:
+
+- **Job-scoped secret guard.** Reference `secrets.OPENAI_API_KEY` from a
+  preceding step that writes a boolean output, then gate downstream steps
+  with `if: steps.<id>.outputs.secret_present == 'true'`. This keeps the
+  workflow silent on forks and pre-secret states (no red X on PRs from
+  contributors who do not own the secret).
+- **No `set -x` and no `echo $VAR`.** Both leak secret material into the
+  run log. Use `printf` with redirection only. Disable trace mode
+  defensively (`set +x`) inside the credential step.
+- **Mode 700 on the directory, mode 600 on the file.** `umask 077` plus
+  `chmod 600` on the dotenv satisfy both, even when run as the runner
+  user.
+- **No artifact upload of `$HOME` or `/home/vscode`.** Treat the dotenv
+  path as untrusted output; never include it in `actions/upload-artifact`
+  patterns.
+- **Scrub on completion.** Add an `if: always()` cleanup step that
+  removes the projected dotenv. The runner is ephemeral, but the
+  scrubbing step documents intent and survives reuse if anyone refactors
+  the workflow to share runners.
+
 ## Rubric input/output shape
 
 `_build_rubric_input()` in `src/gate_keeper/backends/llm_rubric.py` defines the


### PR DESCRIPTION
## Summary

Add `.github/workflows/dogfooding.yml` (advisory) plus a small
`format_dogfooding_comment.py` helper. On every PR (same-repo head branches
only), if `OPENAI_API_KEY` is registered, the job runs `gate-keeper validate
docs/dogfooding-rules.md --target <PR_URL> --backend llm-rubric --format json`
and posts the output as a Markdown table comment via `gh pr comment`.
Forks, pre-secret states, and any provider error skip silently / surface
as a no-op log entry — the workflow conclusion never gates merge.

`docs/llm-rubric.md` gains a "CI exception: GitHub Actions secret
projection" sub-section documenting the dotenv projection pattern and
the secret-handling constraints (no `set -x`, no `echo $VAR`, mode
700/600, no `$HOME` artifact upload, scrub on completion).

Closes #131

## Acceptance

- [x] `.github/workflows/dogfooding.yml` lands and triggers on `pull_request`.
- [x] Secret guard: job runs only when `OPENAI_API_KEY` is non-empty;
      forks (`head.repo.full_name != github.repository`) skip the entire
      job. Implemented as `steps.secret_guard.outputs.secret_present` so
      the workflow stays green on PRs that lack the secret.
- [x] Credential injection writes to the absolute path the llm-rubric
      backend reads from (`/home/vscode/.config/hermes-projects/gate-keeper.env`).
      Uses `printf` + redirect (no `echo $VAR`, no `set -x`); umask 077 +
      chmod 600 on the file, mode 700 on the directories.
- [x] Comment post uses `gh pr comment $PR_NUMBER --body-file ...`
      (`GH_TOKEN` from `secrets.GITHUB_TOKEN`).
- [x] Failure mode advisory: `continue-on-error: true` on validate /
      format / post; the job conclusion never gates merge.
- [x] `docs/llm-rubric.md` "CI exception: GitHub Actions secret projection"
      sub-section added.

Note: per scope, "workflow runs on a real PR with advisory comment posted"
is observed on this PR's own run after merge; the Acceptance items above
reflect the file/docs landing only. Live observation will surface in the
next PR's run logs.

## Test plan

- [x] YAML parses (`uv run python -c 'import yaml; yaml.safe_load(...)'`).
- [x] Formatter smoke-tested with synthetic JSON (pass + fail rows,
      telemetry summary line) and fallback paths (missing file,
      malformed JSON).
- [x] `uvx ruff check .` passes.
- [x] `uvx ruff format --check` passes (auto-fix applied to formatter).
- [ ] `uv run pytest`: 12 pre-existing failures in `test_llm_rubric_backend.py` /
      `test_validator.py` / `test_cli_validate.py` confirmed identical on
      `origin/main` (env has a real provider dotenv from #129 →
      `_load_env_file` returns configured creds, so the tests that assume
      "no provider configured" expect `UNAVAILABLE` but observe `FAIL`).
      Out of scope for #131 — those tests need monkeypatching, not a
      workflow change.
- [x] `uvx pyright` reports only pre-existing missing-pytest-stubs.
- [x] `npx --no textlint docs/llm-rubric.md` clean.
- [ ] First live execution observable on the next PR after merge.

## Files

- `.github/workflows/dogfooding.yml` (new)
- `.github/workflows/format_dogfooding_comment.py` (new helper, workflow-glue)
- `docs/llm-rubric.md` (CI exception sub-section under "Host-side credential setup")