### PR TITLE
feat(external): project-local command adapter (#149)

### DIFF
--- a/docs/backend-external.md
+++ b/docs/backend-external.md
@@ -104,6 +104,43 @@ These adapters ship with gate-keeper and self-register at CLI entry
     [`docs/textlint/severity-policy.md §7`](textlint/severity-policy.md) for
     the resolution of the §6 deferred adapter-implementation decision.
 
+- **command** — `src/gate_keeper/adapters/command.py` (#149)
+  - Disabled by default for security. Enable per-process with
+    `gate-keeper validate ... --allow-command-adapter`. The adapter
+    executes arbitrary local commands defined by the rule document, so
+    only enable for rule documents you fully trust. See the trust-model
+    callout in [`docs/cli-reference.md`](cli-reference.md) for the full
+    warning.
+  - Params: `tool="command"` (required); `argv` (required, non-empty
+    list of strings — shell strings rejected; `subprocess.run` runs with
+    `shell=False`); `timeout_seconds` (optional, default `30`, hard
+    maximum `300`).
+  - Input contract: the adapter passes a single JSON object to the
+    command on stdin:
+
+    ```json
+    { "rule": { "id": "...", "text": "...", "params": { ... } }, "target": "..." }
+    ```
+
+  - Output contract: the command must print a `Diagnostic` (or a
+    `DiagnosticReport` containing exactly one diagnostic) to stdout and
+    exit `0` for both pass and fail outcomes. The adapter overrides
+    `rule_id`, `source`, `severity`, and `backend` on the returned
+    Diagnostic so a misbehaving command cannot spoof another rule's
+    result.
+  - Adapter-specific Evidence kinds: `command_adapter_disabled` (default
+    state when the flag is not passed), `params_error`,
+    `command_failure` (non-zero exit), `parse_error` (malformed or
+    missing JSON output). Subprocess-level faults (binary missing /
+    timeout / OS error) produce the shared `cli_missing`, `cli_timeout`,
+    and `cli_os_error` evidence kinds via `failure_diag`.
+  - Status mapping: adapter disabled → `unavailable` /
+    `command_adapter_disabled`; non-zero exit → `unavailable` /
+    `command_failure`; missing executable → `unavailable` / `cli_missing`;
+    timeout → `error` / `cli_timeout`; OS error → `error` / `cli_os_error`;
+    malformed stdout → `unavailable` / `parse_error`; otherwise the
+    parsed Diagnostic status from the command (typically `pass` or `fail`).
+
 ## Out of scope for the foundation
 
 - Concrete adapter implementations (textlint, vale, …).

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -182,6 +182,7 @@ gate-keeper validate [--rules-format {markdown,ir}]
                      [--backend {auto,filesystem,github,llm-rubric,external}]
                      [--format {text,json}] [--verbose]
                      [--reproducibility N]
+                     [--allow-command-adapter]
                      --target <TARGET> [--target <TARGET> ...]
                      (<rules> | --include GLOB [--include GLOB ...])
 ```
@@ -201,6 +202,7 @@ Provide either a single positional `rules` document **or** one or more
 | `--format {text,json}` | option | `text` | Output format. |
 | `--verbose, -v` | flag | off | Expand structured LLM-rubric rationale (judgment, reason, evidence quotes, suggested action, model) as indented lines below each diagnostic. Has no effect for non-LLM backends. |
 | `--reproducibility N` | option | `1` | Run each LLM-rubric rule N times and record an agreement-rate `reproducibility_score` evidence entry. **No-op for non-LLM backends** (filesystem, GitHub, external ignore this flag). |
+| `--allow-command-adapter` | flag | off | Enable the project-local `command` external adapter for this run only. **Security: pass this only for rule documents you fully trust** — the adapter executes whatever `params.argv` the rule document defines. Without this flag, every `external_check` rule whose `params.tool == "command"` returns `unavailable` / `command_adapter_disabled` and no subprocess runs. See [Project-local `command` adapter (#149)](#project-local-command-adapter-149) below. |
 | `-h, --help` | flag | — | Show help and exit. |
 
 ### When to use `--rules-format ir`
@@ -390,6 +392,64 @@ of the resolved paths.
 
 See [docs/design/multi-target.md](design/multi-target.md) for the design
 background; this section documents the first implemented slice.
+
+### Project-local `command` adapter (#149)
+
+The `command` external adapter lets a trusted local rule document delegate a
+check to a project-local executable. It runs only when `--allow-command-adapter`
+is passed; otherwise every `external_check` rule with `params.tool == "command"`
+returns `unavailable` and no subprocess is spawned.
+
+> **Trust model — read this before passing the flag.**
+>
+> The rule document supplies `params.argv` (a list of strings). The adapter
+> spawns that command directly (no shell), so passing
+> `--allow-command-adapter` against a rule document you do not fully trust is
+> a remote-code-execution vector equivalent to running the document's argv
+> by hand. Never pass this flag against rule documents fetched from the
+> network or authored by an untrusted party.
+
+**Required IR shape (rule excerpt):**
+
+```json
+{
+  "kind": "external_check",
+  "backend_hint": "external",
+  "params": {
+    "tool": "command",
+    "argv": ["python", "tools/policy/validate_path_policy.py"],
+    "timeout_seconds": 30
+  }
+}
+```
+
+**Behaviour:**
+
+- `argv` must be a non-empty list of strings; shell strings are rejected.
+- `subprocess.run` is invoked with `shell=False` — no shell expansion,
+  globbing, or environment-variable interpolation into argv.
+- The adapter writes a JSON object to the command's stdin:
+
+  ```json
+  {
+    "rule": { "id": "...", "text": "...", "params": { "tool": "command", "argv": [...] } },
+    "target": "..."
+  }
+  ```
+
+- The command must print a single Diagnostic JSON object (or a
+  `DiagnosticReport` with exactly one diagnostic) to stdout and exit `0`
+  for both pass and fail outcomes. Any non-zero exit is treated as a
+  fail-closed `unavailable` / `command_failure` diagnostic.
+- `timeout_seconds` defaults to `30`, hard maximum `300`. Timeouts
+  produce `error` / `cli_timeout`. Missing executables produce
+  `unavailable` / `cli_missing`.
+- The adapter is the source of truth for `rule_id`, `source`, `severity`,
+  and `backend` on the returned Diagnostic — a misbehaving command cannot
+  rebrand another rule's result.
+
+See [`docs/backend-external.md`](backend-external.md) for the full adapter
+contract and full set of evidence kinds.
 
 ---
 

--- a/docs/example-rules.md
+++ b/docs/example-rules.md
@@ -364,3 +364,79 @@ overrides would be dropped.
 - Run `npx --no textlint --fix <file>` to apply auto-fixable corrections.
 - See `docs/backend-external.md` for the full adapter contract and
   `docs/cli-reference.md#validate` for the `--rules-format` flag reference.
+
+---
+
+## 8. Project-local validator script — `external / external_check` (`tool=command`)
+
+The `command` external adapter delegates a check to a project-local
+executable. The rule document supplies `params.argv`; the adapter spawns
+that command directly (no shell), passes a JSON `{rule, target}` object on
+stdin, and parses a Diagnostic from stdout.
+
+> **Security:** disabled by default. Pass `--allow-command-adapter` ONLY
+> for rule documents you fully trust — the rule document supplies the
+> argv. See the trust-model callout in `docs/cli-reference.md`.
+
+**Compiled rule (JSON excerpt):**
+
+```json
+{
+  "rules": [{
+    "id": "policy-path-allowlist",
+    "text": "Repository paths must satisfy the project's path-allowlist policy.",
+    "kind": "external_check",
+    "severity": "error",
+    "backend_hint": "external",
+    "params": {
+      "tool": "command",
+      "argv": ["python", "tools/policy/validate_path_policy.py"],
+      "timeout_seconds": 30
+    }
+  }]
+}
+```
+
+**Sample command (`tools/policy/validate_path_policy.py`):**
+
+```python
+#!/usr/bin/env python3
+import json, sys
+payload = json.loads(sys.stdin.read())
+target = payload["target"]
+# project-specific check ...
+ok = True
+print(json.dumps({
+    "status": "pass" if ok else "fail",
+    "message": f"path policy {'satisfied' if ok else 'violated'} for {target}",
+    "evidence": [{"kind": "policy_check", "data": {"target": target}}],
+}))
+sys.exit(0)  # exit 0 on both pass and fail
+```
+
+**Sample run (disabled by default):**
+
+```
+$ gate-keeper validate rules.md --target .
+rules.md:3: error: [external/unavailable] policy-path-allowlist: command adapter is disabled by default for security; pass --allow-command-adapter to enable it for trusted rule documents
+```
+
+**Sample run (explicitly enabled):**
+
+```
+$ gate-keeper validate rules.md --target . --allow-command-adapter
+rules.md:3: error: [external/pass] policy-path-allowlist: path policy satisfied for .
+```
+
+**Notes:**
+
+- `argv` is required and must be a non-empty list of strings. Shell strings
+  (e.g. `"python tools/check.py"`) are rejected.
+- `timeout_seconds` defaults to `30`, hard maximum `300`. Timeouts produce
+  `error` / `cli_timeout`.
+- The command must print exactly one Diagnostic JSON to stdout and exit `0`
+  for both pass and fail. Any non-zero exit collapses to
+  `unavailable` / `command_failure` regardless of stdout content — that
+  channel is reserved for adapter-detected faults.
+- See `docs/backend-external.md` and `docs/cli-reference.md` for the full
+  contract.

--- a/docs/rule-ir.md
+++ b/docs/rule-ir.md
@@ -131,6 +131,8 @@ backend rather than minting new `Backend` enum values; see
 | `markdown_evidence_block` | `format` | _(required)_ | Format of the fenced block. Currently only `"yaml"` is supported. Other values → `unsupported`. |
 | `markdown_evidence_block` | `required_keys` | _(required)_ | Non-empty list of dotted-key strings (e.g. `"policy.bundle"`). Each must resolve through nested mappings. Missing or empty → `unavailable`. |
 | `markdown_evidence_block` | `allowed_sentinel_values` | `[]` | Optional list of allowed lowercase-token sentinel values (e.g. `["not_applicable", "missing_blocker"]`). When non-empty, any string leaf at a required key that matches the sentinel-token shape `^[a-z][a-z0-9_]*$` must appear in this list; free-form strings (with spaces, hyphens, mixed case, slashes) are not validated. |
+| `external_check` (`tool=command`) | `argv` | _(required)_ | Non-empty list of strings. The first element is the executable; remaining elements are arguments. Shell strings (a single string with spaces) are rejected. The adapter never invokes a shell. |
+| `external_check` (`tool=command`) | `timeout_seconds` | `30` | Subprocess timeout in seconds. Must satisfy `0 < timeout_seconds <= 300`. Timeouts produce `error` / `cli_timeout` diagnostics. |
 
 ## `markdown_evidence_block` — structured policy evidence
 

--- a/src/gate_keeper/adapters/command.py
+++ b/src/gate_keeper/adapters/command.py
@@ -1,0 +1,595 @@
+"""Generic project-local ``command`` external adapter (#149).
+
+Lets a trusted local rule document delegate a check to a project-local
+executable. The adapter passes the rule and target to the command as a
+JSON object on stdin and parses a single ``Diagnostic`` from stdout.
+
+Trust model
+-----------
+This adapter executes arbitrary local commands. It is disabled by default;
+the CLI flag ``--allow-command-adapter`` enables it for the current process
+only. Without the flag, every ``external_check`` rule whose
+``params.tool == "command"`` returns ``Status.UNAVAILABLE`` with a
+``command_adapter_disabled`` evidence record. Documentation MUST warn that
+running this flag against an untrusted rule document is a remote-code-
+execution vector — the rule document supplies the argv.
+
+Security constraints
+--------------------
+- ``argv`` is a non-empty list of strings; shell strings are rejected.
+- ``subprocess.run`` is invoked with ``shell=False`` (via
+  ``backends._cli.run_cli``); no shell expansion or globbing is performed.
+- No ``argv`` element is ever passed through string formatting,
+  ``os.path.expandvars``, or ``os.path.expanduser``.
+- Target is forwarded only via stdin JSON (and never via shell
+  interpolation or environment substitution into ``argv``).
+- A timeout (default 30s, hard maximum 300s) bounds runtime; expiry
+  produces a fail-closed ``Diagnostic`` and the OS kills the subprocess
+  via ``subprocess.run``'s timeout machinery.
+- ``stderr`` is truncated in evidence to bounded size for forensic use.
+
+Output contract
+---------------
+The command must emit exactly one of the following JSON shapes on stdout:
+
+- a ``Diagnostic`` object (single rule result), OR
+- a ``DiagnosticReport`` with one diagnostic in its ``diagnostics`` array.
+
+Either way the adapter:
+
+- echoes ``rule.id``, ``rule.source``, and ``rule.severity`` from the
+  input rule onto whatever the command produced (the command's own copies
+  of those fields are ignored — the adapter is the source of truth);
+- forces ``backend == external``.
+
+Malformed JSON, an output that does not match the expected diagnostic
+shape, or a status outside the allowed enum produces an
+``unavailable`` / ``parse_error`` diagnostic.
+
+See ``docs/backend-external.md`` and the security-warning callout in
+``docs/cli-reference.md`` for the user-facing contract.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+from typing import Any
+
+from gate_keeper.backends._cli import (
+    CliFault as _CliFault,
+)
+from gate_keeper.backends._cli import (
+    classify_cli_failure,
+    cli_missing_diag,
+    cli_os_error_diag,
+    cli_timeout_diag,
+    run_cli,
+)
+from gate_keeper.models import (
+    Backend,
+    Diagnostic,
+    Evidence,
+    Rule,
+    Status,
+)
+
+#: Default subprocess timeout (seconds) when ``params.timeout_seconds`` is unset.
+DEFAULT_TIMEOUT_SECONDS = 30
+#: Hard upper bound on ``params.timeout_seconds`` (seconds).
+MAX_TIMEOUT_SECONDS = 300
+
+#: Cap on stderr characters retained in evidence to keep diagnostics bounded.
+_STDERR_EXCERPT_LIMIT = 1000
+
+# ---------------------------------------------------------------------------
+# Process-local enable flag
+# ---------------------------------------------------------------------------
+#
+# The flag is stored in a one-element mutable list rather than a plain module
+# attribute so callers can use ``contextlib.contextmanager`` patterns and so
+# tests can ``snapshot`` / ``restore`` predictably without monkeypatching the
+# module attribute (which can collide with reload / re-import semantics).
+
+_ENABLED: list[bool] = [False]
+
+
+def is_enabled() -> bool:
+    """Return whether the ``command`` adapter is allowed to spawn subprocesses."""
+    return _ENABLED[0]
+
+
+def set_enabled(value: bool) -> None:
+    """Set the process-local enable flag. CLI use only."""
+    _ENABLED[0] = bool(value)
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic helpers
+# ---------------------------------------------------------------------------
+
+
+def _diag(
+    rule: Rule,
+    status: Status,
+    message: str,
+    evidence: list[Evidence],
+    remediation: str | None = None,
+) -> Diagnostic:
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=Backend.EXTERNAL,
+        status=status,
+        severity=rule.severity,
+        message=message,
+        evidence=evidence,
+        remediation=remediation,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Param validation
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class _Params:
+    argv: list[str]
+    timeout_seconds: float
+
+
+def _validate_params(rule: Rule) -> _Params | Diagnostic:
+    """Return parsed params or a fail-closed ``Diagnostic`` with the reason."""
+    raw_argv = rule.params.get("argv")
+    if raw_argv is None:
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            "command adapter requires params.argv (non-empty list of strings)",
+            [Evidence(kind="params_error", data={"missing": "argv"})],
+            remediation=(
+                'Set params.argv to a non-empty list of strings, e.g. ["python", "tools/policy/check.py"].'
+            ),
+        )
+    if not isinstance(raw_argv, list):
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            "command adapter requires params.argv to be a list of strings (no shell strings)",
+            [
+                Evidence(
+                    kind="params_error",
+                    data={"field": "argv", "type": type(raw_argv).__name__},
+                )
+            ],
+            remediation=(
+                "Replace any shell-string argv with a list, e.g. "
+                '["python", "tools/check.py"]; shell strings are not supported.'
+            ),
+        )
+    if not raw_argv:
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            "command adapter requires params.argv to be a non-empty list",
+            [Evidence(kind="params_error", data={"field": "argv", "reason": "empty"})],
+            remediation=("Provide at least the executable as the first argv element."),
+        )
+    for index, item in enumerate(raw_argv):
+        if not isinstance(item, str):
+            return _diag(
+                rule,
+                Status.UNAVAILABLE,
+                "command adapter requires every argv element to be a string",
+                [
+                    Evidence(
+                        kind="params_error",
+                        data={
+                            "field": "argv",
+                            "index": index,
+                            "type": type(item).__name__,
+                        },
+                    )
+                ],
+                remediation=(
+                    "Argv elements must be strings; coerce numeric / path "
+                    "values to str at rule-authoring time."
+                ),
+            )
+
+    raw_timeout = rule.params.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
+    if isinstance(raw_timeout, bool) or not isinstance(raw_timeout, (int, float)):
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            "command adapter requires params.timeout_seconds to be a positive number",
+            [
+                Evidence(
+                    kind="params_error",
+                    data={
+                        "field": "timeout_seconds",
+                        "type": type(raw_timeout).__name__,
+                    },
+                )
+            ],
+        )
+    timeout_value = float(raw_timeout)
+    if not (0 < timeout_value <= MAX_TIMEOUT_SECONDS):
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            (f"command adapter requires 0 < params.timeout_seconds <= {MAX_TIMEOUT_SECONDS}"),
+            [
+                Evidence(
+                    kind="params_error",
+                    data={
+                        "field": "timeout_seconds",
+                        "value": timeout_value,
+                        "max": MAX_TIMEOUT_SECONDS,
+                    },
+                )
+            ],
+        )
+
+    return _Params(argv=list(raw_argv), timeout_seconds=timeout_value)
+
+
+# ---------------------------------------------------------------------------
+# Output parsing
+# ---------------------------------------------------------------------------
+
+_ALLOWED_STATUS_VALUES = frozenset(s.value for s in Status)
+
+
+def _stderr_excerpt(stderr: str) -> str:
+    if len(stderr) <= _STDERR_EXCERPT_LIMIT:
+        return stderr
+    return stderr[:_STDERR_EXCERPT_LIMIT] + "…"
+
+
+def _parse_output(
+    rule: Rule,
+    stdout: str,
+    stderr: str,
+) -> Diagnostic:
+    """Parse *stdout* into a Diagnostic, or return a fail-closed parse_error.
+
+    Accepts either a single ``Diagnostic`` JSON object or a
+    ``DiagnosticReport`` containing exactly one diagnostic. The adapter
+    overwrites ``rule_id``, ``source``, ``severity``, and ``backend`` from
+    the input rule so a misbehaving command cannot spoof another rule.
+    """
+    if not stdout.strip():
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            "command adapter received empty stdout from the project-local command",
+            [
+                Evidence(
+                    kind="parse_error",
+                    data={
+                        "reason": "empty_stdout",
+                        "stderr_excerpt": _stderr_excerpt(stderr),
+                    },
+                )
+            ],
+        )
+
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            "command adapter could not parse stdout as JSON",
+            [
+                Evidence(
+                    kind="parse_error",
+                    data={
+                        "reason": "json_decode_error",
+                        "error": str(exc),
+                        "stdout_excerpt": stdout[:300],
+                        "stderr_excerpt": _stderr_excerpt(stderr),
+                    },
+                )
+            ],
+        )
+
+    if not isinstance(payload, dict):
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            "command adapter expected a JSON object on stdout (Diagnostic or DiagnosticReport)",
+            [
+                Evidence(
+                    kind="parse_error",
+                    data={
+                        "reason": "non_object_top_level",
+                        "type": type(payload).__name__,
+                    },
+                )
+            ],
+        )
+
+    diagnostic_payload: Any = payload
+    if "diagnostics" in payload and "status" not in payload:
+        diagnostics = payload.get("diagnostics")
+        if not isinstance(diagnostics, list) or len(diagnostics) != 1:
+            return _diag(
+                rule,
+                Status.UNAVAILABLE,
+                "command adapter expected exactly one diagnostic in DiagnosticReport.diagnostics",
+                [
+                    Evidence(
+                        kind="parse_error",
+                        data={
+                            "reason": "diagnostic_count",
+                            "count": len(diagnostics) if isinstance(diagnostics, list) else None,
+                        },
+                    )
+                ],
+            )
+        diagnostic_payload = diagnostics[0]
+
+    if not isinstance(diagnostic_payload, dict):
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            "command adapter expected a Diagnostic object",
+            [
+                Evidence(
+                    kind="parse_error",
+                    data={
+                        "reason": "non_object_diagnostic",
+                        "type": type(diagnostic_payload).__name__,
+                    },
+                )
+            ],
+        )
+
+    raw_status = diagnostic_payload.get("status")
+    if raw_status not in _ALLOWED_STATUS_VALUES:
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            "command adapter received an invalid or missing diagnostic status",
+            [
+                Evidence(
+                    kind="parse_error",
+                    data={
+                        "reason": "invalid_status",
+                        "status": raw_status,
+                        "allowed": sorted(_ALLOWED_STATUS_VALUES),
+                    },
+                )
+            ],
+        )
+
+    raw_message = diagnostic_payload.get("message")
+    if not isinstance(raw_message, str):
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            "command adapter requires diagnostic.message to be a string",
+            [
+                Evidence(
+                    kind="parse_error",
+                    data={
+                        "reason": "invalid_message",
+                        "type": type(raw_message).__name__,
+                    },
+                )
+            ],
+        )
+
+    raw_evidence = diagnostic_payload.get("evidence", [])
+    parsed_evidence: list[Evidence] = []
+    if isinstance(raw_evidence, list):
+        for index, item in enumerate(raw_evidence):
+            if not isinstance(item, dict):
+                return _diag(
+                    rule,
+                    Status.UNAVAILABLE,
+                    "command adapter requires each evidence entry to be an object",
+                    [
+                        Evidence(
+                            kind="parse_error",
+                            data={
+                                "reason": "invalid_evidence_item",
+                                "index": index,
+                                "type": type(item).__name__,
+                            },
+                        )
+                    ],
+                )
+            kind = item.get("kind")
+            data = item.get("data", {})
+            if not isinstance(kind, str) or not kind:
+                return _diag(
+                    rule,
+                    Status.UNAVAILABLE,
+                    "command adapter requires each evidence.kind to be a non-empty string",
+                    [
+                        Evidence(
+                            kind="parse_error",
+                            data={
+                                "reason": "invalid_evidence_kind",
+                                "index": index,
+                            },
+                        )
+                    ],
+                )
+            if not isinstance(data, dict):
+                return _diag(
+                    rule,
+                    Status.UNAVAILABLE,
+                    "command adapter requires each evidence.data to be an object",
+                    [
+                        Evidence(
+                            kind="parse_error",
+                            data={
+                                "reason": "invalid_evidence_data",
+                                "index": index,
+                                "type": type(data).__name__,
+                            },
+                        )
+                    ],
+                )
+            parsed_evidence.append(Evidence(kind=kind, data=dict(data)))
+    else:
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            "command adapter requires diagnostic.evidence to be a list",
+            [
+                Evidence(
+                    kind="parse_error",
+                    data={
+                        "reason": "invalid_evidence_list",
+                        "type": type(raw_evidence).__name__,
+                    },
+                )
+            ],
+        )
+
+    raw_remediation = diagnostic_payload.get("remediation")
+    if raw_remediation is not None and not isinstance(raw_remediation, str):
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            "command adapter requires diagnostic.remediation to be a string or null",
+            [
+                Evidence(
+                    kind="parse_error",
+                    data={
+                        "reason": "invalid_remediation",
+                        "type": type(raw_remediation).__name__,
+                    },
+                )
+            ],
+        )
+
+    # Adapter is the source of truth for rule_id / source / severity / backend;
+    # untrusted output cannot rebrand someone else's rule.
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=Backend.EXTERNAL,
+        status=Status(raw_status),
+        severity=rule.severity,
+        message=raw_message,
+        evidence=parsed_evidence,
+        remediation=raw_remediation,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class CommandAdapter:
+    """Run a project-local command and parse its JSON Diagnostic from stdout.
+
+    See module docstring for the trust model and contract.
+    """
+
+    name = "command"
+
+    def check(self, rule: Rule, target: str | Path) -> Diagnostic:
+        if not is_enabled():
+            return _diag(
+                rule,
+                Status.UNAVAILABLE,
+                (
+                    "command adapter is disabled by default for security; pass "
+                    "--allow-command-adapter to enable it for trusted rule documents"
+                ),
+                [
+                    Evidence(
+                        kind="command_adapter_disabled",
+                        data={"flag": "--allow-command-adapter"},
+                    )
+                ],
+                remediation=(
+                    "Pass --allow-command-adapter ONLY when validating with a "
+                    "rule document you fully trust. The command adapter executes "
+                    "arbitrary local commands defined by the rule document."
+                ),
+            )
+
+        params_or_diag = _validate_params(rule)
+        if isinstance(params_or_diag, Diagnostic):
+            return params_or_diag
+        params = params_or_diag
+
+        target_str = str(target)
+        stdin_payload = json.dumps(
+            {
+                "rule": {
+                    "id": rule.id,
+                    "text": rule.text,
+                    "params": dict(rule.params),
+                },
+                "target": target_str,
+            },
+            sort_keys=True,
+        )
+
+        executable = params.argv[0]
+        rest = params.argv[1:]
+        result = run_cli(
+            executable,
+            rest,
+            input=stdin_payload,
+            timeout=params.timeout_seconds,
+        )
+
+        # Sub-process-level failures (binary missing / timeout / OS error) are
+        # mapped to the shared cli_* diagnostic vocabulary. A non-zero exit is
+        # a strict, fail-closed signal in this adapter — the contract says the
+        # command must emit a JSON diagnostic on stdout regardless of pass/fail
+        # outcome, so non-zero exit means the command itself faulted.
+        if not result.ok:
+            fault = classify_cli_failure(result)
+            if fault is _CliFault.MISSING:
+                return cli_missing_diag(rule, Backend.EXTERNAL, executable)
+            if fault is _CliFault.TIMEOUT:
+                return cli_timeout_diag(rule, Backend.EXTERNAL, "command", result)
+            if fault is _CliFault.OS_ERROR:
+                return cli_os_error_diag(rule, Backend.EXTERNAL, "command", result)
+            # NONZERO_EXIT: surface stderr excerpt for debugging.
+            return _diag(
+                rule,
+                Status.UNAVAILABLE,
+                f"command adapter subprocess exited non-zero ({result.returncode})",
+                [
+                    Evidence(
+                        kind="command_failure",
+                        data={
+                            "executable": executable,
+                            "returncode": result.returncode,
+                            "stderr_excerpt": _stderr_excerpt(result.stderr),
+                            "stdout_excerpt": result.stdout[:300],
+                        },
+                    )
+                ],
+                remediation=(
+                    "The project-local command must emit a Diagnostic JSON on "
+                    "stdout and exit zero on both pass and fail. Investigate the "
+                    "stderr excerpt and rerun once the command is healthy."
+                ),
+            )
+
+        return _parse_output(rule, result.stdout or "", result.stderr or "")
+
+
+__all__ = [
+    "CommandAdapter",
+    "DEFAULT_TIMEOUT_SECONDS",
+    "MAX_TIMEOUT_SECONDS",
+    "is_enabled",
+    "set_enabled",
+]

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -262,6 +262,16 @@ def build_parser() -> argparse.ArgumentParser:
             "ignore this flag)"
         ),
     )
+    validate_parser.add_argument(
+        "--allow-command-adapter",
+        action="store_true",
+        default=False,
+        help=(
+            "enable the project-local 'command' external adapter for this run. "
+            "WARNING: this lets the rule document execute arbitrary local commands "
+            "(via params.argv). Pass this ONLY for rule documents you fully trust."
+        ),
+    )
 
     subparsers.add_parser(
         "diagnose",
@@ -565,8 +575,18 @@ def _cmd_validate(args: argparse.Namespace) -> int:
             print(f"error: --target: {exc}", file=sys.stderr)
             return EXIT_USAGE
 
-    # Run validation.
-    report = validator.validate(ruleset, target, backend=backend, reproducibility=args.reproducibility)
+    # Toggle the project-local command adapter for this process only. The flag
+    # is intentionally not propagated through the validator API — the adapter
+    # owns its own enable state to keep the trust boundary obvious.
+    from gate_keeper.adapters import command as command_adapter
+
+    previous_enabled = command_adapter.is_enabled()
+    command_adapter.set_enabled(bool(args.allow_command_adapter))
+    try:
+        # Run validation.
+        report = validator.validate(ruleset, target, backend=backend, reproducibility=args.reproducibility)
+    finally:
+        command_adapter.set_enabled(previous_enabled)
 
     # Render output.
     if args.format == "json":
@@ -718,15 +738,22 @@ def _register_default_adapters() -> None:
     Registration happens lazily at CLI entry rather than at module-import time
     of ``gate_keeper.adapters`` so test isolation in ``tests/test_external_backend.py``
     is preserved (those tests snapshot/restore an empty registry per test).
+
+    The ``command`` adapter is registered here, but is gated behind the
+    process-local enable flag in ``gate_keeper.adapters.command``. Without
+    ``--allow-command-adapter`` it returns ``unavailable`` and never spawns
+    a subprocess; see ``docs/cli-reference.md`` for the trust model.
     """
+    from gate_keeper.adapters.command import CommandAdapter
     from gate_keeper.adapters.textlint import TextlintAdapter
     from gate_keeper.backends import external
 
-    try:
-        external.register(TextlintAdapter())
-    except ValueError:
-        # Already registered (e.g. main called twice in the same process).
-        pass
+    for adapter in (TextlintAdapter(), CommandAdapter()):
+        try:
+            external.register(adapter)
+        except ValueError:
+            # Already registered (e.g. main called twice in the same process).
+            pass
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/fixtures/command/fail_command.py
+++ b/tests/fixtures/command/fail_command.py
@@ -1,0 +1,29 @@
+"""Fixture command: reads stdin JSON, prints a FAIL Diagnostic, exits non-zero.
+
+Tests the strict contract that any non-zero exit collapses to UNAVAILABLE
+even if the stdout would have parsed cleanly.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main() -> int:
+    sys.stdin.read()
+    diagnostic = {
+        "status": "fail",
+        "message": "fixture command reports a violation",
+        "evidence": [
+            {"kind": "fixture_fail", "data": {"reason": "test"}},
+        ],
+        "remediation": "fix the violation",
+    }
+    sys.stdout.write(json.dumps(diagnostic))
+    sys.stderr.write("fixture command exiting non-zero on purpose\n")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/command/fail_status_command.py
+++ b/tests/fixtures/command/fail_status_command.py
@@ -1,0 +1,30 @@
+"""Fixture command: prints a FAIL Diagnostic and exits 0.
+
+The contract says: emit JSON Diagnostic on stdout, exit 0 even on fail.
+This fixture lets the adapter return a real ``Status.FAIL`` Diagnostic via
+the parsed-output path.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main() -> int:
+    payload = json.loads(sys.stdin.read())
+    rule = payload.get("rule", {})
+    diagnostic = {
+        "status": "fail",
+        "message": f"rule {rule.get('id', '?')} failed in fixture",
+        "evidence": [
+            {"kind": "fixture_fail", "data": {"rule_id": rule.get("id")}},
+        ],
+        "remediation": "edit the artifact to satisfy the rule",
+    }
+    sys.stdout.write(json.dumps(diagnostic))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/command/pass_command.py
+++ b/tests/fixtures/command/pass_command.py
@@ -1,0 +1,29 @@
+"""Fixture command: reads stdin JSON, prints a PASS Diagnostic.
+
+Used by ``tests/test_command_adapter.py`` end-to-end test that exercises a
+real subprocess. Always exits 0 regardless of pass/fail outcome — the
+command adapter contract requires a JSON Diagnostic on stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main() -> int:
+    payload = json.loads(sys.stdin.read())
+    target = payload.get("target", "")
+    diagnostic = {
+        "status": "pass",
+        "message": f"fixture command saw target={target}",
+        "evidence": [
+            {"kind": "fixture_pass", "data": {"echo_target": target}},
+        ],
+    }
+    sys.stdout.write(json.dumps(diagnostic))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_command_adapter.py
+++ b/tests/test_command_adapter.py
@@ -1,0 +1,565 @@
+"""Tests for ``CommandAdapter`` (#149).
+
+The command adapter executes project-local commands, so the trust model
+matters. These tests pin:
+
+- disabled-by-default unavailability (no subprocess spawned);
+- enabled-then-pass with stdin JSON contract;
+- enabled-then-fail (non-zero exit is fail-closed);
+- enabled-then-fail (zero exit + Status.FAIL JSON);
+- invalid params (argv missing / wrong shape / non-string element /
+  shell-string rejection / timeout out of range);
+- command-not-found (binary missing);
+- malformed JSON output;
+- timeout fail-closed;
+- adapter overwrites rule_id / source / severity / backend on output;
+- CLI ``--allow-command-adapter`` flag toggling.
+
+Real subprocess fixtures live under ``tests/fixtures/command/``; unit
+tests stub ``run_cli`` so no subprocess is spawned.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from gate_keeper.adapters.command import (
+    DEFAULT_TIMEOUT_SECONDS,
+    MAX_TIMEOUT_SECONDS,
+    CommandAdapter,
+    is_enabled,
+    set_enabled,
+)
+from gate_keeper.backends._cli import CliResult
+from gate_keeper.backends.external import ExternalAdapter
+from gate_keeper.models import (
+    Backend,
+    Confidence,
+    Rule,
+    RuleKind,
+    Severity,
+    SourceLocation,
+    Status,
+)
+
+
+def _rule(severity: Severity = Severity.ERROR, **params: object) -> Rule:
+    base = {"tool": "command", "argv": ["echo", "hello"]}
+    base.update(params)
+    return Rule(
+        id="test-rule",
+        title="command adapter test rule",
+        source=SourceLocation(path="rules.md", line=4),
+        text="rule text",
+        kind=RuleKind.EXTERNAL_CHECK,
+        severity=severity,
+        backend_hint=Backend.EXTERNAL,
+        confidence=Confidence.HIGH,
+        params=base,
+    )
+
+
+def _ok_result(stdout: str, stderr: str = "") -> CliResult:
+    return CliResult(
+        ok=True,
+        stdout=stdout,
+        stderr=stderr,
+        returncode=0,
+        cmd=("echo", "hello"),
+    )
+
+
+def _nonzero_result(stdout: str, stderr: str, returncode: int = 2) -> CliResult:
+    return CliResult(
+        ok=False,
+        stdout=stdout,
+        stderr=stderr,
+        returncode=returncode,
+        cmd=("echo", "hello"),
+    )
+
+
+def _binary_missing_result() -> CliResult:
+    return CliResult(
+        ok=False,
+        stdout="",
+        stderr="'echo' binary not found",
+        returncode=127,
+        cmd=("echo", "hello"),
+        binary_missing=True,
+    )
+
+
+def _timeout_result() -> CliResult:
+    return CliResult(
+        ok=False,
+        stdout="",
+        stderr="timed out after 30s",
+        returncode=-2,
+        cmd=("echo", "hello"),
+        timed_out=True,
+    )
+
+
+@pytest.fixture
+def patch_run_cli(monkeypatch):
+    """Patch ``run_cli`` in the command adapter module."""
+
+    def _patch(stub):
+        from gate_keeper.adapters import command as adapter_module
+
+        monkeypatch.setattr(adapter_module, "run_cli", stub)
+
+    return _patch
+
+
+@pytest.fixture(autouse=True)
+def _reset_enable_flag():
+    """Always start tests with the adapter disabled; restore prior state."""
+    prior = is_enabled()
+    set_enabled(False)
+    try:
+        yield
+    finally:
+        set_enabled(prior)
+
+
+class TestProtocolConformance:
+    def test_adapter_satisfies_external_adapter_protocol(self):
+        assert isinstance(CommandAdapter(), ExternalAdapter)
+
+    def test_adapter_name_matches_expected_id(self):
+        assert CommandAdapter().name == "command"
+
+
+class TestDisabledByDefault:
+    def test_returns_unavailable_when_disabled(self):
+        # Default state — no flag, no subprocess.
+        diag = CommandAdapter().check(_rule(), "target")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "command_adapter_disabled"
+        assert diag.evidence[0].data["flag"] == "--allow-command-adapter"
+        assert diag.remediation is not None
+        assert "trust" in diag.remediation.lower()
+
+    def test_disabled_does_not_invoke_run_cli(self, patch_run_cli):
+        called = {"count": 0}
+
+        def stub(*a, **kw):
+            called["count"] += 1
+            return _ok_result("{}")
+
+        patch_run_cli(stub)
+        CommandAdapter().check(_rule(), "target")
+        # Disabled path must short-circuit before any subprocess attempt.
+        assert called["count"] == 0
+
+
+class TestPassPath:
+    def test_enabled_pass_diagnostic_parsed_from_stdout(self, patch_run_cli):
+        set_enabled(True)
+        captured: dict[str, object] = {}
+
+        def stub(executable, args, *, input=None, timeout=None, **kw):
+            captured["executable"] = executable
+            captured["args"] = list(args)
+            captured["timeout"] = timeout
+            captured["input"] = input
+            return _ok_result(
+                json.dumps(
+                    {
+                        "status": "pass",
+                        "message": "all good",
+                        "evidence": [{"kind": "ok", "data": {"x": 1}}],
+                    }
+                )
+            )
+
+        patch_run_cli(stub)
+        rule = _rule(argv=["python", "tools/check.py", "--strict"])
+        diag = CommandAdapter().check(rule, "some/target")
+        assert diag.status is Status.PASS
+        assert diag.message == "all good"
+        assert diag.backend is Backend.EXTERNAL
+        assert diag.evidence[0].kind == "ok"
+        assert diag.evidence[0].data == {"x": 1}
+        # stdin payload contract
+        assert isinstance(captured["input"], str)
+        stdin_obj = json.loads(captured["input"])  # type: ignore[arg-type]
+        assert stdin_obj == {
+            "rule": {"id": "test-rule", "text": "rule text", "params": rule.params},
+            "target": "some/target",
+        }
+        # argv goes through verbatim, executable comes from argv[0]
+        assert captured["executable"] == "python"
+        assert captured["args"] == ["tools/check.py", "--strict"]
+        # default timeout
+        assert captured["timeout"] == float(DEFAULT_TIMEOUT_SECONDS)
+
+    def test_diagnostic_report_with_one_diagnostic_is_accepted(self, patch_run_cli):
+        set_enabled(True)
+        patch_run_cli(
+            lambda *a, **kw: _ok_result(
+                json.dumps(
+                    {
+                        "diagnostics": [
+                            {
+                                "status": "pass",
+                                "message": "ok",
+                                "evidence": [],
+                            }
+                        ]
+                    }
+                )
+            )
+        )
+        diag = CommandAdapter().check(_rule(), "x")
+        assert diag.status is Status.PASS
+        assert diag.message == "ok"
+
+    def test_adapter_overrides_rule_id_source_severity_backend(self, patch_run_cli):
+        # A misbehaving command tries to spoof another rule_id; the adapter
+        # is the source of truth for these fields.
+        set_enabled(True)
+        patch_run_cli(
+            lambda *a, **kw: _ok_result(
+                json.dumps(
+                    {
+                        "rule_id": "OTHER-RULE",
+                        "source": {"path": "x", "line": 99},
+                        "backend": "filesystem",
+                        "severity": "advisory",
+                        "status": "pass",
+                        "message": "spoofed",
+                        "evidence": [],
+                    }
+                )
+            )
+        )
+        rule = _rule(severity=Severity.WARNING)
+        diag = CommandAdapter().check(rule, "t")
+        assert diag.rule_id == rule.id
+        assert diag.source == rule.source
+        assert diag.backend is Backend.EXTERNAL
+        assert diag.severity is Severity.WARNING
+
+    def test_remediation_string_passthrough(self, patch_run_cli):
+        set_enabled(True)
+        patch_run_cli(
+            lambda *a, **kw: _ok_result(
+                json.dumps(
+                    {
+                        "status": "fail",
+                        "message": "violation",
+                        "evidence": [],
+                        "remediation": "do the thing",
+                    }
+                )
+            )
+        )
+        diag = CommandAdapter().check(_rule(), "t")
+        assert diag.status is Status.FAIL
+        assert diag.remediation == "do the thing"
+
+
+class TestFailPaths:
+    def test_nonzero_exit_yields_unavailable_even_if_stdout_parses(self, patch_run_cli):
+        # Strict contract: non-zero exit means the command itself faulted, so
+        # parseable stdout is ignored. Status collapses to UNAVAILABLE.
+        set_enabled(True)
+        patch_run_cli(
+            lambda *a, **kw: _nonzero_result(
+                stdout=json.dumps(
+                    {
+                        "status": "fail",
+                        "message": "would have been fail",
+                        "evidence": [],
+                    }
+                ),
+                stderr="boom",
+            )
+        )
+        diag = CommandAdapter().check(_rule(), "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "command_failure"
+        assert diag.evidence[0].data["returncode"] == 2
+        assert "boom" in diag.evidence[0].data["stderr_excerpt"]
+
+    def test_command_not_found_is_cli_missing(self, patch_run_cli):
+        set_enabled(True)
+        patch_run_cli(lambda *a, **kw: _binary_missing_result())
+        diag = CommandAdapter().check(_rule(), "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "cli_missing"
+
+    def test_timeout_is_error(self, patch_run_cli):
+        set_enabled(True)
+        patch_run_cli(lambda *a, **kw: _timeout_result())
+        diag = CommandAdapter().check(_rule(), "t")
+        assert diag.status is Status.ERROR
+        assert diag.evidence[0].kind == "cli_timeout"
+
+
+class TestParamValidation:
+    def setup_method(self):
+        set_enabled(True)
+
+    def teardown_method(self):
+        set_enabled(False)
+
+    def test_argv_missing_is_unavailable(self):
+        rule = Rule(
+            id="r",
+            title="t",
+            source=SourceLocation(path="p", line=1),
+            text="x",
+            kind=RuleKind.EXTERNAL_CHECK,
+            severity=Severity.ERROR,
+            backend_hint=Backend.EXTERNAL,
+            confidence=Confidence.HIGH,
+            params={"tool": "command"},
+        )
+        diag = CommandAdapter().check(rule, "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "params_error"
+        assert diag.evidence[0].data["missing"] == "argv"
+
+    def test_argv_shell_string_rejected(self):
+        rule = _rule(argv="python tools/check.py")  # type: ignore[arg-type]
+        diag = CommandAdapter().check(rule, "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "params_error"
+        assert diag.evidence[0].data == {"field": "argv", "type": "str"}
+        assert diag.remediation is not None
+        assert "list" in diag.remediation
+
+    def test_argv_empty_list_rejected(self):
+        rule = _rule(argv=[])
+        diag = CommandAdapter().check(rule, "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "params_error"
+        assert diag.evidence[0].data == {"field": "argv", "reason": "empty"}
+
+    def test_argv_non_string_element_rejected(self):
+        rule = _rule(argv=["python", 42])  # type: ignore[list-item]
+        diag = CommandAdapter().check(rule, "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "params_error"
+        assert diag.evidence[0].data["field"] == "argv"
+        assert diag.evidence[0].data["index"] == 1
+
+    def test_timeout_not_a_number_rejected(self):
+        rule = _rule(timeout_seconds="forever")
+        diag = CommandAdapter().check(rule, "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].data["field"] == "timeout_seconds"
+
+    def test_timeout_zero_rejected(self):
+        rule = _rule(timeout_seconds=0)
+        diag = CommandAdapter().check(rule, "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].data["field"] == "timeout_seconds"
+
+    def test_timeout_above_max_rejected(self):
+        rule = _rule(timeout_seconds=MAX_TIMEOUT_SECONDS + 1)
+        diag = CommandAdapter().check(rule, "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].data["field"] == "timeout_seconds"
+        assert diag.evidence[0].data["max"] == MAX_TIMEOUT_SECONDS
+
+    def test_timeout_within_range_passed_through(self, monkeypatch):
+        captured: dict[str, object] = {}
+
+        def stub(executable, args, *, input=None, timeout=None, **kw):
+            captured["timeout"] = timeout
+            return _ok_result(json.dumps({"status": "pass", "message": "ok", "evidence": []}))
+
+        from gate_keeper.adapters import command as adapter_module
+
+        monkeypatch.setattr(adapter_module, "run_cli", stub)
+        CommandAdapter().check(_rule(timeout_seconds=10), "t")
+        assert captured["timeout"] == 10.0
+
+
+class TestOutputParsing:
+    def setup_method(self):
+        set_enabled(True)
+
+    def teardown_method(self):
+        set_enabled(False)
+
+    def _stub(self, monkeypatch, stdout: str, stderr: str = ""):
+        def stub(*a, **kw):
+            return _ok_result(stdout, stderr)
+
+        from gate_keeper.adapters import command as adapter_module
+
+        monkeypatch.setattr(adapter_module, "run_cli", stub)
+
+    def test_empty_stdout_yields_parse_error(self, monkeypatch):
+        self._stub(monkeypatch, "")
+        diag = CommandAdapter().check(_rule(), "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "parse_error"
+        assert diag.evidence[0].data["reason"] == "empty_stdout"
+
+    def test_invalid_json_yields_parse_error(self, monkeypatch):
+        self._stub(monkeypatch, "not json")
+        diag = CommandAdapter().check(_rule(), "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "parse_error"
+        assert diag.evidence[0].data["reason"] == "json_decode_error"
+        assert "not json" in diag.evidence[0].data["stdout_excerpt"]
+
+    def test_top_level_array_rejected(self, monkeypatch):
+        self._stub(monkeypatch, json.dumps([1, 2, 3]))
+        diag = CommandAdapter().check(_rule(), "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "parse_error"
+
+    def test_status_outside_enum_rejected(self, monkeypatch):
+        self._stub(monkeypatch, json.dumps({"status": "skipped", "message": "x", "evidence": []}))
+        diag = CommandAdapter().check(_rule(), "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].data["reason"] == "invalid_status"
+
+    def test_missing_message_rejected(self, monkeypatch):
+        self._stub(monkeypatch, json.dumps({"status": "pass", "evidence": []}))
+        diag = CommandAdapter().check(_rule(), "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].data["reason"] == "invalid_message"
+
+    def test_evidence_must_be_list(self, monkeypatch):
+        self._stub(
+            monkeypatch,
+            json.dumps({"status": "pass", "message": "ok", "evidence": "nope"}),
+        )
+        diag = CommandAdapter().check(_rule(), "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].data["reason"] == "invalid_evidence_list"
+
+    def test_evidence_item_must_have_kind_and_data(self, monkeypatch):
+        self._stub(
+            monkeypatch,
+            json.dumps(
+                {
+                    "status": "pass",
+                    "message": "ok",
+                    "evidence": [{"data": {}}],
+                }
+            ),
+        )
+        diag = CommandAdapter().check(_rule(), "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].data["reason"] == "invalid_evidence_kind"
+
+    def test_remediation_must_be_string_or_null(self, monkeypatch):
+        self._stub(
+            monkeypatch,
+            json.dumps(
+                {
+                    "status": "pass",
+                    "message": "ok",
+                    "evidence": [],
+                    "remediation": 123,
+                }
+            ),
+        )
+        diag = CommandAdapter().check(_rule(), "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].data["reason"] == "invalid_remediation"
+
+    def test_diagnostics_array_must_have_exactly_one(self, monkeypatch):
+        self._stub(monkeypatch, json.dumps({"diagnostics": []}))
+        diag = CommandAdapter().check(_rule(), "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].data["reason"] == "diagnostic_count"
+
+    def test_stderr_truncated_in_evidence(self, monkeypatch):
+        # Long stderr through the parse_error empty-stdout path.
+        long_stderr = "x" * 5000
+        self._stub(monkeypatch, "", long_stderr)
+        diag = CommandAdapter().check(_rule(), "t")
+        excerpt = diag.evidence[0].data["stderr_excerpt"]
+        assert len(excerpt) <= 1000 + 1  # include ellipsis char
+
+
+class TestRealSubprocess:
+    """End-to-end runs against the fixture commands using ``sys.executable``.
+
+    These exercise the actual subprocess plumbing (stdin JSON, argv list, no
+    shell) so the adapter is verified against real stdin/stdout I/O — not
+    just stubs.
+    """
+
+    fixtures = Path(__file__).parent / "fixtures" / "command"
+
+    def setup_method(self):
+        set_enabled(True)
+
+    def teardown_method(self):
+        set_enabled(False)
+
+    def test_pass_fixture_runs_and_parses(self):
+        rule = _rule(argv=[sys.executable, str(self.fixtures / "pass_command.py")])
+        diag = CommandAdapter().check(rule, "some-target")
+        assert diag.status is Status.PASS
+        assert "some-target" in diag.message
+        assert diag.evidence[0].kind == "fixture_pass"
+        assert diag.evidence[0].data == {"echo_target": "some-target"}
+
+    def test_fail_status_zero_exit_is_fail(self):
+        rule = _rule(argv=[sys.executable, str(self.fixtures / "fail_status_command.py")])
+        diag = CommandAdapter().check(rule, "t")
+        assert diag.status is Status.FAIL
+        assert diag.remediation == "edit the artifact to satisfy the rule"
+
+    def test_nonzero_exit_fixture_yields_unavailable(self):
+        rule = _rule(argv=[sys.executable, str(self.fixtures / "fail_command.py")])
+        diag = CommandAdapter().check(rule, "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "command_failure"
+        assert diag.evidence[0].data["returncode"] != 0
+
+    def test_command_not_found_real(self):
+        rule = _rule(argv=["/nonexistent/gate-keeper-test-binary"])
+        diag = CommandAdapter().check(rule, "t")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "cli_missing"
+
+
+class TestCliFlagIntegration:
+    """The CLI ``--allow-command-adapter`` flag toggles the adapter for the run."""
+
+    def test_cli_validate_disabled_by_default(self, tmp_path, capsys, monkeypatch):
+        # Build a tiny rule document that the parser/classifier will turn
+        # into a rule routed somewhere; the actual classifier route does not
+        # matter — we exercise the flag plumbing only.
+        rules = tmp_path / "rules.md"
+        rules.write_text("- The README must exist in the repository root.\n")
+
+        from gate_keeper.adapters import command as command_adapter
+        from gate_keeper.cli import main
+
+        # Sanity: enable flag is not on after a default run.
+        rc = main(["validate", str(rules), "--target", str(tmp_path)])
+        assert rc in (0, 1)
+        assert command_adapter.is_enabled() is False
+        capsys.readouterr()
+
+    def test_cli_validate_with_flag_enables_for_run_only(self, tmp_path, capsys):
+        rules = tmp_path / "rules.md"
+        rules.write_text("- The README must exist in the repository root.\n")
+
+        from gate_keeper.adapters import command as command_adapter
+        from gate_keeper.cli import main
+
+        rc = main(["validate", str(rules), "--target", str(tmp_path), "--allow-command-adapter"])
+        assert rc in (0, 1)
+        # Flag is reset after the call returns.
+        assert command_adapter.is_enabled() is False
+        capsys.readouterr()


### PR DESCRIPTION
Closes #149.

## Summary

- New generic `command` external adapter that lets a trusted local rule document delegate a check to a project-local executable. Spawned with `shell=False`; communicates via JSON stdin / JSON stdout.
- Disabled by default for security. Opt in with `gate-keeper validate ... --allow-command-adapter` for the current process only.
- Strict argv-list contract (no shell strings), timeout (default 30s, hard maximum 300s), bounded stderr in evidence, fail-closed on every error mode.

## Trust model (security-sensitive)

The rule document supplies `params.argv` (a list of strings). Passing `--allow-command-adapter` against an untrusted rule document is equivalent to running the document's argv by hand — i.e. arbitrary local code execution.

- **Default state:** without the flag, every `external_check` whose `params.tool == "command"` returns `unavailable` / `command_adapter_disabled`. **No subprocess is ever spawned.** Tests pin this.
- **Enabled state:** the flag is process-local; it is reset before `_cmd_validate` returns even on exception.
- Documentation in `docs/cli-reference.md` and `docs/example-rules.md` carries an explicit warning callout: pass the flag only for rule documents you fully trust.

## Reviewer scrutiny — security focus areas

Codex, please pay particular attention to:

1. **`argv` handling** (`src/gate_keeper/adapters/command.py::_validate_params`) — only a `list[str]` is accepted. A bare `str` (`"python tools/check.py"`) is rejected as `params_error / type=str`. Non-string elements rejected. Empty list rejected.
2. **No shell, no eval** — `subprocess.run` is invoked via `gate_keeper.backends._cli.run_cli`, which calls `subprocess.run(list(argv), shell=False)`. No `os.path.expandvars`, `os.path.expanduser`, or `str.format` is applied to argv elements.
3. **No env injection** — the adapter does not pass `env=...` to `run_cli`, so the subprocess inherits the current process environment unchanged. Target is forwarded only via stdin JSON, not via env or shell interpolation.
4. **Output spoofing prevention** — the adapter overrides `rule_id`, `source`, `severity`, and `backend` on the parsed Diagnostic so a misbehaving command cannot rebrand another rule's result.
5. **Timeout / non-zero exit** — both fail-closed: timeout → `error` / `cli_timeout` (subprocess killed by `subprocess.run`'s machinery); non-zero exit → `unavailable` / `command_failure` even when stdout would have parsed cleanly. Tests pin both.
6. **Bounded evidence** — stderr is truncated to 1000 chars in evidence to keep diagnostics bounded.

## What's in the diff

- `src/gate_keeper/adapters/command.py` — adapter + process-local enable flag (`is_enabled`/`set_enabled`).
- `src/gate_keeper/cli.py` — `--allow-command-adapter` flag; toggles the adapter for the duration of `_cmd_validate` only; auto-registers `CommandAdapter` alongside the existing textlint adapter.
- `tests/test_command_adapter.py` — 35 tests covering protocol conformance, disabled-by-default, pass/fail paths (with real subprocess fixtures), invalid params (incl. shell-string rejection), command-not-found, timeout, malformed output, output-spoofing prevention, and CLI flag plumbing.
- `tests/fixtures/command/{pass_command,fail_command,fail_status_command}.py` — minimal stdin-JSON / stdout-JSON fixture scripts (no network, no real external services).
- Docs: `docs/rule-ir.md` (params table), `docs/cli-reference.md` (flag entry + `Project-local command adapter` section with trust-model callout), `docs/backend-external.md` (registered-adapter entry with the full evidence vocabulary), `docs/example-rules.md` (annotated walkthrough #6).

## Test plan

- [x] `uv run pytest` — 828 tests pass (including 35 new `test_command_adapter.py`).
- [x] `uvx ruff check .` — clean.
- [x] `uvx ruff format --check .` — clean.
- [x] `uv run pyright` — 0 errors.
- [x] Verified `gate-keeper validate --help` includes the new flag with security warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)