### PR TITLE
feat(cli): add --rules-format {markdown,ir} to validate (#144)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -145,7 +145,8 @@ document and report pass/fail with evidence.
 ### Synopsis
 
 ```
-gate-keeper validate [--backend {auto,filesystem,github,llm-rubric,external}]
+gate-keeper validate [--rules-format {markdown,ir}]
+                     [--backend {auto,filesystem,github,llm-rubric,external}]
                      [--format {text,json}] [--verbose]
                      [--reproducibility N]
                      --target <TARGET> <rules>
@@ -155,19 +156,37 @@ gate-keeper validate [--backend {auto,filesystem,github,llm-rubric,external}]
 
 | Argument / option | Type | Default | Description |
 |---|---|---|---|
-| `rules` | positional | — | Path to a Markdown rule document. |
+| `rules` | positional | — | Path to a Markdown rule document, or to a precompiled Rule IR JSON file when `--rules-format ir` is given. |
 | `--target TARGET` | option | **required** | Artifact or PR to validate. Pass a local path for filesystem rules; a GitHub PR URL or `owner/repo#N` for GitHub rules. |
-| `--backend {auto,filesystem,github,llm-rubric,external}` | option | `auto` | Validation backend. `auto` delegates each rule to the backend the classifier selected. |
+| `--rules-format {markdown,ir}` | option | `markdown` | How to interpret `rules`. `markdown` (default) parses and classifies a Markdown rule document — the historical behaviour. `ir` loads a precompiled `RuleSet` JSON file (the same shape `compile` emits) using the strict IR parser and **bypasses the classifier**, so hand-authored `kind`, `backend_hint`, and `params` fields reach the validator unchanged. |
+| `--backend {auto,filesystem,github,llm-rubric,external}` | option | `auto` | Validation backend. `auto` delegates each rule to the backend the classifier (or the IR file) selected. |
 | `--format {text,json}` | option | `text` | Output format. |
 | `--verbose, -v` | flag | off | Expand structured LLM-rubric rationale (judgment, reason, evidence quotes, suggested action, model) as indented lines below each diagnostic. Has no effect for non-LLM backends. |
 | `--reproducibility N` | option | `1` | Run each LLM-rubric rule N times and record an agreement-rate `reproducibility_score` evidence entry. **No-op for non-LLM backends** (filesystem, GitHub, external ignore this flag). |
 | `-h, --help` | flag | — | Show help and exit. |
 
+### When to use `--rules-format ir`
+
+- You hand-author or generate a `RuleSet` JSON file directly (e.g. for the
+  `external` backend with `params.tool: textlint`) and need `kind`,
+  `backend_hint`, and `params` to survive verbatim.
+- You want to validate a snapshot produced by `gate-keeper compile`
+  (`compile rules.md > rules.json`) without re-parsing the source document.
+- You are wiring `validate` into a pipeline where the classifier has already
+  been run upstream and re-classification would erase intent.
+
+The default Markdown path remains the right choice when authoring rules from
+natural-language documents — the classifier turns prose into routed rules.
+
 ### Sample invocation
 
 ```sh
-# text output (default)
+# Markdown rules (default; --rules-format markdown is implicit)
 uv run gate-keeper validate docs/dogfooding-rules.md --target .
+
+# Precompiled IR JSON
+uv run gate-keeper compile docs/dogfooding-rules.md > rules.json
+uv run gate-keeper validate --rules-format ir rules.json --target .
 
 # JSON output
 uv run gate-keeper validate docs/dogfooding-rules.md --target . --format json
@@ -179,6 +198,18 @@ uv run gate-keeper validate docs/dogfooding-rules.md --target . --verbose
 uv run gate-keeper validate docs/dogfooding-rules.md --target . \
     --backend llm-rubric --reproducibility 3
 ```
+
+### Errors specific to `--rules-format ir`
+
+| Condition | Exit code | Message shape |
+|---|---|---|
+| Missing IR file | `2` | `error: <path>: No such file or directory` |
+| Not valid UTF-8 | `2` | `error: <path>: not valid UTF-8 (...)` |
+| Invalid JSON | `2` | `error: <path>: invalid JSON (<reason> at line N column M)` |
+| JSON shape fails strict `RuleSet` parsing | `2` | `error: <path>: invalid rule IR (<reason>)` |
+
+The IR parser is strict: unknown fields and enum values outside the schema are
+errors, not warnings. See [docs/rule-ir.md](rule-ir.md) for the contract.
 
 ### Sample output — `--format text`
 

--- a/docs/example-rules.md
+++ b/docs/example-rules.md
@@ -186,9 +186,24 @@ external/fail — prose-textlint: textlint reported 2 finding(s)
       rule_id=terminology, message=Incorrect term: "github", use "GitHub" instead, fixable=True)]
 ```
 
+**Running the IR file through `validate`:**
+
+```sh
+# After compile + edit (or hand-authoring the JSON directly):
+uv run gate-keeper validate --rules-format ir rules.json --target docs/draft.md
+```
+
+`--rules-format ir` parses the JSON with the strict `RuleSet` loader and
+**bypasses the classifier**, so the hand-authored `kind: external_check`,
+`backend_hint: external`, and `params.tool: textlint` reach the textlint
+adapter unchanged. The default (`--rules-format markdown`) re-parses and
+re-classifies a Markdown rule document on every call and is **not** the
+right path for hand-authored IR — custom `kind` / `backend_hint` / `params`
+overrides would be dropped.
+
 **Notes:**
 
-- The `gate-keeper validate` CLI re-parses and re-classifies the rule document on every call (`src/gate_keeper/cli.py` `_cmd_validate`), so a hand-edited compiled `rules.json` is not honoured. The JSON is read as text and the custom `kind` / `backend_hint` / `params` overrides are dropped. Use the IR shape above as a reference for the adapter contract; exercise the textlint adapter via the `gate_keeper.validator.validate` Python API or via the test fixtures in `tests/fixtures/external/` until a CLI flag for IR input lands.
 - Requires Node and `npm install` at the repository root to install textlint.
 - Run `npx --no textlint --fix <file>` to apply auto-fixable corrections.
-- See `docs/backend-external.md` for the full adapter contract.
+- See `docs/backend-external.md` for the full adapter contract and
+  `docs/cli-reference.md#validate` for the `--rules-format` flag reference.

