### PR TITLE
feat(cli): --include GLOB for compile and validate (#145)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -18,7 +18,7 @@ Subcommands: [`compile`](#compile), [`explain`](#explain),
 |------|----------|---------|
 | `0`  | `EXIT_OK`   | All rules passed (or `bench` ran without a usage error). |
 | `1`  | `EXIT_FAIL` | One or more rules produced a non-passing status (`fail`, `unavailable`, `unsupported`, or `error`). |
-| `2`  | `EXIT_USAGE` | Bad arguments, unreadable input file, or other usage error. |
+| `2`  | `EXIT_USAGE` | Bad arguments, unreadable input file, an unmatched `--include` glob, or a duplicate rule id across composed documents. |
 
 Defined in `src/gate_keeper/diagnostics.py`.
 
@@ -30,26 +30,59 @@ accuracy is observational and does not constitute a CLI-level failure. It exits
 
 ## compile
 
-Extract rules from a Markdown rule document and emit them as the rule IR (JSON).
+Extract rules from one or more Markdown rule documents and emit them as the
+rule IR (JSON).
 
 ### Synopsis
 
 ```
-gate-keeper compile [--format {json}] <document>
+gate-keeper compile [--format {json}] (<document> | --include GLOB [--include GLOB ...])
 ```
+
+Provide either a single positional `document` **or** one or more `--include`
+globs — not both.
 
 ### Arguments and options
 
 | Argument / option | Type | Default | Description |
 |---|---|---|---|
-| `document` | positional | — | Path to a Markdown rule document. |
+| `document` | positional | — | Path to a single Markdown rule document. Omit when using `--include`. |
+| `--include GLOB` | option (repeatable) | — | Compose a policy bundle from every Markdown document matching `GLOB`. May be passed multiple times to combine multiple glob patterns. Mutually exclusive with the positional `document`. |
 | `--format {json}` | option | `json` | Output format. Only `json` is supported. |
 | `-h, --help` | flag | — | Show help and exit. |
+
+### `--include` semantics
+
+- Each `--include` glob is expanded with Python's `glob.glob(..., recursive=True)`,
+  so `**` matches across directory boundaries when used.
+- The combined set of matched paths is **sorted lexicographically** before
+  parsing. Iteration order is therefore deterministic across platforms and
+  independent of the order in which `--include` flags appear on the command
+  line.
+- Each matched document is parsed with its own source path, then all rules
+  are merged into a single RuleSet. Per-rule `source.path` and `source.line`
+  point back to the originating document.
+- If any `--include` glob matches no files, the command exits `2` and prints
+  the unmatched pattern.
+- Rule ids must be unique across the composed RuleSet. If two documents
+  produce the same rule id (the default scheme is `rule-<stem>-L<line>`,
+  so two files with the same stem and a rule on the same line collide),
+  the command exits `2` and reports both source path/line locations. Rule
+  ids are never silently renamed.
 
 ### Sample invocation
 
 ```sh
+# single document (positional)
 uv run gate-keeper compile docs/dogfooding-rules.md
+
+# policy bundle composed from one glob
+uv run gate-keeper compile --include 'rules/gatekeeper/*.md'
+
+# policy bundle composed from multiple globs
+uv run gate-keeper compile \
+    --include 'rules/repo-structure/*.md' \
+    --include 'rules/pr-governance/*.md'
 ```
 
 ### Sample output
@@ -139,8 +172,8 @@ Each block contains:
 
 ## validate
 
-Validate an artifact (local directory, file, or GitHub PR) against a rule
-document and report pass/fail with evidence.
+Validate an artifact (local directory, file, or GitHub PR) against one or more
+Markdown rule documents and report pass/fail with evidence.
 
 ### Synopsis
 
@@ -149,14 +182,19 @@ gate-keeper validate [--rules-format {markdown,ir}]
                      [--backend {auto,filesystem,github,llm-rubric,external}]
                      [--format {text,json}] [--verbose]
                      [--reproducibility N]
-                     --target <TARGET> <rules>
+                     --target <TARGET>
+                     (<rules> | --include GLOB [--include GLOB ...])
 ```
+
+Provide either a single positional `rules` document **or** one or more
+`--include` globs — not both.
 
 ### Arguments and options
 
 | Argument / option | Type | Default | Description |
 |---|---|---|---|
-| `rules` | positional | — | Path to a Markdown rule document, or to a precompiled Rule IR JSON file when `--rules-format ir` is given. |
+| `rules` | positional | — | Path to a Markdown rule document, or to a precompiled Rule IR JSON file when `--rules-format ir` is given. Omit when using `--include`. |
+| `--include GLOB` | option (repeatable) | — | Compose a policy bundle from every Markdown document matching `GLOB`. May be passed multiple times. Mutually exclusive with the positional `rules`. Not compatible with `--rules-format ir`. |
 | `--target TARGET` | option | **required** | Artifact or PR to validate. Pass a local path for filesystem rules; a GitHub PR URL or `owner/repo#N` for GitHub rules. |
 | `--rules-format {markdown,ir}` | option | `markdown` | How to interpret `rules`. `markdown` (default) parses and classifies a Markdown rule document — the historical behaviour. `ir` loads a precompiled `RuleSet` JSON file (the same shape `compile` emits) using the strict IR parser and **bypasses the classifier**, so hand-authored `kind`, `backend_hint`, and `params` fields reach the validator unchanged. |
 | `--backend {auto,filesystem,github,llm-rubric,external}` | option | `auto` | Validation backend. `auto` delegates each rule to the backend the classifier (or the IR file) selected. |
@@ -178,6 +216,14 @@ gate-keeper validate [--rules-format {markdown,ir}]
 The default Markdown path remains the right choice when authoring rules from
 natural-language documents — the classifier turns prose into routed rules.
 
+### `--include` semantics
+
+`--include` follows the same semantics as in [`compile`](#compile): globs are
+expanded with `glob.glob(..., recursive=True)`, the matched paths are sorted
+lexicographically before parsing, an unmatched glob exits `2`, and duplicate
+rule IDs across documents exit `2` with both source locations reported.
+`--include` is Markdown-only and not compatible with `--rules-format ir`.
+
 ### Sample invocation
 
 ```sh
@@ -190,6 +236,9 @@ uv run gate-keeper validate --rules-format ir rules.json --target .
 
 # JSON output
 uv run gate-keeper validate docs/dogfooding-rules.md --target . --format json
+
+# Validate against a policy bundle composed from a glob
+uv run gate-keeper validate --include 'rules/gatekeeper/*.md' --target .
 
 # With verbose LLM rationale
 uv run gate-keeper validate docs/dogfooding-rules.md --target . --verbose

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import glob as _glob
 import json
 import sys
 from pathlib import Path
@@ -11,6 +12,106 @@ from gate_keeper.models import RuleSet
 
 # Backend choices exposed by the registry (always includes auto).
 _BACKEND_CHOICES = ["auto", "filesystem", "github", "llm-rubric", "external"]
+
+
+class _IncludeError(Exception):
+    """Raised when --include glob expansion or rule-id merge fails.
+
+    Carries a pre-formatted human-readable message that the CLI prints to
+    stderr. Always maps to ``EXIT_USAGE`` (exit code 2) per the issue #145
+    spec.
+    """
+
+
+def _expand_include_globs(patterns: list[str]) -> list[Path]:
+    """Expand --include glob patterns to a deterministic, sorted list of paths.
+
+    Each pattern is resolved with ``glob.glob`` (relative to the current
+    working directory). The combined match list is sorted lexicographically by
+    string path so iteration order is stable across platforms (the spec
+    guarantees a deterministic, documented include-expansion order).
+
+    Each pattern must match at least one path; unmatched patterns raise
+    ``_IncludeError`` per the empty-include policy in issue #145.
+    """
+    seen: set[str] = set()
+    matched: list[str] = []
+    for pattern in patterns:
+        # ``glob`` expands shell-style globs; recursive ``**`` requires
+        # ``recursive=True``. Patterns without metacharacters resolve to a
+        # single path (or zero, which we report as an unmatched glob below).
+        hits = _glob.glob(pattern, recursive=True)
+        if not hits:
+            raise _IncludeError(
+                f"--include: no files matched pattern {pattern!r}"
+            )
+        for hit in hits:
+            if hit not in seen:
+                seen.add(hit)
+                matched.append(hit)
+    # Lexicographic sort on the string path keeps order deterministic across
+    # platforms and across multiple --include flags.
+    matched.sort()
+    return [Path(p) for p in matched]
+
+
+def _read_ruleset_from_paths(paths: list[Path]) -> RuleSet:
+    """Parse each Markdown document into a Rule list, then merge into one RuleSet.
+
+    Each document is parsed with its own source path so per-rule
+    ``SourceLocation`` entries point back to the originating file. Rule
+    objects from every document are concatenated in path-order; classification
+    happens once on the merged set.
+    """
+    from gate_keeper import classifier, parser
+
+    merged_rules = []
+    for path in paths:
+        content = _read_text(path)
+        # ``parser.parse`` is a pure parse step — it never makes network calls
+        # and preserves source.path / source.line for each candidate rule.
+        ruleset = parser.parse(str(path), content)
+        merged_rules.extend(ruleset.rules)
+
+    # Classify once over the merged list; classification is per-rule so
+    # ordering is preserved and no document boundary matters here.
+    classified = classifier.classify(RuleSet(rules=merged_rules))
+
+    # Detect duplicate rule ids before validation/output. The default rule-id
+    # scheme is ``rule-<stem>-L<line>`` so two files with the same stem at the
+    # same line collide; per #145 we must fail clearly with both source
+    # locations rather than silently rename.
+    _check_duplicate_ids(classified)
+    return classified
+
+
+def _read_text(path: Path) -> str:
+    """Read *path* as UTF-8 and translate IO errors to ``_IncludeError``."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise _IncludeError(f"{path}: {exc.strerror}") from exc
+    except UnicodeDecodeError as exc:
+        raise _IncludeError(f"{path}: not valid UTF-8 ({exc.reason})") from exc
+
+
+def _check_duplicate_ids(ruleset: RuleSet) -> None:
+    """Raise ``_IncludeError`` if two rules share the same id.
+
+    The error message lists the duplicated id and the source path/line for
+    both occurrences so the user can locate and rename either rule.
+    """
+    first_seen: dict[str, tuple[str, int]] = {}
+    for rule in ruleset.rules:
+        loc = (rule.source.path, rule.source.line)
+        if rule.id in first_seen:
+            prev_path, prev_line = first_seen[rule.id]
+            raise _IncludeError(
+                f"duplicate rule id {rule.id!r}: "
+                f"first at {prev_path}:{prev_line}, "
+                f"second at {loc[0]}:{loc[1]}"
+            )
+        first_seen[rule.id] = loc
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -26,7 +127,27 @@ def build_parser() -> argparse.ArgumentParser:
         "compile",
         help="extract rules from a document into the rule IR",
     )
-    compile_parser.add_argument("document", help="path to a rule document")
+    # ``document`` stays a single positional path for the existing
+    # single-document form. Composition uses ``--include`` instead, which
+    # avoids ambiguity with multiple positional arguments (per issue #145
+    # CLI-shape decision).
+    compile_parser.add_argument(
+        "document",
+        nargs="?",
+        default=None,
+        help="path to a rule document (omit when using --include)",
+    )
+    compile_parser.add_argument(
+        "--include",
+        action="append",
+        default=None,
+        metavar="GLOB",
+        help=(
+            "include Markdown rule documents matching GLOB; may be repeated. "
+            "Globs expand in lexicographic path order; the merged result is "
+            "one RuleSet."
+        ),
+    )
     compile_parser.add_argument(
         "--format",
         choices=["json"],
@@ -52,9 +173,23 @@ def build_parser() -> argparse.ArgumentParser:
     )
     validate_parser.add_argument(
         "rules",
+        nargs="?",
+        default=None,
         help=(
             "path to the rule input; interpreted as Markdown by default, or as "
-            "Rule IR JSON when --rules-format ir is given"
+            "Rule IR JSON when --rules-format ir is given. Omit when using --include."
+        ),
+    )
+    validate_parser.add_argument(
+        "--include",
+        action="append",
+        default=None,
+        metavar="GLOB",
+        help=(
+            "include Markdown rule documents matching GLOB; may be repeated. "
+            "Globs expand in lexicographic path order; the merged result is "
+            "one RuleSet. IR composition is not supported (use a single "
+            "positional path with --rules-format ir for IR input)."
         ),
     )
     validate_parser.add_argument("--target", required=True, help="artifact or PR to validate")
@@ -145,6 +280,36 @@ def build_parser() -> argparse.ArgumentParser:
 def _cmd_compile(args: argparse.Namespace) -> int:
     from gate_keeper import classifier, parser
 
+    # Mutually-exclusive sources: exactly one of ``document`` or ``--include``.
+    if args.document is None and not args.include:
+        print(
+            "error: compile requires either a document path or --include GLOB",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+    if args.document is not None and args.include:
+        print(
+            "error: compile accepts either a document path or --include, not both",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+
+    if args.include:
+        # Composition path: expand globs, parse each, merge, classify, then
+        # check for duplicate ids before emitting the IR.
+        try:
+            paths = _expand_include_globs(args.include)
+            ruleset = _read_ruleset_from_paths(paths)
+        except _IncludeError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return EXIT_USAGE
+        print(json.dumps(ruleset.to_dict(), indent=2))
+        return EXIT_OK
+
+    # Single-document positional form (existing behaviour, unchanged).
+    # ``args.document`` is non-None here: the input-validation block above
+    # rejects (None, no --include) before we reach this branch.
+    assert args.document is not None
     path = Path(args.document)
 
     if not path.exists():
@@ -263,20 +428,54 @@ def _cmd_validate(args: argparse.Namespace) -> int:
         print(f"error: unknown backend {backend!r}", file=sys.stderr)
         return EXIT_USAGE
 
-    # Read and compile the rule document.
-    doc_path = Path(args.rules)
-    if not doc_path.exists():
-        print(f"error: {args.rules}: No such file or directory", file=sys.stderr)
+    # Mutually-exclusive sources: exactly one of ``rules`` or ``--include``.
+    if args.rules is None and not args.include:
+        print(
+            "error: validate requires either a rules path or --include GLOB",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+    if args.rules is not None and args.include:
+        print(
+            "error: validate accepts either a rules path or --include, not both",
+            file=sys.stderr,
+        )
         return EXIT_USAGE
 
     rules_format = getattr(args, "rules_format", "markdown")
-    if rules_format == "ir":
-        loaded = _load_ir_ruleset(doc_path)
+    if args.include:
+        # Composition path: expand globs, parse each, merge, classify, then
+        # check for duplicate ids before running validation. Markdown only —
+        # IR composition is intentionally out of scope (use single positional
+        # with --rules-format ir for IR input).
+        if rules_format == "ir":
+            print(
+                "error: --include is incompatible with --rules-format ir "
+                "(IR composition is not supported)",
+                file=sys.stderr,
+            )
+            return EXIT_USAGE
+        try:
+            paths = _expand_include_globs(args.include)
+            ruleset = _read_ruleset_from_paths(paths)
+        except _IncludeError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return EXIT_USAGE
     else:
-        loaded = _load_markdown_ruleset(doc_path)
-    if isinstance(loaded, int):
-        return loaded
-    ruleset = loaded
+        # Single positional path. ``args.rules`` is non-None here: the
+        # input-validation block above rejects (None, no --include) already.
+        assert args.rules is not None
+        doc_path = Path(args.rules)
+        if not doc_path.exists():
+            print(f"error: {args.rules}: No such file or directory", file=sys.stderr)
+            return EXIT_USAGE
+        if rules_format == "ir":
+            loaded = _load_ir_ruleset(doc_path)
+        else:
+            loaded = _load_markdown_ruleset(doc_path)
+        if isinstance(loaded, int):
+            return loaded
+        ruleset = loaded
 
     # Validate reproducibility argument.
     if args.reproducibility < 1:

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -49,7 +49,16 @@ def _expand_include_globs(patterns: list[str]) -> list[Path]:
         if not hits:
             raise _IncludeError(f"--include: no files matched pattern {pattern!r}")
         for hit in hits:
-            canonical = Path(hit).resolve()
+            # ``Path.resolve()`` can raise ``RuntimeError`` on symlink loops
+            # (e.g. ``a.md -> b.md -> a.md``) and ``OSError`` on broken paths.
+            # Translate either into ``_IncludeError`` so the CLI surfaces a
+            # ``EXIT_USAGE`` (2) instead of an uncaught traceback — the
+            # ``_cmd_compile`` / ``_cmd_validate`` wrappers only catch
+            # ``_IncludeError``.
+            try:
+                canonical = Path(hit).resolve()
+            except (OSError, RuntimeError) as exc:
+                raise _IncludeError(f"--include: cannot resolve path {hit!r}: {exc}") from exc
             if canonical not in seen_canonical:
                 seen_canonical.add(canonical)
                 matched.append(hit)

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -465,8 +465,7 @@ def _cmd_validate(args: argparse.Namespace) -> int:
         # with --rules-format ir for IR input).
         if rules_format == "ir":
             print(
-                "error: --include is incompatible with --rules-format ir "
-                "(IR composition is not supported)",
+                "error: --include is incompatible with --rules-format ir (IR composition is not supported)",
                 file=sys.stderr,
             )
             return EXIT_USAGE

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -42,9 +42,7 @@ def _expand_include_globs(patterns: list[str]) -> list[Path]:
         # single path (or zero, which we report as an unmatched glob below).
         hits = _glob.glob(pattern, recursive=True)
         if not hits:
-            raise _IncludeError(
-                f"--include: no files matched pattern {pattern!r}"
-            )
+            raise _IncludeError(f"--include: no files matched pattern {pattern!r}")
         for hit in hits:
             if hit not in seen:
                 seen.add(hit)

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -34,7 +34,12 @@ def _expand_include_globs(patterns: list[str]) -> list[Path]:
     Each pattern must match at least one path; unmatched patterns raise
     ``_IncludeError`` per the empty-include policy in issue #145.
     """
-    seen: set[str] = set()
+    # Dedup on the resolved (canonical) path so different glob spellings of
+    # the same physical file (e.g. ``a.md`` vs ``./a.md``, or distinct
+    # patterns whose hits overlap) are merged into a single include. Without
+    # this, the same file would be parsed twice and ``_check_duplicate_ids``
+    # would surface a false ``EXIT_USAGE`` for an otherwise-valid bundle.
+    seen_canonical: set[Path] = set()
     matched: list[str] = []
     for pattern in patterns:
         # ``glob`` expands shell-style globs; recursive ``**`` requires
@@ -44,11 +49,14 @@ def _expand_include_globs(patterns: list[str]) -> list[Path]:
         if not hits:
             raise _IncludeError(f"--include: no files matched pattern {pattern!r}")
         for hit in hits:
-            if hit not in seen:
-                seen.add(hit)
+            canonical = Path(hit).resolve()
+            if canonical not in seen_canonical:
+                seen_canonical.add(canonical)
                 matched.append(hit)
     # Lexicographic sort on the string path keeps order deterministic across
-    # platforms and across multiple --include flags.
+    # platforms and across multiple --include flags. The retained spelling
+    # for each physical file is the first one encountered, so per-rule
+    # ``source.path`` reflects how the user wrote the include.
     matched.sort()
     return [Path(p) for p in matched]
 

--- a/tests/test_cli_include.py
+++ b/tests/test_cli_include.py
@@ -326,3 +326,45 @@ class TestExpandIncludeGlobs:
         out = _expand_include_globs(["a.md", "./a.md"])
         assert len(out) == 1
         assert out[0].name == "a.md"
+
+    def test_helper_translates_symlink_loop_to_include_error(self, tmp_path, monkeypatch):
+        # Regression for codex review on PR #150 (issue #145):
+        # ``Path.resolve()`` raises ``RuntimeError`` when canonicalization
+        # encounters a symlink loop (``a.md -> b.md -> a.md``). The helper
+        # must catch that and re-raise as ``_IncludeError`` so the CLI maps
+        # it to the documented usage exit (``2``) rather than crashing with
+        # an uncaught traceback in ``_cmd_compile`` / ``_cmd_validate``.
+        import os
+
+        from gate_keeper.cli import _expand_include_globs, _IncludeError
+
+        a = tmp_path / "a.md"
+        b = tmp_path / "b.md"
+        try:
+            os.symlink(b, a)
+            os.symlink(a, b)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation not supported on this platform")
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(_IncludeError) as excinfo:
+            _expand_include_globs(["a.md"])
+        assert "a.md" in str(excinfo.value)
+
+    def test_cli_symlink_loop_exits_2(self, tmp_path, monkeypatch, capsys):
+        # End-to-end guard: a symlink loop reachable through ``--include``
+        # must surface as ``EXIT_USAGE`` (2) on the ``compile`` subcommand,
+        # not as an uncaught ``RuntimeError`` traceback.
+        import os
+
+        a = tmp_path / "a.md"
+        b = tmp_path / "b.md"
+        try:
+            os.symlink(b, a)
+            os.symlink(a, b)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation not supported on this platform")
+        monkeypatch.chdir(tmp_path)
+        rc = main(["compile", "--include", "a.md"])
+        captured = capsys.readouterr()
+        assert rc == EXIT_USAGE
+        assert "a.md" in captured.err

--- a/tests/test_cli_include.py
+++ b/tests/test_cli_include.py
@@ -311,3 +311,18 @@ class TestExpandIncludeGlobs:
         with pytest.raises(_IncludeError) as excinfo:
             _expand_include_globs(["nope/*.md"])
         assert "nope/*.md" in str(excinfo.value)
+
+    def test_helper_dedupes_different_spellings_of_same_path(self, tmp_path, monkeypatch):
+        # Regression for codex review on PR #150 (issue #145):
+        # ``a.md`` and ``./a.md`` resolve to the same physical file but
+        # would have produced distinct entries in the raw-string dedup set,
+        # causing ``_check_duplicate_ids`` to raise a false ``EXIT_USAGE``
+        # error when both spellings appeared via different ``--include``
+        # patterns. The helper must collapse them to a single include.
+        from gate_keeper.cli import _expand_include_globs
+
+        (tmp_path / "a.md").write_text("# x\n", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        out = _expand_include_globs(["a.md", "./a.md"])
+        assert len(out) == 1
+        assert out[0].name == "a.md"

--- a/tests/test_cli_include.py
+++ b/tests/test_cli_include.py
@@ -86,12 +86,8 @@ class TestCompileInclude:
     def test_compile_multiple_globs_merge(self, tmp_path, capsys, monkeypatch):
         (tmp_path / "rulesA").mkdir()
         (tmp_path / "rulesB").mkdir()
-        _write_rules_doc(
-            tmp_path / "rulesA" / "x.md", _basic_doc("X", "`x.md` must exist.")
-        )
-        _write_rules_doc(
-            tmp_path / "rulesB" / "y.md", _basic_doc("Y", "`y.md` must exist.")
-        )
+        _write_rules_doc(tmp_path / "rulesA" / "x.md", _basic_doc("X", "`x.md` must exist."))
+        _write_rules_doc(tmp_path / "rulesB" / "y.md", _basic_doc("Y", "`y.md` must exist."))
         monkeypatch.chdir(tmp_path)
         rc = main(
             [
@@ -155,9 +151,7 @@ class TestCompileInclude:
         assert paths[0].endswith("alpha.md")
         assert paths[-1].endswith("zeta.md")
 
-    def test_compile_rejects_positional_and_include_together(
-        self, tmp_path, capsys, monkeypatch
-    ):
+    def test_compile_rejects_positional_and_include_together(self, tmp_path, capsys, monkeypatch):
         doc = tmp_path / "rules.md"
         _write_rules_doc(doc, _basic_doc("R", "`README.md` must exist."))
         monkeypatch.chdir(tmp_path)
@@ -184,12 +178,8 @@ class TestValidateInclude:
         # against ``PASS_README`` (which exists) should exit OK.
         rules_dir = tmp_path / "rules"
         rules_dir.mkdir()
-        _write_rules_doc(
-            rules_dir / "a.md", _basic_doc("A", "`README.md` must exist.")
-        )
-        _write_rules_doc(
-            rules_dir / "b.md", _basic_doc("B", "`README.md` must exist.")
-        )
+        _write_rules_doc(rules_dir / "a.md", _basic_doc("A", "`README.md` must exist."))
+        _write_rules_doc(rules_dir / "b.md", _basic_doc("B", "`README.md` must exist."))
         monkeypatch.chdir(tmp_path)
         rc = main(
             [
@@ -253,9 +243,7 @@ class TestValidateInclude:
         assert "rules/sub1/shared.md" in captured.err
         assert "rules/sub2/shared.md" in captured.err
 
-    def test_validate_rejects_positional_and_include_together(
-        self, tmp_path, capsys, monkeypatch
-    ):
+    def test_validate_rejects_positional_and_include_together(self, tmp_path, capsys, monkeypatch):
         doc = tmp_path / "rules.md"
         _write_rules_doc(doc, _basic_doc("R", "`README.md` must exist."))
         monkeypatch.chdir(tmp_path)

--- a/tests/test_cli_include.py
+++ b/tests/test_cli_include.py
@@ -1,0 +1,325 @@
+"""Tests for the --include glob feature on ``compile`` and ``validate`` (issue #145).
+
+Covers:
+- Single-document positional form continues to work unchanged.
+- One ``--include`` glob composes a single Markdown document into one RuleSet.
+- Multiple ``--include`` flags merge into one RuleSet across documents.
+- Unmatched glob exits ``2`` and reports the unmatched pattern.
+- Duplicate rule ids exit ``2`` and report both source path/line.
+- Include expansion order is deterministic (lexicographic path order).
+- Mixing positional and ``--include`` is rejected as a usage error.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gate_keeper.cli import main
+from gate_keeper.diagnostics import EXIT_OK, EXIT_USAGE
+
+REPO_ROOT = Path(__file__).parent.parent
+LOCAL_FIXTURES = Path(__file__).parent / "fixtures" / "local"
+PASS_DIR = LOCAL_FIXTURES / "pass"
+PASS_README = PASS_DIR / "README.md"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_rules_doc(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def _basic_doc(name: str, line_text: str) -> str:
+    """Return a minimal rule document body that produces exactly one rule.
+
+    The bullet form ``- <text>`` plus a normative keyword (``must``) is enough
+    for ``parser.parse`` to emit a single Rule whose source location points at
+    that bullet line.
+    """
+    return f"# {name}\n\nIntro paragraph (non-normative).\n\n## Rules\n\n- {line_text}\n"
+
+
+# ---------------------------------------------------------------------------
+# Compile: single-document form still works (regression guard)
+# ---------------------------------------------------------------------------
+
+
+class TestCompileSingleDocument:
+    def test_compile_positional_single_document(self, tmp_path, capsys):
+        doc = tmp_path / "rules.md"
+        _write_rules_doc(doc, _basic_doc("R", "`README.md` must exist."))
+        rc = main(["compile", str(doc)])
+        captured = capsys.readouterr()
+        assert rc == EXIT_OK
+        data = json.loads(captured.out)
+        assert len(data["rules"]) == 1
+        assert data["rules"][0]["source"]["path"] == str(doc)
+
+
+# ---------------------------------------------------------------------------
+# Compile: --include
+# ---------------------------------------------------------------------------
+
+
+class TestCompileInclude:
+    def test_compile_one_glob_composes_ruleset(self, tmp_path, capsys, monkeypatch):
+        rules_dir = tmp_path / "rules"
+        _write_rules_doc(rules_dir / "a.md", _basic_doc("A", "`a.md` must exist."))
+        _write_rules_doc(rules_dir / "b.md", _basic_doc("B", "`b.md` must exist."))
+        monkeypatch.chdir(tmp_path)
+        rc = main(["compile", "--include", "rules/*.md"])
+        captured = capsys.readouterr()
+        assert rc == EXIT_OK
+        data = json.loads(captured.out)
+        assert len(data["rules"]) == 2
+        # Sources point back to each individual document.
+        sources = sorted(r["source"]["path"] for r in data["rules"])
+        assert sources == ["rules/a.md", "rules/b.md"]
+
+    def test_compile_multiple_globs_merge(self, tmp_path, capsys, monkeypatch):
+        (tmp_path / "rulesA").mkdir()
+        (tmp_path / "rulesB").mkdir()
+        _write_rules_doc(
+            tmp_path / "rulesA" / "x.md", _basic_doc("X", "`x.md` must exist.")
+        )
+        _write_rules_doc(
+            tmp_path / "rulesB" / "y.md", _basic_doc("Y", "`y.md` must exist.")
+        )
+        monkeypatch.chdir(tmp_path)
+        rc = main(
+            [
+                "compile",
+                "--include",
+                "rulesA/*.md",
+                "--include",
+                "rulesB/*.md",
+            ]
+        )
+        captured = capsys.readouterr()
+        assert rc == EXIT_OK
+        data = json.loads(captured.out)
+        assert len(data["rules"]) == 2
+
+    def test_compile_unmatched_glob_exits_2(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        rc = main(["compile", "--include", "no-such-dir/*.md"])
+        captured = capsys.readouterr()
+        assert rc == EXIT_USAGE
+        assert "no-such-dir/*.md" in captured.err
+        assert "no files matched" in captured.err
+
+    def test_compile_duplicate_rule_id_exits_2(self, tmp_path, capsys, monkeypatch):
+        # Two files with the same stem at the same bullet line collide on the
+        # default rule-id scheme ``rule-<stem>-L<line>``. Different parent
+        # directories — same stem, same line — is the canonical collision case
+        # the issue #145 spec calls out.
+        (tmp_path / "rules" / "sub1").mkdir(parents=True)
+        (tmp_path / "rules" / "sub2").mkdir(parents=True)
+        body = _basic_doc("Same", "`README.md` must exist.")
+        _write_rules_doc(tmp_path / "rules" / "sub1" / "shared.md", body)
+        _write_rules_doc(tmp_path / "rules" / "sub2" / "shared.md", body)
+        monkeypatch.chdir(tmp_path)
+        rc = main(["compile", "--include", "rules/*/shared.md"])
+        captured = capsys.readouterr()
+        assert rc == EXIT_USAGE
+        assert "duplicate rule id" in captured.err
+        # Both source paths must appear in the error so the user can locate
+        # and rename either rule.
+        assert "rules/sub1/shared.md" in captured.err
+        assert "rules/sub2/shared.md" in captured.err
+
+    def test_compile_include_order_is_lexicographic(self, tmp_path, capsys, monkeypatch):
+        # Lexicographic ordering on the matched path strings is the documented
+        # determinism contract. Files named to defeat insertion order:
+        # ``zeta.md`` is created first but must come *after* ``alpha.md`` in
+        # the merged rule list.
+        rules_dir = tmp_path / "rules"
+        rules_dir.mkdir()
+        _write_rules_doc(rules_dir / "zeta.md", _basic_doc("Z", "`z.md` must exist."))
+        _write_rules_doc(rules_dir / "alpha.md", _basic_doc("A", "`a.md` must exist."))
+        monkeypatch.chdir(tmp_path)
+        rc = main(["compile", "--include", "rules/*.md"])
+        captured = capsys.readouterr()
+        assert rc == EXIT_OK
+        data = json.loads(captured.out)
+        paths = [r["source"]["path"] for r in data["rules"]]
+        # alpha.md must precede zeta.md.
+        assert paths == sorted(paths)
+        assert paths[0].endswith("alpha.md")
+        assert paths[-1].endswith("zeta.md")
+
+    def test_compile_rejects_positional_and_include_together(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        doc = tmp_path / "rules.md"
+        _write_rules_doc(doc, _basic_doc("R", "`README.md` must exist."))
+        monkeypatch.chdir(tmp_path)
+        rc = main(["compile", "rules.md", "--include", "rules.md"])
+        captured = capsys.readouterr()
+        assert rc == EXIT_USAGE
+        assert "either" in captured.err
+
+    def test_compile_requires_some_input(self, capsys):
+        rc = main(["compile"])
+        captured = capsys.readouterr()
+        assert rc == EXIT_USAGE
+        assert "either" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Validate: --include
+# ---------------------------------------------------------------------------
+
+
+class TestValidateInclude:
+    def test_validate_with_include_runs(self, tmp_path, capsys, monkeypatch):
+        # Two rule docs, each producing one filesystem rule. Validation
+        # against ``PASS_README`` (which exists) should exit OK.
+        rules_dir = tmp_path / "rules"
+        rules_dir.mkdir()
+        _write_rules_doc(
+            rules_dir / "a.md", _basic_doc("A", "`README.md` must exist.")
+        )
+        _write_rules_doc(
+            rules_dir / "b.md", _basic_doc("B", "`README.md` must exist.")
+        )
+        monkeypatch.chdir(tmp_path)
+        rc = main(
+            [
+                "validate",
+                "--include",
+                "rules/*.md",
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+                "--format",
+                "json",
+            ]
+        )
+        captured = capsys.readouterr()
+        assert rc == EXIT_OK
+        data = json.loads(captured.out)
+        # Two diagnostics, each pointing at one of the two source documents.
+        assert len(data["diagnostics"]) == 2
+        sources = sorted(d["source"]["path"] for d in data["diagnostics"])
+        assert sources == ["rules/a.md", "rules/b.md"]
+
+    def test_validate_unmatched_include_exits_2(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        rc = main(
+            [
+                "validate",
+                "--include",
+                "no-such-dir/*.md",
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+            ]
+        )
+        captured = capsys.readouterr()
+        assert rc == EXIT_USAGE
+        assert "no files matched" in captured.err
+
+    def test_validate_duplicate_rule_id_exits_2(self, tmp_path, capsys, monkeypatch):
+        (tmp_path / "rules" / "sub1").mkdir(parents=True)
+        (tmp_path / "rules" / "sub2").mkdir(parents=True)
+        body = _basic_doc("Same", "`README.md` must exist.")
+        _write_rules_doc(tmp_path / "rules" / "sub1" / "shared.md", body)
+        _write_rules_doc(tmp_path / "rules" / "sub2" / "shared.md", body)
+        monkeypatch.chdir(tmp_path)
+        rc = main(
+            [
+                "validate",
+                "--include",
+                "rules/*/shared.md",
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+            ]
+        )
+        captured = capsys.readouterr()
+        assert rc == EXIT_USAGE
+        assert "duplicate rule id" in captured.err
+        assert "rules/sub1/shared.md" in captured.err
+        assert "rules/sub2/shared.md" in captured.err
+
+    def test_validate_rejects_positional_and_include_together(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        doc = tmp_path / "rules.md"
+        _write_rules_doc(doc, _basic_doc("R", "`README.md` must exist."))
+        monkeypatch.chdir(tmp_path)
+        rc = main(
+            [
+                "validate",
+                "rules.md",
+                "--include",
+                "rules.md",
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+            ]
+        )
+        captured = capsys.readouterr()
+        assert rc == EXIT_USAGE
+        assert "either" in captured.err
+
+    def test_validate_requires_some_input(self, capsys):
+        rc = main(
+            [
+                "validate",
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+            ]
+        )
+        captured = capsys.readouterr()
+        assert rc == EXIT_USAGE
+        assert "either" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Determinism on the helper directly
+# ---------------------------------------------------------------------------
+
+
+class TestExpandIncludeGlobs:
+    """Direct unit tests on the helper to lock the lexicographic contract."""
+
+    def test_helper_returns_sorted_paths(self, tmp_path, monkeypatch):
+        from gate_keeper.cli import _expand_include_globs
+
+        for name in ["c.md", "a.md", "b.md"]:
+            (tmp_path / name).write_text("# x\n", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        out = _expand_include_globs(["*.md"])
+        assert [p.name for p in out] == ["a.md", "b.md", "c.md"]
+
+    def test_helper_dedupes_overlapping_globs(self, tmp_path, monkeypatch):
+        from gate_keeper.cli import _expand_include_globs
+
+        (tmp_path / "a.md").write_text("# x\n", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        # Two globs that both match a.md → only one path in output.
+        out = _expand_include_globs(["*.md", "a.md"])
+        assert [p.name for p in out] == ["a.md"]
+
+    def test_helper_raises_on_unmatched(self, tmp_path, monkeypatch):
+        from gate_keeper.cli import _expand_include_globs, _IncludeError
+
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(_IncludeError) as excinfo:
+            _expand_include_globs(["nope/*.md"])
+        assert "nope/*.md" in str(excinfo.value)


### PR DESCRIPTION
## Summary

- Add a repeatable `--include GLOB` to `gate-keeper compile` and
  `gate-keeper validate`. Globs expand deterministically in lexicographic
  path order, each document is parsed with its own source path, and the
  results are merged into one RuleSet before classification.
- Empty include (no files matched) exits `2` with the unmatched pattern.
  Duplicate rule ids across documents exit `2` and report both source
  path/line — never silently rename.
- Existing single-document positional form is unchanged. `--include` is
  mutually exclusive with the positional `document`/`rules` argument so
  the surface stays unambiguous.

Closes #145

## Test plan

- [x] `uv run pytest` (809 passed; new `tests/test_cli_include.py` adds 16 cases:
  single-doc regression, one glob, multiple globs, unmatched glob, duplicate
  ids, deterministic lex order, helper-level dedup/error)
- [x] `uvx ruff check .` clean
- [x] `uvx pyright` no new errors (15 pre-existing pytest/dotenv/anthropic/openai
  import-resolution warnings remain; baseline `main` had 19)
- [x] Manual smoke: `uv run gate-keeper compile --include 'tests/fixtures/validate/*.md'`
- [x] Manual smoke: unmatched glob exits 2 with the pattern in stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)