### PR TITLE
feat(cli): gate-keeper bench fixture-corpus harness

### DIFF
--- a/src/gate_keeper/bench.py
+++ b/src/gate_keeper/bench.py
@@ -322,7 +322,10 @@ def _evaluate_entry(entry: BenchEntry, targets_root: Path, n: int) -> PerRuleRes
 
     pass_count = 0
     fail_count = 0
-    primary_reason: str | None = None
+    # Collect per-run (judgment, primary_reason) so we can pick a rationale
+    # that matches the majority judgment after aggregation (P1: avoid reporting
+    # a PASS rationale when the majority outcome is FAIL, or vice-versa).
+    per_run_reasons: list[tuple[str, str | None]] = []
     failure_mode: str | None = None
     tokens_in_total = 0
     tokens_out_total = 0
@@ -335,6 +338,7 @@ def _evaluate_entry(entry: BenchEntry, targets_root: Path, n: int) -> PerRuleRes
 
         # Telemetry is recorded on llm_judgment evidence; provider_error /
         # provider_unconfigured carry no telemetry.
+        run_reason: str | None = None
         for ev in diag.evidence:
             if ev.kind == "llm_judgment":
                 tokens_in_total += int(ev.data.get("tokens_in", 0) or 0)
@@ -344,13 +348,15 @@ def _evaluate_entry(entry: BenchEntry, targets_root: Path, n: int) -> PerRuleRes
                     model = ev.data.get("model")
                 if prompt_version is None:
                     prompt_version = ev.data.get("prompt_version")
-                if primary_reason is None:
-                    primary_reason = ev.data.get("primary_reason")
+                if run_reason is None:
+                    run_reason = ev.data.get("primary_reason")
 
         if diag.status is Status.PASS:
             pass_count += 1
+            per_run_reasons.append(("pass", run_reason))
         elif diag.status is Status.FAIL:
             fail_count += 1
+            per_run_reasons.append(("fail", run_reason))
         else:
             # UNAVAILABLE / UNSUPPORTED / ERROR — fail-closed, report immediately.
             for ev in diag.evidence:
@@ -369,7 +375,7 @@ def _evaluate_entry(entry: BenchEntry, targets_root: Path, n: int) -> PerRuleRes
                 actual=actual,
                 status="FAIL",  # mismatch with expected pass/fail
                 reproducibility=0.0,
-                primary_reason=primary_reason or diag.message,
+                primary_reason=run_reason or diag.message,
                 failure_mode=failure_mode or actual,
                 tokens_in=tokens_in_total,
                 tokens_out=tokens_out_total,
@@ -384,6 +390,14 @@ def _evaluate_entry(entry: BenchEntry, targets_root: Path, n: int) -> PerRuleRes
     majority_count = pass_count if majority_is_pass else fail_count
     reproducibility = majority_count / total if total > 0 else 0.0
     correct = actual == entry.expected_judgment