--- a/docs/rule-ir.md
+++ b/docs/rule-ir.md
@@ -7,6 +7,22 @@ This document describes the persisted JSON contract between
 The schema is intentionally minimal for the 3-day MVP. Plugin abstractions,
 provider configuration, and schema versioning are out of scope.
 
+## Consuming IR with `gate-keeper validate`
+
+`compile` emits the IR JSON shape; `validate` can consume it directly:
+
+```sh
+gate-keeper compile rules.md > rules.json
+gate-keeper validate --rules-format ir rules.json --target .
+```
+
+`--rules-format ir` parses the file with the strict `RuleSet.from_dict`
+loader and **bypasses the classifier**, so hand-authored `kind`,
+`backend_hint`, and `params` (notably `params.tool` for the `external`
+backend) survive into the validator. See
+[docs/cli-reference.md#validate](cli-reference.md#validate) for the full
+flag reference and the IR-specific error table.
+
 ## Top-level shapes
 
 `compile` emits a `RuleSet`:

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from pathlib import Path
 
 from gate_keeper import __version__
 from gate_keeper.diagnostics import EXIT_OK, EXIT_USAGE
+from gate_keeper.models import RuleSet
 
 # Backend choices exposed by the registry (always includes auto).
 _BACKEND_CHOICES = ["auto", "filesystem", "github", "llm-rubric", "external"]
@@ -48,8 +50,26 @@ def build_parser() -> argparse.ArgumentParser:
         "validate",
         help="validate an artifact against a rule document",
     )
-    validate_parser.add_argument("rules", help="path to a rule document")
+    validate_parser.add_argument(
+        "rules",
+        help=(
+            "path to the rule input; interpreted as Markdown by default, or as "
+            "Rule IR JSON when --rules-format ir is given"
+        ),
+    )
     validate_parser.add_argument("--target", required=True, help="artifact or PR to validate")
+    validate_parser.add_argument(
+        "--rules-format",
+        dest="rules_format",
+        choices=["markdown", "ir"],
+        default="markdown",
+        help=(
+            "format of the rules argument (default: markdown). 'ir' loads a "
+            "precompiled RuleSet JSON file; the strict IR parser is used and the "
+            "classifier is bypassed so hand-authored kind/backend_hint/params are "
+            "preserved."
+        ),
+    )
     validate_parser.add_argument(
         "--backend",
         choices=_BACKEND_CHOICES,
@@ -123,8 +143,6 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _cmd_compile(args: argparse.Namespace) -> int:
-    from pathlib import Path
-
     from gate_keeper import classifier, parser
 
     path = Path(args.document)
@@ -150,8 +168,6 @@ def _cmd_compile(args: argparse.Namespace) -> int:
 
 
 def _cmd_explain(args: argparse.Namespace) -> int:
-    from pathlib import Path
-
     from gate_keeper import classifier, parser
     from gate_keeper.diagnostics import render_explain_text
 
@@ -179,10 +195,65 @@ def _cmd_explain(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
-def _cmd_validate(args: argparse.Namespace) -> int:
-    from pathlib import Path
+def _load_markdown_ruleset(path: Path) -> RuleSet | int:
+    """Load a Markdown rule document and return a classified RuleSet.
 
-    from gate_keeper import classifier, parser, validator
+    Returns ``EXIT_USAGE`` (int) on read errors so the caller can propagate
+    the exit code without raising. Reads the file, parses it via
+    ``gate_keeper.parser.parse``, and runs the classifier — this is the
+    historical Markdown path.
+    """
+    from gate_keeper import classifier, parser
+
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"error: {path}: {exc.strerror}", file=sys.stderr)
+        return EXIT_USAGE
+    except UnicodeDecodeError as exc:
+        print(f"error: {path}: not valid UTF-8 ({exc.reason})", file=sys.stderr)
+        return EXIT_USAGE
+
+    ruleset = parser.parse(str(path), content)
+    ruleset = classifier.classify(ruleset)
+    return ruleset
+
+
+def _load_ir_ruleset(path: Path) -> RuleSet | int:
+    """Load a precompiled Rule IR JSON file via the strict RuleSet parser.
+
+    The classifier is intentionally **not** invoked: hand-authored ``kind``,
+    ``backend_hint``, and ``params`` fields must reach the validator
+    unchanged (see issue #144). Errors map to ``EXIT_USAGE`` with a
+    diagnostic that names the path and the parse/validation reason.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"error: {path}: {exc.strerror}", file=sys.stderr)
+        return EXIT_USAGE
+    except UnicodeDecodeError as exc:
+        print(f"error: {path}: not valid UTF-8 ({exc.reason})", file=sys.stderr)
+        return EXIT_USAGE
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(
+            f"error: {path}: invalid JSON ({exc.msg} at line {exc.lineno} column {exc.colno})",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+
+    try:
+        return RuleSet.from_dict(data)
+    except ValueError as exc:
+        print(f"error: {path}: invalid rule IR ({exc})", file=sys.stderr)
+        return EXIT_USAGE
+
+
+def _cmd_validate(args: argparse.Namespace) -> int:
+    from gate_keeper import validator
     from gate_keeper.backends import is_registered
     from gate_keeper.diagnostics import compute_exit_code, render_json, render_text
 
@@ -198,17 +269,14 @@ def _cmd_validate(args: argparse.Namespace) -> int:
         print(f"error: {args.rules}: No such file or directory", file=sys.stderr)
         return EXIT_USAGE
 
-    try:
-        content = doc_path.read_text(encoding="utf-8")
-    except OSError as exc:
-        print(f"error: {args.rules}: {exc.strerror}", file=sys.stderr)
-        return EXIT_USAGE
-    except UnicodeDecodeError as exc:
-        print(f"error: {args.rules}: not valid UTF-8 ({exc.reason})", file=sys.stderr)
-        return EXIT_USAGE
-
-    ruleset = parser.parse(str(doc_path), content)
-    ruleset = classifier.classify(ruleset)
+    rules_format = getattr(args, "rules_format", "markdown")
+    if rules_format == "ir":
+        loaded = _load_ir_ruleset(doc_path)
+    else:
+        loaded = _load_markdown_ruleset(doc_path)
+    if isinstance(loaded, int):
+        return loaded
+    ruleset = loaded
 
     # Validate reproducibility argument.
     if args.reproducibility < 1:
@@ -315,8 +383,6 @@ def _cmd_bench(args: argparse.Namespace) -> int:
     stored baseline JSON document. The framework lands here in #130; the
     canonical baseline file is added by the follow-up issue (#132).
     """
-    from pathlib import Path
-
     from gate_keeper import bench as _bench
 
     entries_dir = Path(args.entries_dir)

--- a/tests/fixtures/ir/rule-external-textlint.json
+++ b/tests/fixtures/ir/rule-external-textlint.json
@@ -1,0 +1,21 @@
+{
+  "rules": [
+    {
+      "id": "prose-textlint",
+      "title": "Repository prose should be free of textlint findings.",
+      "source": {
+        "path": "docs/example-rules.md",
+        "line": 152,
+        "heading": "textlint prose quality"
+      },
+      "text": "Repository prose should be free of textlint findings.",
+      "kind": "external_check",
+      "severity": "warning",
+      "backend_hint": "external",
+      "confidence": "high",
+      "params": {
+        "tool": "textlint"
+      }
+    }
+  ]
+}

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -18,6 +18,9 @@ FAIL_DIR = LOCAL_FIXTURES / "fail"
 PASS_README = PASS_DIR / "README.md"
 # A minimal rules doc that produces exactly one file_exists rule.
 SIMPLE_RULES = Path(__file__).parent / "fixtures" / "validate" / "rules-file-exists.md"
+IR_FIXTURES = Path(__file__).parent / "fixtures" / "ir"
+IR_FILESYSTEM_RULES = IR_FIXTURES / "rule-filesystem-text-required.json"
+IR_TEXTLINT_RULES = IR_FIXTURES / "rule-external-textlint.json"
 
 
 # ---------------------------------------------------------------------------
@@ -671,3 +674,259 @@ class TestReproducibilityFlag:
                     assert 0.0 <= ev["data"]["score"] <= 1.0
         assert repro_count >= 1, "expected at least one reproducibility_score evidence in JSON output"
         assert rc == EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+# --rules-format flag (issue #144)
+# ---------------------------------------------------------------------------
+
+
+class TestRulesFormatMarkdownDefault:
+    """Without ``--rules-format`` the existing Markdown path is preserved."""
+
+    def test_default_format_is_markdown(self, capsys):
+        """Omitting --rules-format runs the Markdown loader (regression check)."""
+        rc = main(
+            [
+                "validate",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == EXIT_OK
+        captured = capsys.readouterr()
+        report = json.loads(captured.out)
+        assert report["diagnostics"], "markdown path should still produce diagnostics"
+
+    def test_explicit_markdown_format_matches_default(self, capsys):
+        """--rules-format markdown is accepted and equivalent to the default."""
+        rc = main(
+            [
+                "validate",
+                "--rules-format",
+                "markdown",
+                str(SIMPLE_RULES),
+                "--target",
+                str(PASS_README),
+                "--backend",
+                "filesystem",
+            ]
+        )
+        assert rc == EXIT_OK
+
+
+class TestRulesFormatIR:
+    """``--rules-format ir`` reads precompiled RuleSet JSON without re-classifying."""
+
+    def test_ir_filesystem_rule_validates_against_target(self, tmp_path, capsys):
+        """An IR file with a text_required filesystem rule validates end-to-end."""
+        # The IR fixture is a text_required rule with pattern "uv"; the
+        # filesystem backend expects --target to point at the file under
+        # test, so build a matching file under tmp_path.
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text("Run `uv sync` to install.\n", encoding="utf-8")
+
+        rc = main(
+            [
+                "validate",
+                "--rules-format",
+                "ir",
+                str(IR_FILESYSTEM_RULES),
+                "--target",
+                str(agents),
+                "--backend",
+                "filesystem",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == EXIT_OK
+        captured = capsys.readouterr()
+        report = json.loads(captured.out)
+        diagnostics = report["diagnostics"]
+        assert len(diagnostics) == 1
+        diag = diagnostics[0]
+        # IR-supplied rule_id must survive untouched (no re-classification).
+        assert diag["rule_id"] == "agents-md-must-mention-uv"
+        assert diag["backend"] == "filesystem"
+        assert diag["status"] == "pass"
+
+    def test_ir_loading_preserves_kind_backend_hint_and_params(self, monkeypatch):
+        """Regression: IR loading must not re-classify rules.
+
+        Hand-authored ``kind``, ``backend_hint``, and ``params`` must reach
+        the validator unchanged. We capture the RuleSet that
+        ``validator.validate`` is called with and assert each field matches
+        the on-disk IR fixture exactly.
+        """
+        from unittest.mock import MagicMock
+
+        from gate_keeper.cli import _load_ir_ruleset
+        from gate_keeper.models import (
+            Backend,
+            DiagnosticReport,
+            RuleKind,
+            RuleSet,
+        )
+
+        captured_rulesets: list[RuleSet] = []
+
+        def fake_validate(ruleset, target, *, backend, reproducibility):
+            captured_rulesets.append(ruleset)
+            return DiagnosticReport(diagnostics=[])
+
+        monkeypatch.setattr("gate_keeper.validator.validate", MagicMock(side_effect=fake_validate))
+
+        rc = main(
+            [
+                "validate",
+                "--rules-format",
+                "ir",
+                str(IR_TEXTLINT_RULES),
+                "--target",
+                ".",
+                "--backend",
+                "auto",
+            ]
+        )
+        # With no diagnostics the exit code is OK regardless of backend.
+        assert rc == EXIT_OK
+        assert len(captured_rulesets) == 1
+        ruleset = captured_rulesets[0]
+        assert len(ruleset.rules) == 1
+        rule = ruleset.rules[0]
+        # Confirm the exact fields the IR file declares — proves the
+        # classifier was bypassed.
+        assert rule.id == "prose-textlint"
+        assert rule.kind == RuleKind.EXTERNAL_CHECK
+        assert rule.backend_hint == Backend.EXTERNAL
+        assert rule.params == {"tool": "textlint"}
+
+        # Loader-level smoke check: the helper returns an equivalent
+        # RuleSet directly (and never raises through the classifier).
+        loaded = _load_ir_ruleset(IR_TEXTLINT_RULES)
+        assert isinstance(loaded, RuleSet)
+        assert loaded.rules[0].kind == RuleKind.EXTERNAL_CHECK
+        assert loaded.rules[0].backend_hint == Backend.EXTERNAL
+        assert loaded.rules[0].params == {"tool": "textlint"}
+
+    def test_ir_missing_file_exits_2(self, capsys):
+        rc = main(
+            [
+                "validate",
+                "--rules-format",
+                "ir",
+                "/nonexistent/rules.json",
+                "--target",
+                str(PASS_DIR),
+                "--backend",
+                "auto",
+            ]
+        )
+        assert rc == EXIT_USAGE
+        captured = capsys.readouterr()
+        assert "error:" in captured.err
+        assert "/nonexistent/rules.json" in captured.err
+
+    def test_ir_invalid_json_exits_2_with_path_and_reason(self, tmp_path, capsys):
+        bad = tmp_path / "rules.json"
+        bad.write_text("{ this is not json", encoding="utf-8")
+        rc = main(
+            [
+                "validate",
+                "--rules-format",
+                "ir",
+                str(bad),
+                "--target",
+                str(PASS_DIR),
+                "--backend",
+                "auto",
+            ]
+        )
+        assert rc == EXIT_USAGE
+        captured = capsys.readouterr()
+        assert "error:" in captured.err
+        assert str(bad) in captured.err
+        assert "invalid JSON" in captured.err
+
+    def test_ir_invalid_shape_exits_2_with_path_and_reason(self, tmp_path, capsys):
+        """JSON that fails strict RuleSet parsing exits 2 with a clear error."""
+        bad = tmp_path / "rules.json"
+        # Missing required "rules" key.
+        bad.write_text(json.dumps({"oops": []}), encoding="utf-8")
+        rc = main(
+            [
+                "validate",
+                "--rules-format",
+                "ir",
+                str(bad),
+                "--target",
+                str(PASS_DIR),
+                "--backend",
+                "auto",
+            ]
+        )
+        assert rc == EXIT_USAGE
+        captured = capsys.readouterr()
+        assert "error:" in captured.err
+        assert str(bad) in captured.err
+        assert "invalid rule IR" in captured.err
+
+    def test_ir_unknown_field_exits_2(self, tmp_path, capsys):
+        """Strict parser rejects unknown fields — must surface as exit 2."""
+        bad = tmp_path / "rules.json"
+        bad.write_text(
+            json.dumps(
+                {
+                    "rules": [
+                        {
+                            "id": "r1",
+                            "title": "t",
+                            "source": {"path": "x.md", "line": 1},
+                            "text": "t",
+                            "kind": "file_exists",
+                            "severity": "warning",
+                            "backend_hint": "filesystem",
+                            "confidence": "high",
+                            "params": {},
+                            "extra_unknown_field": "not allowed",
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        rc = main(
+            [
+                "validate",
+                "--rules-format",
+                "ir",
+                str(bad),
+                "--target",
+                str(PASS_DIR),
+                "--backend",
+                "auto",
+            ]
+        )
+        assert rc == EXIT_USAGE
+        captured = capsys.readouterr()
+        assert "invalid rule IR" in captured.err
+
+    def test_ir_unknown_format_value_rejected_by_argparse(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main(
+                [
+                    "validate",
+                    "--rules-format",
+                    "yaml",
+                    str(SIMPLE_RULES),
+                    "--target",
+                    str(PASS_README),
+                ]
+            )
+        assert exc_info.value.code == 2


### PR DESCRIPTION
## Summary

- Add `--rules-format {markdown,ir}` to `gate-keeper validate`. Default is `markdown` (existing behaviour); `ir` reads a precompiled `RuleSet` JSON file via the strict `RuleSet.from_dict` loader and **bypasses the classifier** so hand-authored `kind`, `backend_hint`, and `params` survive untouched.
- Factor the loader into `_load_markdown_ruleset` / `_load_ir_ruleset` helpers in `src/gate_keeper/cli.py`. All other `validate` flags (`--backend`, `--format`, `--verbose`, `--reproducibility`) are preserved.
- Errors exit `2` with path + reason: missing file, non-UTF-8, invalid JSON, and IR-shape failures (unknown fields, bad enums, etc.).
- Add `tests/fixtures/ir/rule-external-textlint.json` (kind: `external_check`, backend_hint: `external`, params.tool: `textlint`) and a regression test asserting the IR-supplied fields reach `validator.validate` unchanged.
- Update `docs/cli-reference.md`, `docs/rule-ir.md`, and the textlint walkthrough in `docs/example-rules.md`.

## Out of scope

Per the LITE_SPEC: no schema versioning, no multi-document composition, no recursive include, no IR relaxation, no auto-migration of Markdown examples, and no `--reclassify` flag.

## Test plan

- [x] `uv run pytest` (802 passed)
- [x] `uv run ruff check .` (clean)
- [x] `uv run ruff format --check .` (clean)
- [x] `uv run pyright` (0 errors)
- [x] `npx --no -- textlint docs/cli-reference.md docs/rule-ir.md docs/example-rules.md` (clean)
- [x] Manual smoke: `gate-keeper validate --rules-format ir tests/fixtures/ir/rule-external-textlint.json --target <file>` routes through the textlint adapter with `params.tool` preserved.

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)