+
+    # Pick the primary_reason from the first run that matches the majority
+    # judgment, so the rationale is internally consistent with the reported
+    # outcome (P1: avoids a PASS rationale when majority outcome is FAIL).
+    primary_reason: str | None = next(
+        (reason for judgment, reason in per_run_reasons if judgment == actual),
+        None,
+    )
 
     return PerRuleResult(
         id=entry.id,

--- a/src/gate_keeper/bench.py
+++ b/src/gate_keeper/bench.py
@@ -1,0 +1,611 @@
+"""Fixture-corpus benchmark harness for the LLM-rubric backend (#130).
+
+Loads benchmark entries from a directory of JSON files (schema documented in
+``tests/fixtures/semantic/README.md``) and evaluates each entry against the
+``llm-rubric`` backend, producing aggregate accuracy / reproducibility / token
+metrics plus a per-entry breakdown.
+
+The CLI surface is wired in ``cli.py`` via ``gate-keeper bench``; this module
+contains the loader + evaluator + result aggregator so the logic is testable
+in isolation and reusable from future tooling.
+
+Entry shape (subset used here)::
+
+    {
+      "rule_text": "...",
+      "target": {"kind": "path"|"inline", "value": "..."},
+      "expected_judgment": "pass" | "fail",
+      "expected_rationale_keywords": ["..."],
+      "category": "clarity" | ...,
+      "intended_backend": "llm-rubric" | ...,
+      "notes": "..."
+    }
+
+When ``target.kind == "path"`` the value is resolved relative to a sibling
+``targets/`` directory (``<entries_dir>/../targets/``). Inline targets are
+passed through verbatim.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+from gate_keeper.backends import llm_rubric as _llm
+from gate_keeper.models import (
+    Backend,
+    Confidence,
+    Rule,
+    RuleKind,
+    Severity,
+    SourceLocation,
+    Status,
+)
+
+# ---------------------------------------------------------------------------
+# Entry loader
+# ---------------------------------------------------------------------------
+
+
+_REQUIRED_FIELDS = frozenset(
+    {
+        "rule_text",
+        "target",
+        "expected_judgment",
+        "expected_rationale_keywords",
+        "category",
+        "intended_backend",
+    }
+)
+_OPTIONAL_FIELDS = frozenset({"notes"})
+_TARGET_FIELDS = frozenset({"kind", "value"})
+_VALID_KINDS = ("path", "inline")
+_VALID_JUDGMENTS = ("pass", "fail")
+
+
+@dataclass(frozen=True)
+class BenchEntry:
+    """A single benchmark fixture entry, loaded from JSON."""
+
+    id: str
+    rule_text: str
+    target_kind: str
+    target_value: str
+    expected_judgment: str
+    expected_rationale_keywords: tuple[str, ...]
+    category: str
+    intended_backend: str
+    notes: str | None
+    source_path: Path
+
+    def resolve_target(self, targets_root: Path) -> str:
+        """Return the literal text the rule should be evaluated against."""
+        if self.target_kind == "inline":
+            return self.target_value
+        path = targets_root / self.target_value
+        if not path.is_file():
+            raise FileNotFoundError(
+                f"target path does not resolve to a file: {path} (referenced from {self.source_path.name})"
+            )
+        return path.read_text(encoding="utf-8")
+
+
+def _expect_str(value: Any, ctx: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{ctx}: expected str, got {type(value).__name__}")
+    return value
+
+
+def _expect_list_of_str(value: Any, ctx: str) -> list[str]:
+    if not isinstance(value, list):
+        raise ValueError(f"{ctx}: expected list, got {type(value).__name__}")
+    out: list[str] = []
+    for i, item in enumerate(value):
+        out.append(_expect_str(item, f"{ctx}[{i}]"))
+    return out
+
+
+def parse_entry(data: Any, *, source_path: Path) -> BenchEntry:
+    """Parse a single fixture entry; raise ``ValueError`` on schema violation."""
+    if not isinstance(data, dict):
+        raise ValueError(f"BenchEntry({source_path.name}): expected mapping, got {type(data).__name__}")
+    keys = set(data)
+    missing = _REQUIRED_FIELDS - keys
+    if missing:
+        raise ValueError(f"BenchEntry({source_path.name}): missing required fields: {sorted(missing)}")
+    unknown = keys - _REQUIRED_FIELDS - _OPTIONAL_FIELDS
+    if unknown:
+        raise ValueError(f"BenchEntry({source_path.name}): unknown fields: {sorted(unknown)}")
+
+    target = data["target"]
+    if not isinstance(target, dict):
+        raise ValueError(
+            f"BenchEntry({source_path.name}).target: expected mapping, got {type(target).__name__}"
+        )
+    target_keys = set(target)
+    missing_target = _TARGET_FIELDS - target_keys
+    if missing_target:
+        raise ValueError(f"BenchEntry({source_path.name}).target: missing fields: {sorted(missing_target)}")
+    unknown_target = target_keys - _TARGET_FIELDS
+    if unknown_target:
+        raise ValueError(f"BenchEntry({source_path.name}).target: unknown fields: {sorted(unknown_target)}")
+
+    target_kind = _expect_str(target["kind"], "target.kind")
+    if target_kind not in _VALID_KINDS:
+        raise ValueError(
+            f"BenchEntry({source_path.name}).target.kind: expected one of {list(_VALID_KINDS)}, "
+            f"got {target_kind!r}"
+        )
+    target_value = _expect_str(target["value"], "target.value")
+
+    expected_judgment = _expect_str(data["expected_judgment"], "expected_judgment")
+    if expected_judgment not in _VALID_JUDGMENTS:
+        raise ValueError(
+            f"BenchEntry({source_path.name}).expected_judgment: expected one of {list(_VALID_JUDGMENTS)}, "
+            f"got {expected_judgment!r}"
+        )
+
+    notes_value = data.get("notes")
+    if notes_value is not None and not isinstance(notes_value, str):
+        raise ValueError(
+            f"BenchEntry({source_path.name}).notes: expected str or absent, got {type(notes_value).__name__}"
+        )
+
+    return BenchEntry(
+        id=source_path.stem,
+        rule_text=_expect_str(data["rule_text"], "rule_text"),
+        target_kind=target_kind,
+        target_value=target_value,
+        expected_judgment=expected_judgment,
+        expected_rationale_keywords=tuple(
+            _expect_list_of_str(data["expected_rationale_keywords"], "expected_rationale_keywords")
+        ),
+        category=_expect_str(data["category"], "category"),
+        intended_backend=_expect_str(data["intended_backend"], "intended_backend"),
+        notes=notes_value,
+        source_path=source_path,
+    )
+
+
+def load_entry(path: Path) -> BenchEntry:
+    """Load and validate a single entry JSON file."""
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    return parse_entry(data, source_path=path)
+
+
+def iter_entries(entries_dir: Path) -> Iterable[BenchEntry]:
+    """Yield all entries under *entries_dir* in stable filename order."""
+    for path in sorted(entries_dir.glob("*.json")):
+        yield load_entry(path)
+
+
+# ---------------------------------------------------------------------------
+# Rule synthesis (entry → IR Rule)
+# ---------------------------------------------------------------------------
+
+
+def _entry_to_rule(entry: BenchEntry) -> Rule:
+    """Synthesise a ``Rule`` IR object from a benchmark entry.
+
+    Bench entries are decoupled from on-disk Markdown documents: the entry's
+    ``rule_text`` is the rule, and the rest of the IR fields take fixed defaults
+    (kind ``SEMANTIC_RUBRIC``, backend hint ``LLM_RUBRIC``, severity
+    ``WARNING``). The ``source`` path is the entry filename so diagnostic
+    output remains traceable to a fixture file.
+    """
+    return Rule(
+        id=entry.id,
+        title=entry.rule_text[:80],
+        source=SourceLocation(path=entry.source_path.name, line=1),
+        text=entry.rule_text,
+        kind=RuleKind.SEMANTIC_RUBRIC,
+        severity=Severity.WARNING,
+        backend_hint=Backend.LLM_RUBRIC,
+        confidence=Confidence.LOW,
+        params={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PerRuleResult:
+    """Result for a single bench entry after N evaluations."""
+
+    id: str
+    category: str
+    intended_backend: str
+    expected: str
+    actual: str  # "pass" | "fail" | "unavailable" | "error"
+    status: str  # "PASS" | "FAIL" — does *actual* match *expected*?
+    reproducibility: float
+    primary_reason: str | None
+    failure_mode: str | None
+    tokens_in: int
+    tokens_out: int
+    latency_ms: int
+    model: str | None
+    prompt_version: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "category": self.category,
+            "intended_backend": self.intended_backend,
+            "expected": self.expected,
+            "actual": self.actual,
+            "status": self.status,
+            "reproducibility": self.reproducibility,
+            "primary_reason": self.primary_reason,
+            "failure_mode": self.failure_mode,
+            "tokens_in": self.tokens_in,
+            "tokens_out": self.tokens_out,
+            "latency_ms": self.latency_ms,
+            "model": self.model,
+            "prompt_version": self.prompt_version,
+        }
+
+
+@dataclass
+class BenchSummary:
+    """Aggregate counters across all bench entries."""
+
+    entries: int
+    correct: int
+    accuracy: float
+    reproducibility_avg: float
+    tokens_in: int
+    tokens_out: int
+    latency_ms: int
+    model: str | None
+    prompt_version: str | None
+    reproducibility_n: int
+    unavailable: int
+    errors: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "entries": self.entries,
+            "correct": self.correct,
+            "accuracy": self.accuracy,
+            "reproducibility_avg": self.reproducibility_avg,
+            "tokens_in": self.tokens_in,
+            "tokens_out": self.tokens_out,
+            "latency_ms": self.latency_ms,
+            "model": self.model,
+            "prompt_version": self.prompt_version,
+            "reproducibility_n": self.reproducibility_n,
+            "unavailable": self.unavailable,
+            "errors": self.errors,
+        }
+
+
+@dataclass
+class BenchResult:
+    """Top-level bench output, JSON-serialisable."""
+
+    summary: BenchSummary
+    per_rule: list[PerRuleResult] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "summary": self.summary.to_dict(),
+            "per_rule": [p.to_dict() for p in self.per_rule],
+        }
+
+
+def _evaluate_entry(entry: BenchEntry, targets_root: Path, n: int) -> PerRuleResult:
+    """Evaluate a single entry ``n`` times, aggregating via majority vote.
+
+    Mirrors ``llm_rubric.run_n``'s aggregation semantics but inlines the loop so
+    we can keep raw per-run telemetry sums (the run_n diagnostic only carries
+    a single representative's telemetry, not the cumulative cost across runs).
+
+    Tie-break for the majority judgment is fail-closed (fail wins ties).
+    Non-pass/fail outcomes (UNAVAILABLE / ERROR) abort aggregation early — the
+    entry is reported with its actual status and reproducibility 0.0, so a
+    misconfigured provider does not silently inflate accuracy.
+    """
+    if n < 1:
+        raise ValueError(f"reproducibility n must be >= 1, got {n}")
+
+    rule = _entry_to_rule(entry)
+    target_text = entry.resolve_target(targets_root)
+
+    pass_count = 0
+    fail_count = 0
+    primary_reason: str | None = None
+    failure_mode: str | None = None
+    tokens_in_total = 0
+    tokens_out_total = 0
+    latency_ms_total = 0
+    model: str | None = None
+    prompt_version: str | None = None
+
+    for _ in range(n):
+        diag = _llm.check(rule, target_text)
+
+        # Telemetry is recorded on llm_judgment evidence; provider_error /
+        # provider_unconfigured carry no telemetry.
+        for ev in diag.evidence:
+            if ev.kind == "llm_judgment":
+                tokens_in_total += int(ev.data.get("tokens_in", 0) or 0)
+                tokens_out_total += int(ev.data.get("tokens_out", 0) or 0)
+                latency_ms_total += int(ev.data.get("latency_ms", 0) or 0)
+                if model is None:
+                    model = ev.data.get("model")
+                if prompt_version is None:
+                    prompt_version = ev.data.get("prompt_version")
+                if primary_reason is None:
+                    primary_reason = ev.data.get("primary_reason")
+
+        if diag.status is Status.PASS:
+            pass_count += 1
+        elif diag.status is Status.FAIL:
+            fail_count += 1
+        else:
+            # UNAVAILABLE / UNSUPPORTED / ERROR — fail-closed, report immediately.
+            for ev in diag.evidence:
+                if ev.kind == "provider_error":
+                    failure_mode = str(ev.data.get("failure_mode", "provider_error"))
+                    break
+                if ev.kind == "provider_unconfigured":
+                    failure_mode = "provider_unconfigured"
+                    break
+            actual = diag.status.value
+            return PerRuleResult(
+                id=entry.id,
+                category=entry.category,
+                intended_backend=entry.intended_backend,
+                expected=entry.expected_judgment,
+                actual=actual,
+                status="FAIL",  # mismatch with expected pass/fail
+                reproducibility=0.0,
+                primary_reason=primary_reason or diag.message,
+                failure_mode=failure_mode or actual,
+                tokens_in=tokens_in_total,
+                tokens_out=tokens_out_total,
+                latency_ms=latency_ms_total,
+                model=model,
+                prompt_version=prompt_version,
+            )
+
+    total = pass_count + fail_count
+    majority_is_pass = pass_count > fail_count
+    actual = "pass" if majority_is_pass else "fail"
+    majority_count = pass_count if majority_is_pass else fail_count
+    reproducibility = majority_count / total if total > 0 else 0.0
+    correct = actual == entry.expected_judgment
+
+    return PerRuleResult(
+        id=entry.id,
+        category=entry.category,
+        intended_backend=entry.intended_backend,
+        expected=entry.expected_judgment,
+        actual=actual,
+        status="PASS" if correct else "FAIL",
+        reproducibility=reproducibility,
+        primary_reason=primary_reason,
+        failure_mode=None if correct else f"llm_{actual}",
+        tokens_in=tokens_in_total,
+        tokens_out=tokens_out_total,
+        latency_ms=latency_ms_total,
+        model=model,
+        prompt_version=prompt_version,
+    )
+
+
+def run_bench(entries_dir: Path, *, reproducibility: int = 1) -> BenchResult:
+    """Evaluate every entry under *entries_dir* and aggregate the results.
+
+    Targets resolve relative to ``<entries_dir>/../targets/`` (matching the
+    repo layout under ``tests/fixtures/semantic/``).
+    """
+    if reproducibility < 1:
+        raise ValueError(f"reproducibility must be >= 1, got {reproducibility}")
+
+    targets_root = entries_dir.parent / "targets"
+
+    per_rule: list[PerRuleResult] = []
+    for entry in iter_entries(entries_dir):
+        per_rule.append(_evaluate_entry(entry, targets_root, reproducibility))
+
+    entries_count = len(per_rule)
+    correct = sum(1 for r in per_rule if r.status == "PASS")
+    accuracy = correct / entries_count if entries_count else 0.0
+    # Reproducibility average is taken across entries that produced a pass/fail
+    # outcome (i.e. exclude unavailable/error rows whose reproducibility is
+    # mechanically 0.0 and would skew the metric downward).
+    judged = [r for r in per_rule if r.actual in ("pass", "fail")]
+    if judged:
+        reproducibility_avg = sum(r.reproducibility for r in judged) / len(judged)
+    else:
+        reproducibility_avg = 0.0
+    tokens_in = sum(r.tokens_in for r in per_rule)
+    tokens_out = sum(r.tokens_out for r in per_rule)
+    latency_ms = sum(r.latency_ms for r in per_rule)
+
+    model = next((r.model for r in per_rule if r.model), None)
+    prompt_version = next((r.prompt_version for r in per_rule if r.prompt_version), None)
+
+    unavailable = sum(1 for r in per_rule if r.actual == "unavailable")
+    errors = sum(1 for r in per_rule if r.actual == "error")
+
+    summary = BenchSummary(
+        entries=entries_count,
+        correct=correct,
+        accuracy=accuracy,
+        reproducibility_avg=reproducibility_avg,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        latency_ms=latency_ms,
+        model=model,
+        prompt_version=prompt_version,
+        reproducibility_n=reproducibility,
+        unavailable=unavailable,
+        errors=errors,
+    )
+    return BenchResult(summary=summary, per_rule=per_rule)
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def render_text(result: BenchResult) -> str:
+    """Render a bench result as a compact human-readable summary."""
+    s = result.summary
+    lines: list[str] = []
+    lines.append(f"entries: {s.entries}")
+    accuracy_pct = s.accuracy * 100.0
+    lines.append(f"correct: {s.correct}    accuracy: {accuracy_pct:.1f}%")
+    lines.append(f"reproducibility (avg): {s.reproducibility_avg:.2f}  (n={s.reproducibility_n})")
+    if s.unavailable or s.errors:
+        lines.append(f"unavailable: {s.unavailable}    errors: {s.errors}")
+    if result.per_rule:
+        # Determine column width for entry ids
+        id_width = max(len(r.id) for r in result.per_rule)
+        lines.append("per-rule:")
+        for r in result.per_rule:
+            note = ""
+            if r.status == "FAIL":
+                if r.actual in ("pass", "fail"):
+                    note = f"  (expected {r.expected}, got {r.actual})"
+                else:
+                    note = f"  ({r.actual}: {r.failure_mode or '?'})"
+            lines.append(f"  {r.id:<{id_width}}  {r.status}  rep={r.reproducibility:.2f}{note}")
+    model_part = f" model={s.model}" if s.model else ""
+    prompt_part = f" prompt_version={s.prompt_version}" if s.prompt_version else ""
+    lines.append(
+        f"total: tokens_in={s.tokens_in} tokens_out={s.tokens_out} "
+        f"latency_ms={s.latency_ms}{model_part}{prompt_part}"
+    )
+    return "\n".join(lines)
+
+
+def render_json(result: BenchResult) -> str:
+    """Render a bench result as deterministic JSON."""
+    return json.dumps(result.to_dict(), sort_keys=True, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Baseline diff (#132 lands the actual baseline.json; this is the framework)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BaselineDelta:
+    """Diff between the current bench result and a stored baseline."""
+
+    accuracy_delta: float
+    reproducibility_avg_delta: float
+    regressed: list[str]  # entry ids that flipped PASS → FAIL
+    fixed: list[str]  # entry ids that flipped FAIL → PASS
+    new_entries: list[str]  # ids present in current but not baseline
+    removed_entries: list[str]  # ids present in baseline but not current
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+def diff_baseline(current: BenchResult, baseline_path: Path) -> BaselineDelta:
+    """Compute a delta between the current bench result and a stored baseline.
+
+    The baseline file is expected to be a JSON document with the same shape as
+    ``BenchResult.to_dict()`` (i.e. produced by ``gate-keeper bench --format
+    json``). #132 lands the canonical ``tests/fixtures/semantic/baseline.json``;
+    this function provides the diff plumbing now so the CLI surface is stable.
+    """
+    if not baseline_path.is_file():
+        raise FileNotFoundError(f"baseline not found: {baseline_path}")
+    with baseline_path.open("r", encoding="utf-8") as fh:
+        baseline_data = json.load(fh)
+    baseline_summary = baseline_data.get("summary", {})
+    baseline_rules = {r["id"]: r for r in baseline_data.get("per_rule", [])}
+    current_rules = {r.id: r for r in current.per_rule}
+
+    regressed: list[str] = []
+    fixed: list[str] = []
+    for entry_id, current_row in current_rules.items():
+        baseline_row = baseline_rules.get(entry_id)
+        if baseline_row is None:
+            continue
+        baseline_status = baseline_row.get("status")
+        if baseline_status == "PASS" and current_row.status == "FAIL":
+            regressed.append(entry_id)
+        elif baseline_status == "FAIL" and current_row.status == "PASS":
+            fixed.append(entry_id)
+
+    new_entries = sorted(set(current_rules) - set(baseline_rules))
+    removed_entries = sorted(set(baseline_rules) - set(current_rules))
+
+    accuracy_delta = current.summary.accuracy - float(baseline_summary.get("accuracy", 0.0))
+    reproducibility_avg_delta = current.summary.reproducibility_avg - float(
+        baseline_summary.get("reproducibility_avg", 0.0)
+    )
+
+    return BaselineDelta(
+        accuracy_delta=accuracy_delta,
+        reproducibility_avg_delta=reproducibility_avg_delta,
+        regressed=sorted(regressed),
+        fixed=sorted(fixed),
+        new_entries=new_entries,
+        removed_entries=removed_entries,
+    )
+
+
+def render_baseline_delta_text(delta: BaselineDelta) -> str:
+    """Human-readable summary of a baseline delta."""
+    lines: list[str] = ["baseline delta:"]
+    lines.append(f"  accuracy:          {delta.accuracy_delta:+.4f}")
+    lines.append(f"  reproducibility:   {delta.reproducibility_avg_delta:+.4f}")
+    if delta.regressed:
+        lines.append(f"  regressed ({len(delta.regressed)}): {', '.join(delta.regressed)}")
+    else:
+        lines.append("  regressed (0): -")
+    if delta.fixed:
+        lines.append(f"  fixed ({len(delta.fixed)}): {', '.join(delta.fixed)}")
+    else:
+        lines.append("  fixed (0): -")
+    if delta.new_entries:
+        lines.append(f"  new ({len(delta.new_entries)}): {', '.join(delta.new_entries)}")
+    if delta.removed_entries:
+        lines.append(f"  removed ({len(delta.removed_entries)}): {', '.join(delta.removed_entries)}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Walltime helper (kept here so the CLI command can attach it cheaply)
+# ---------------------------------------------------------------------------
+
+
+def wall_now() -> float:
+    """Indirection around ``time.perf_counter`` for testability."""
+    return time.perf_counter()
+
+
+__all__ = [
+    "BenchEntry",
+    "BenchResult",
+    "BenchSummary",
+    "PerRuleResult",
+    "BaselineDelta",
+    "diff_baseline",
+    "iter_entries",
+    "load_entry",
+    "parse_entry",
+    "render_baseline_delta_text",
+    "render_json",
+    "render_text",
+    "run_bench",
+    "wall_now",
+]

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -340,12 +340,8 @@ def _cmd_bench(args: argparse.Namespace) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return EXIT_USAGE
 
-    if args.format == "json":
-        print(_bench.render_json(result))
-    else:
-        print(_bench.render_text(result))
-
     # Baseline diff (advisory, does not change the exit code).
+    delta = None
     if args.baseline is not None:
         baseline_path = Path(args.baseline)
         try:
@@ -353,12 +349,19 @@ def _cmd_bench(args: argparse.Namespace) -> int:
         except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
             print(f"error: --baseline: {exc}", file=sys.stderr)
             return EXIT_USAGE
-        # Print delta after the main result so JSON consumers can split on the
-        # second top-level object if they wish; for text, the human reads them
-        # in order.
-        if args.format == "json":
-            print(json.dumps(delta.to_dict(), sort_keys=True, indent=2))
-        else:
+
+    if args.format == "json":
+        # Emit a single JSON object so machine consumers (json.loads, jq, etc.)
+        # can parse the output with one call regardless of whether --baseline is
+        # present.  The baseline delta is embedded under "baseline_delta" when
+        # requested; the key is absent otherwise.
+        payload = result.to_dict()
+        if delta is not None:
+            payload["baseline_delta"] = delta.to_dict()
+        print(json.dumps(payload, sort_keys=True, indent=2))
+    else:
+        print(_bench.render_text(result))
+        if delta is not None:
             print(_bench.render_baseline_delta_text(delta))
 
     return EXIT_OK

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -86,6 +86,39 @@ def build_parser() -> argparse.ArgumentParser:
         help="report LLM-rubric provider credential state (length-only, never the key)",
     )
 
+    bench_parser = subparsers.add_parser(
+        "bench",
+        help="evaluate a fixture-corpus benchmark against the LLM-rubric backend",
+    )
+    bench_parser.add_argument(
+        "entries_dir",
+        help="directory of JSON benchmark entries (e.g. tests/fixtures/semantic/entries/)",
+    )
+    bench_parser.add_argument(
+        "--reproducibility",
+        type=int,
+        default=1,
+        metavar="N",
+        help=(
+            "evaluate each entry N times and aggregate via majority vote (default: 1; ties break toward fail)"
+        ),
+    )
+    bench_parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="output format (default: text)",
+    )
+    bench_parser.add_argument(
+        "--baseline",
+        default=None,
+        metavar="PATH",
+        help=(
+            "compare the current run against a baseline JSON file "
+            "(produced by `bench --format json`); prints regressions/fixes"
+        ),
+    )
+
     return parser
 
 
@@ -262,6 +295,75 @@ def _cmd_diagnose(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def _cmd_bench(args: argparse.Namespace) -> int:
+    """Evaluate a fixture-corpus benchmark against the LLM-rubric backend.
+
+    Loads JSON entries under *entries_dir*, evaluates each one ``--reproducibility``
+    times via the LLM-rubric backend, and prints aggregate accuracy /
+    reproducibility / token metrics plus a per-entry breakdown. Output format is
+    ``text`` (default) or ``json``.
+
+    Exit codes
+    ----------
+    - ``0`` (EXIT_OK) — bench ran end-to-end (entries loaded, evaluator returned
+      a result). The bench surface is observational; a low accuracy is *not* a
+      CLI-level failure (this lets dogfooding pipelines record regressions
+      without turning the run red).
+    - ``2`` (EXIT_USAGE) — bad arguments or unreadable entries directory.
+
+    The ``--baseline`` option (when provided) compares the current run against a
+    stored baseline JSON document. The framework lands here in #130; the
+    canonical baseline file is added by the follow-up issue (#132).
+    """
+    from pathlib import Path
+
+    from gate_keeper import bench as _bench
+
+    entries_dir = Path(args.entries_dir)
+    if not entries_dir.is_dir():
+        print(
+            f"error: {args.entries_dir}: not a directory or does not exist",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+
+    if args.reproducibility < 1:
+        print(
+            f"error: --reproducibility must be >= 1, got {args.reproducibility}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+
+    try:
+        result = _bench.run_bench(entries_dir, reproducibility=args.reproducibility)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+
+    if args.format == "json":
+        print(_bench.render_json(result))
+    else:
+        print(_bench.render_text(result))
+
+    # Baseline diff (advisory, does not change the exit code).
+    if args.baseline is not None:
+        baseline_path = Path(args.baseline)
+        try:
+            delta = _bench.diff_baseline(result, baseline_path)
+        except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+            print(f"error: --baseline: {exc}", file=sys.stderr)
+            return EXIT_USAGE
+        # Print delta after the main result so JSON consumers can split on the
+        # second top-level object if they wish; for text, the human reads them
+        # in order.
+        if args.format == "json":
+            print(json.dumps(delta.to_dict(), sort_keys=True, indent=2))
+        else:
+            print(_bench.render_baseline_delta_text(delta))
+
+    return EXIT_OK
+
+
 def _register_default_adapters() -> None:
     """Register adapters that ship with gate-keeper.
 
@@ -299,6 +401,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "diagnose":
         return _cmd_diagnose(args)
+
+    if args.command == "bench":
+        return _cmd_bench(args)
 
     parser.error(f"{args.command!r} is planned but not implemented in the scaffold")
     return 2

--- a/tests/test_cli_bench.py
+++ b/tests/test_cli_bench.py
@@ -188,6 +188,47 @@ class TestRunBenchSmoke:
         assert result.per_rule[0].tokens_in == 50 * 3
         assert result.per_rule[0].tokens_out == 12 * 3
 
+    def test_run_bench_primary_reason_matches_majority(self, monkeypatch, tmp_path):
+        """primary_reason must come from a run that matches the majority outcome (P1).
+
+        Sequence: pass (first) → fail → fail.  Majority = fail (2/3).
+        primary_reason must NOT be the pass rationale from the first run.
+        """
+        _patch_env(monkeypatch, _OPENAI_ENV)
+        call_count = 0
+
+        def _stub_pass_then_fail(*_args, **_kwargs) -> tuple[str, dict[str, int]]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                body = json.dumps(
+                    {
+                        "judgment": "pass",
+                        "primary_reason": "PASS rationale — should not appear",
+                        "supporting_evidence_quotes": [],
+                        "suggested_action": None,
+                    }
+                )
+                return body, {"latency_ms": 10, "tokens_in": 50, "tokens_out": 12}
+            body = json.dumps(
+                {
+                    "judgment": "fail",
+                    "primary_reason": "FAIL rationale — majority side",
+                    "supporting_evidence_quotes": ["evidence of violation"],
+                    "suggested_action": "Fix it.",
+                }
+            )
+            return body, {"latency_ms": 20, "tokens_in": 60, "tokens_out": 18}
+
+        monkeypatch.setattr(_llm, "_call_openai", _stub_pass_then_fail)
+        entries = self._single_entry_dir(tmp_path)
+        result = _bench.run_bench(entries, reproducibility=3)
+        row = result.per_rule[0]
+        # Majority is fail (2/3 runs).
+        assert row.actual == "fail"
+        assert row.primary_reason == "FAIL rationale — majority side"
+        assert "PASS rationale" not in (row.primary_reason or "")
+
     def test_run_bench_unconfigured_marks_unavailable(self, monkeypatch, tmp_path):
         # No provider env → backend returns UNAVAILABLE.
         _patch_env(monkeypatch, {})
@@ -323,6 +364,62 @@ class TestCliBench:
         captured = capsys.readouterr()
         assert "baseline delta:" in captured.out
         assert "accuracy:" in captured.out
+
+    def test_bench_json_baseline_single_object(self, monkeypatch, tmp_path, capsys):
+        """--format json + --baseline must emit exactly one parseable JSON object (P2)."""
+        _patch_env(monkeypatch, _OPENAI_ENV)
+        monkeypatch.setattr(_llm, "_call_openai", _stub_openai_pass)
+        entries = self._smoke_entries(tmp_path)
+
+        baseline = tmp_path / "baseline.json"
+        baseline.write_text(
+            json.dumps(
+                {
+                    "summary": {
+                        "entries": 1,
+                        "correct": 1,
+                        "accuracy": 1.0,
+                        "reproducibility_avg": 1.0,
+                        "tokens_in": 50,
+                        "tokens_out": 12,
+                        "latency_ms": 10,
+                        "model": "gpt-4o-mini",
+                        "prompt_version": "v1",
+                        "reproducibility_n": 1,
+                        "unavailable": 0,
+                        "errors": 0,
+                    },
+                    "per_rule": [
+                        {
+                            "id": "cli-smoke",
+                            "category": "clarity",
+                            "intended_backend": "llm-rubric",
+                            "expected": "pass",
+                            "actual": "pass",
+                            "status": "PASS",
+                            "reproducibility": 1.0,
+                            "primary_reason": "ok",
+                            "failure_mode": None,
+                            "tokens_in": 50,
+                            "tokens_out": 12,
+                            "latency_ms": 10,
+                            "model": "gpt-4o-mini",
+                            "prompt_version": "v1",
+                        }
+                    ],
+                }
+            )
+        )
+
+        rc = main(["bench", str(entries), "--format", "json", "--baseline", str(baseline)])
+        assert rc == 0
+        captured = capsys.readouterr()
+        # Must parse as a single JSON value — json.loads raises if there are two top-level objects.
+        data = json.loads(captured.out)
+        assert "summary" in data
+        assert "per_rule" in data
+        assert "baseline_delta" in data
+        assert "accuracy_delta" in data["baseline_delta"]
 
     def test_bench_baseline_missing_exit_2(self, monkeypatch, tmp_path, capsys):
         _patch_env(monkeypatch, _OPENAI_ENV)

--- a/tests/test_cli_bench.py
+++ b/tests/test_cli_bench.py
@@ -1,0 +1,360 @@
+"""Smoke + unit tests for ``gate-keeper bench`` (#130).
+
+Real provider calls are out of scope for the test suite (they cost money and
+require a configured dotenv). The ``_call_openai`` helper is monkeypatched so
+the bench harness exercises the full eval → aggregate → render path against a
+deterministic stub, mirroring the pattern in
+``tests/test_llm_rubric_backend.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gate_keeper import bench as _bench
+from gate_keeper.backends import llm_rubric as _llm
+from gate_keeper.cli import main
+
+REPO_ROOT = Path(__file__).parent.parent
+ENTRIES_DIR = REPO_ROOT / "tests" / "fixtures" / "semantic" / "entries"
+TARGETS_DIR = REPO_ROOT / "tests" / "fixtures" / "semantic" / "targets"
+
+
+# ---------------------------------------------------------------------------
+# Stub helpers (mirror tests/test_llm_rubric_backend.py)
+# ---------------------------------------------------------------------------
+
+
+def _patch_env(monkeypatch, env: dict[str, str]) -> None:
+    monkeypatch.setattr(_llm, "_load_env_file", lambda *a, **k: env)
+
+
+def _stub_openai_pass(*_args, **_kwargs) -> tuple[str, dict[str, int]]:
+    """Mock OpenAI helper returning a structured `pass` judgment."""
+    body = json.dumps(
+        {
+            "judgment": "pass",
+            "primary_reason": "The artefact satisfies the rule.",
+            "supporting_evidence_quotes": [],
+            "suggested_action": None,
+        }
+    )
+    return body, {"latency_ms": 10, "tokens_in": 50, "tokens_out": 12}
+
+
+def _stub_openai_fail(*_args, **_kwargs) -> tuple[str, dict[str, int]]:
+    body = json.dumps(
+        {
+            "judgment": "fail",
+            "primary_reason": "The artefact violates the rule.",
+            "supporting_evidence_quotes": ["evidence quote"],
+            "suggested_action": "Fix it.",
+        }
+    )
+    return body, {"latency_ms": 20, "tokens_in": 60, "tokens_out": 18}
+
+
+_OPENAI_ENV = {
+    "GATE_KEEPER_LLM_PROVIDER": "openai",
+    "OPENAI_API_KEY": "sk-test-stub-not-real",
+}
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+class TestLoader:
+    def test_load_all_entries_round_trip(self):
+        entries = list(_bench.iter_entries(ENTRIES_DIR))
+        assert len(entries) > 0
+        ids = [e.id for e in entries]
+        # Stable ordering: filename-sorted.
+        assert ids == sorted(ids)
+
+    def test_resolve_inline_target(self):
+        entry = next(e for e in _bench.iter_entries(ENTRIES_DIR) if e.target_kind == "inline")
+        text = entry.resolve_target(TARGETS_DIR)
+        assert text == entry.target_value
+
+    def test_resolve_path_target_reads_file(self):
+        entry = next(e for e in _bench.iter_entries(ENTRIES_DIR) if e.target_kind == "path")
+        text = entry.resolve_target(TARGETS_DIR)
+        assert text  # non-empty
+
+    def test_parse_entry_rejects_unknown_field(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text(
+            json.dumps(
+                {
+                    "rule_text": "x",
+                    "target": {"kind": "inline", "value": "y"},
+                    "expected_judgment": "pass",
+                    "expected_rationale_keywords": [],
+                    "category": "clarity",
+                    "intended_backend": "llm-rubric",
+                    "extra_field": "should fail",
+                }
+            )
+        )
+        with pytest.raises(ValueError, match="unknown fields"):
+            _bench.load_entry(bad)
+
+    def test_parse_entry_rejects_invalid_judgment(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text(
+            json.dumps(
+                {
+                    "rule_text": "x",
+                    "target": {"kind": "inline", "value": "y"},
+                    "expected_judgment": "MAYBE",
+                    "expected_rationale_keywords": [],
+                    "category": "clarity",
+                    "intended_backend": "llm-rubric",
+                }
+            )
+        )
+        with pytest.raises(ValueError, match="expected_judgment"):
+            _bench.load_entry(bad)
+
+
+# ---------------------------------------------------------------------------
+# run_bench (single-entry smoke)
+# ---------------------------------------------------------------------------
+
+
+class TestRunBenchSmoke:
+    def _single_entry_dir(self, tmp_path: Path) -> Path:
+        """Build a one-entry fixture dir whose target is inline (no file deps)."""
+        entries = tmp_path / "entries"
+        entries.mkdir()
+        entry = {
+            "rule_text": "The artefact satisfies the example rule.",
+            "target": {"kind": "inline", "value": "example artefact body"},
+            "expected_judgment": "pass",
+            "expected_rationale_keywords": ["satisfies"],
+            "category": "clarity",
+            "intended_backend": "llm-rubric",
+        }
+        (entries / "smoke-01.json").write_text(json.dumps(entry))
+        return entries
+
+    def test_run_bench_pass(self, monkeypatch, tmp_path):
+        _patch_env(monkeypatch, _OPENAI_ENV)
+        monkeypatch.setattr(_llm, "_call_openai", _stub_openai_pass)
+        entries = self._single_entry_dir(tmp_path)
+        result = _bench.run_bench(entries, reproducibility=1)
+        assert result.summary.entries == 1
+        assert result.summary.correct == 1
+        assert result.summary.accuracy == 1.0
+        assert result.summary.tokens_in == 50
+        assert result.summary.tokens_out == 12
+        assert result.summary.model == _llm.OPENAI_DEFAULT_MODEL
+        assert result.summary.prompt_version == _llm.PROMPT_VERSION
+        assert len(result.per_rule) == 1
+        row = result.per_rule[0]
+        assert row.id == "smoke-01"
+        assert row.status == "PASS"
+        assert row.actual == "pass"
+        assert row.expected == "pass"
+        assert row.reproducibility == 1.0
+
+    def test_run_bench_mismatch_marks_fail(self, monkeypatch, tmp_path):
+        # Stub returns `fail` but expected is `pass` → status=FAIL.
+        _patch_env(monkeypatch, _OPENAI_ENV)
+        monkeypatch.setattr(_llm, "_call_openai", _stub_openai_fail)
+        entries = self._single_entry_dir(tmp_path)
+        result = _bench.run_bench(entries, reproducibility=1)
+        assert result.summary.correct == 0
+        assert result.summary.accuracy == 0.0
+        row = result.per_rule[0]
+        assert row.status == "FAIL"
+        assert row.actual == "fail"
+        assert row.expected == "pass"
+        assert row.failure_mode == "llm_fail"
+
+    def test_run_bench_reproducibility_three(self, monkeypatch, tmp_path):
+        _patch_env(monkeypatch, _OPENAI_ENV)
+        monkeypatch.setattr(_llm, "_call_openai", _stub_openai_pass)
+        entries = self._single_entry_dir(tmp_path)
+        result = _bench.run_bench(entries, reproducibility=3)
+        # All 3 runs return pass → reproducibility=1.0, telemetry sums.
+        assert result.summary.reproducibility_n == 3
+        assert result.per_rule[0].reproducibility == 1.0
+        assert result.per_rule[0].tokens_in == 50 * 3
+        assert result.per_rule[0].tokens_out == 12 * 3
+
+    def test_run_bench_unconfigured_marks_unavailable(self, monkeypatch, tmp_path):
+        # No provider env → backend returns UNAVAILABLE.
+        _patch_env(monkeypatch, {})
+        entries = self._single_entry_dir(tmp_path)
+        result = _bench.run_bench(entries, reproducibility=1)
+        row = result.per_rule[0]
+        assert row.actual == "unavailable"
+        assert row.status == "FAIL"  # mismatch counts as fail
+        assert result.summary.unavailable == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+class TestCliBench:
+    def _smoke_entries(self, tmp_path: Path) -> Path:
+        entries = tmp_path / "entries"
+        entries.mkdir()
+        (entries / "cli-smoke.json").write_text(
+            json.dumps(
+                {
+                    "rule_text": "The artefact satisfies the example rule.",
+                    "target": {"kind": "inline", "value": "example body"},
+                    "expected_judgment": "pass",
+                    "expected_rationale_keywords": [],
+                    "category": "clarity",
+                    "intended_backend": "llm-rubric",
+                }
+            )
+        )
+        return entries
+
+    def test_bench_help(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            main(["bench", "--help"])
+        assert exc.value.code == 0
+        captured = capsys.readouterr()
+        assert "entries_dir" in captured.out
+        assert "--reproducibility" in captured.out
+        assert "--baseline" in captured.out
+
+    def test_bench_text_format(self, monkeypatch, tmp_path, capsys):
+        _patch_env(monkeypatch, _OPENAI_ENV)
+        monkeypatch.setattr(_llm, "_call_openai", _stub_openai_pass)
+        entries = self._smoke_entries(tmp_path)
+        rc = main(["bench", str(entries)])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "entries: 1" in captured.out
+        assert "accuracy:" in captured.out
+        assert "cli-smoke" in captured.out
+
+    def test_bench_json_format(self, monkeypatch, tmp_path, capsys):
+        _patch_env(monkeypatch, _OPENAI_ENV)
+        monkeypatch.setattr(_llm, "_call_openai", _stub_openai_pass)
+        entries = self._smoke_entries(tmp_path)
+        rc = main(["bench", str(entries), "--format", "json"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "summary" in data
+        assert "per_rule" in data
+        assert data["summary"]["entries"] == 1
+        assert data["summary"]["correct"] == 1
+        assert data["per_rule"][0]["id"] == "cli-smoke"
+
+    def test_bench_missing_dir_exit_2(self, capsys):
+        rc = main(["bench", "/nonexistent/does-not-exist"])
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "error:" in captured.err
+
+    def test_bench_negative_reproducibility_exit_2(self, tmp_path, capsys):
+        entries = tmp_path / "entries"
+        entries.mkdir()
+        rc = main(["bench", str(entries), "--reproducibility", "0"])
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "reproducibility" in captured.err
+
+    def test_bench_baseline_diff(self, monkeypatch, tmp_path, capsys):
+        """`--baseline` accepts a JSON file with the bench shape and prints a delta."""
+        _patch_env(monkeypatch, _OPENAI_ENV)
+        monkeypatch.setattr(_llm, "_call_openai", _stub_openai_pass)
+        entries = self._smoke_entries(tmp_path)
+
+        # Build a synthetic baseline that matches the current run shape but
+        # claims a previous PASS status — so a current PASS is a wash.
+        baseline = tmp_path / "baseline.json"
+        baseline.write_text(
+            json.dumps(
+                {
+                    "summary": {
+                        "entries": 1,
+                        "correct": 1,
+                        "accuracy": 1.0,
+                        "reproducibility_avg": 1.0,
+                        "tokens_in": 50,
+                        "tokens_out": 12,
+                        "latency_ms": 10,
+                        "model": "gpt-4o-mini",
+                        "prompt_version": "v1",
+                        "reproducibility_n": 1,
+                        "unavailable": 0,
+                        "errors": 0,
+                    },
+                    "per_rule": [
+                        {
+                            "id": "cli-smoke",
+                            "category": "clarity",
+                            "intended_backend": "llm-rubric",
+                            "expected": "pass",
+                            "actual": "pass",
+                            "status": "PASS",
+                            "reproducibility": 1.0,
+                            "primary_reason": "ok",
+                            "failure_mode": None,
+                            "tokens_in": 50,
+                            "tokens_out": 12,
+                            "latency_ms": 10,
+                            "model": "gpt-4o-mini",
+                            "prompt_version": "v1",
+                        }
+                    ],
+                }
+            )
+        )
+
+        rc = main(["bench", str(entries), "--baseline", str(baseline)])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "baseline delta:" in captured.out
+        assert "accuracy:" in captured.out
+
+    def test_bench_baseline_missing_exit_2(self, monkeypatch, tmp_path, capsys):
+        _patch_env(monkeypatch, _OPENAI_ENV)
+        monkeypatch.setattr(_llm, "_call_openai", _stub_openai_pass)
+        entries = self._smoke_entries(tmp_path)
+        rc = main(
+            [
+                "bench",
+                str(entries),
+                "--baseline",
+                str(tmp_path / "no-such-baseline.json"),
+            ]
+        )
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "baseline" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Real-corpus loader smoke (no LLM call — just shape check)
+# ---------------------------------------------------------------------------
+
+
+def test_real_corpus_loads_and_targets_resolve():
+    """The 24 fixture entries must load and every path target must resolve.
+
+    This guards against drift between fixture files and the bench loader's
+    schema when someone adds or renames an entry.
+    """
+    entries = list(_bench.iter_entries(ENTRIES_DIR))
+    assert len(entries) >= 12  # plan baseline says ~24, accept >=12 to allow growth
+    for e in entries:
+        # Each call resolves either inline value or reads the targets/ file.
+        text = e.resolve_target(TARGETS_DIR)
+        assert isinstance(text, str)


### PR DESCRIPTION
Closes #130

## Summary

Adds `gate-keeper bench` subcommand: evaluates `tests/fixtures/semantic/entries/` (24 fixture entries) against the LLM-rubric backend and produces aggregate accuracy / reproducibility / token metrics plus a per-entry breakdown.

This lands the harness only. Real-call cost is intentionally deferred to #132 (which generates `baseline.json` from `bench --reproducibility 3 × 24`); the bench surface and `--baseline` diff path are stable here so #132 can land cleanly.

## Surface

- `bench <entries_dir>` — load JSON entries, evaluate, render
- `--reproducibility N` — N evals per entry, majority vote, ties break to fail (output shape constant across N=1 and N>1)
- `--format text|json` — text default; json is the shape `baseline.json` will use
- `--baseline PATH` — diff vs stored baseline; advisory, does not change exit code

## JSON shape

```json
{
  "summary": {
    "entries": 24, "correct": 18, "accuracy": 0.75,
    "reproducibility_avg": 0.83,
    "tokens_in": ..., "tokens_out": ..., "latency_ms": ...,
    "model": "gpt-4o-mini", "prompt_version": "v1",
    "reproducibility_n": 1, "unavailable": 0, "errors": 0
  },
  "per_rule": [
    {"id": "...", "status": "PASS|FAIL",
     "expected": "pass|fail", "actual": "pass|fail|unavailable|error",
     "reproducibility": 1.0, "primary_reason": "...",
     "failure_mode": null, "tokens_in": ..., "tokens_out": ..., "latency_ms": ...,
     "model": "...", "prompt_version": "..."}
  ]
}
```

## Implementation notes

- Self-contained loader in `src/gate_keeper/bench.py` (the test-only `tests/semantic_fixtures.py` stays test-only). Schema mirrors `tests/fixtures/semantic/README.md`; unknown fields fail loudly.
- Each entry synthesises an IR `Rule` (kind `SEMANTIC_RUBRIC`, backend `LLM_RUBRIC`) and dispatches directly to `llm_rubric.check` so per-entry telemetry sums across runs (the registry's `run_n` only carries one representative diagnostic's telemetry — not the cumulative cost, which the bench needs).
- Tie-break for the majority judgment is fail-closed.
- Non-pass/fail outcomes (`UNAVAILABLE` / `ERROR`) abort aggregation early so a misconfigured provider does not silently inflate accuracy. Counted into `summary.unavailable` / `summary.errors`.
- Baseline diff is computed by entry id; missing baseline file → exit 2.

## Acceptance (#130)

- [x] `gate-keeper bench --help` displays the four-flag surface
- [x] Existing 24-entry fixture corpus loads end-to-end (`test_real_corpus_loads_and_targets_resolve`)
- [x] `--reproducibility N` honoured, output shape constant for N=1 vs N>1 (`test_run_bench_reproducibility_three`)
- [x] CI mock-provider smoke test added (`tests/test_cli_bench.py`); 17 new tests, 0 real LLM calls
- [ ] Real-call artifact (`bench-2026-05-XX.json`) — deferred to #132 per orchestrator plan (cost-controlled: real corpus run reserved for the baseline-generation PR)

## Validation

```sh
$ uv run pytest tests/test_cli_bench.py -v
17 passed in 0.18s

$ uvx ruff check .
All checks passed!

$ uv run pyright
0 errors, 0 warnings, 0 informations

$ uv run gate-keeper bench --help
usage: gate-keeper bench [-h] [--reproducibility N] [--format {text,json}]
                         [--baseline PATH]
                         entries_dir
```

Pre-existing test failures in `tests/test_validator.py` / `tests/test_llm_rubric_backend.py` / `tests/test_cli_validate.py` (12 cases) are environmental (the host dotenv at `/home/vscode/.config/hermes-projects/gate-keeper.env` is configured, so tests that assume an unconfigured environment fail locally). They reproduce on the `issue-133-cost-estimate` worktree at the same base commit and pass in CI which has no dotenv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)