### PR TITLE
feat(github): add github_changed_files_absent rule kind (#147)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -244,6 +244,12 @@ Each line: `path:line: severity: [backend/status] rule_id: message [evidence]`.
   provider configuration.
 - See [docs/llm-rubric.md](llm-rubric.md) for provider setup and evidence
   shape details.
+- The `github_changed_files_absent` rule kind requires per-rule `params`
+  (`patterns`, optional `case_sensitive`). The natural-language classifier
+  routes only explicit PR/path forbid wording (e.g. *"PRs must not change
+  generated workbook outputs"*) to this kind; ambiguous filesystem rules
+  remain on the filesystem or semantic backends. See
+  [docs/rule-ir.md](rule-ir.md) for the full params and evidence shape.
 
 ---
 

--- a/docs/example-rules.md
+++ b/docs/example-rules.md
@@ -103,7 +103,77 @@ rules.md:5: warning: [github/fail] rule-L5: PR owner/repo#43 has 2 unchecked tas
 
 ---
 
-## 4. Semantic rubric — `llm-rubric / semantic_rubric`
+## 4. PR changed-file path policy — `github / github_changed_files_absent`
+
+Forbid a PR from touching paths that match a glob (e.g. generated outputs,
+binary artifacts, raw researcher data).
+
+**Rule document:**
+
+```markdown
+## Path policy
+
+- PRs must not change generated workbook outputs.
+- PRs must not add raw Office/PDF artifacts.
+- PRs must not create context/researcher/raw/ as a tracked path.
+```
+
+**Classifier route:** `github / github_changed_files_absent / high` —
+explicit PR + verb-of-modification wording. Each rule needs `params.patterns`
+(a list of glob strings); the classifier records the kind and backend, and
+authors fill in `params` after `compile`.
+
+**Compiled rule (JSON excerpt — patterns added by hand):**
+
+```json
+{
+  "rules": [{
+    "id": "no-workbook-outputs",
+    "text": "PRs must not change generated workbook outputs.",
+    "kind": "github_changed_files_absent",
+    "severity": "error",
+    "backend_hint": "github",
+    "params": {
+      "patterns": ["outputs/**", "**/*.xlsx"],
+      "case_sensitive": true
+    }
+  }]
+}
+```
+
+**Sample run (pass — no offending paths):**
+
+```
+$ gate-keeper validate rules.md --target https://github.com/owner/repo/pull/42
+rules.md:3: error: [github/pass] no-workbook-outputs: PR owner/repo#42: 0 of 7 changed file(s) match forbidden patterns.
+  [pr_changed_files(total_changed_files=7, forbidden_patterns=['outputs/**', '**/*.xlsx'], offending=[], pagination_complete=True, ...)]
+```
+
+**Sample run (fail — generated workbook touched):**
+
+```
+$ gate-keeper validate rules.md --target https://github.com/owner/repo/pull/43
+rules.md:3: error: [github/fail] no-workbook-outputs: PR owner/repo#43: 1 of 9 changed file(s) match forbidden patterns: ['outputs/results.xlsx'].
+  [pr_changed_files(total_changed_files=9, offending=[{'path': 'outputs/results.xlsx', 'pattern': 'outputs/**'}], matched_patterns=['outputs/**'], page_count=1, ...)]
+```
+
+**Notes:**
+
+- `patterns` is required and must be a non-empty list of glob strings.
+  Missing or malformed params produce `unavailable` / `params_error`.
+- Glob semantics: `**` matches across `/`, `*` matches within a single
+  segment, `?` matches one non-`/` character. `**/*.xlsx` matches both
+  top-level and nested workbooks.
+- Pagination is exhaustive — the backend walks the full PR file list
+  before evaluating. A truncated fetch returns `unavailable` rather than
+  passing on partial data.
+- Evidence includes `total_changed_files`, `forbidden_patterns`,
+  `offending`, `pagination_complete`, and `page_count`. See
+  [docs/rule-ir.md](rule-ir.md) for the full schema.
+
+---
+
+## 5. Semantic rubric — `llm-rubric / semantic_rubric`
 
 **Rule document:**
 
@@ -147,7 +217,7 @@ rules.md:3: warning: [llm-rubric/fail] rule-L3: The description does not summari
 
 ---
 
-## 5. textlint prose quality — `external / external_check`
+## 6. textlint prose quality — `external / external_check`
 
 textlint rules use `kind: external_check` with `params.tool: textlint`.
 The textlint adapter is registered automatically at CLI entry.

--- a/docs/rule-ir.md
+++ b/docs/rule-ir.md
@@ -90,8 +90,8 @@ backend rather than minting new `Backend` enum values; see
 `file_exists`, `file_absent`, `path_matches`, `text_required`, `text_forbidden`,
 `markdown_tasks_complete`, `github_pr_open`, `github_not_draft`,
 `github_labels_absent`, `github_tasks_complete`, `github_checks_success`,
-`github_threads_resolved`, `github_non_author_approval`, `semantic_rubric`,
-`external_check`
+`github_threads_resolved`, `github_non_author_approval`,
+`github_changed_files_absent`, `semantic_rubric`, `external_check`
 
 ### `Severity`
 `error`, `warning`, `advisory`
@@ -109,6 +109,7 @@ backend rather than minting new `Backend` enum values; see
 | `github_labels_absent` | `labels` | `["blocked","do-not-merge","needs-decision"]` | List of blocking label names (case-insensitive). Absent key uses default list; explicit `[]` means no blocking labels → always PASS. |
 | `github_checks_success` | _(none)_ | — | Evaluates every entry in `statusCheckRollup` as required; only `SUCCESS` state/conclusion passes. Branch protection remains the authoritative control plane. |
 | `external_check` | `tool` | _(required)_ | String adapter ID selecting which `external` adapter handles the rule (e.g. `"textlint"`). Missing → `unavailable` / `params_error`; unregistered → `unsupported` / `adapter_unknown`. All other `params` keys are forwarded verbatim to the adapter, which owns its own per-tool keys. See [`docs/backend-external.md`](backend-external.md). |
+| `github_changed_files_absent` | `patterns`, `case_sensitive` | `case_sensitive=true` | `patterns` is required and must be a non-empty list of glob strings; missing or invalid → `unavailable` / `params_error`. `case_sensitive` is optional (default `true`). Glob semantics: `**` matches zero or more path segments, `*` matches anything except `/`, `?` matches one non-`/` char. See the dedicated section below for the data policy. |
 
 ## `github_non_author_approval` — formal evidence and limitations
 
@@ -142,6 +143,69 @@ reviewer), which avoids any pagination concern on the full reviews connection.
 - `DISMISSED`, `COMMENTED`, `CHANGES_REQUESTED`, and `PENDING` never satisfy the rule.
 - Only the **latest** review per reviewer (by `submittedAt`) is considered.
 - Comment-only and semantically substantive review judgement are out of scope.
+
+## `github_changed_files_absent` — changed-file glob policy
+
+The `github_changed_files_absent` rule fails when any file changed by the
+target PR matches any of the configured forbidden glob patterns.  The
+backend walks the GraphQL `pullRequest.files` connection page-by-page until
+the connection reports `hasNextPage = false` and only then evaluates the
+patterns.
+
+### Params
+
+```json
+{
+  "patterns": ["outputs/**", "**/*.xlsx", "context/researcher/raw/**"],
+  "case_sensitive": true
+}
+```
+
+- `patterns` — required, non-empty list of glob strings.  Each entry must
+  be a non-empty string.
+- `case_sensitive` — optional, defaults to `true`.
+
+Missing or malformed `patterns` (or non-bool `case_sensitive`) produces
+`status = unavailable` with `evidence.kind = params_error`.
+
+### Glob semantics
+
+| Token | Meaning |
+| ----- | ------- |
+| `**`  | zero or more path segments (matches across `/`) |
+| `*`   | any sequence of characters except `/` |
+| `?`   | exactly one character except `/` |
+| literal | matched verbatim (regex metacharacters are escaped) |
+
+`**/*.xlsx` matches both `data.xlsx` and `deep/nested/data.xlsx`.
+`src/*.py` matches `src/a.py` but **not** `src/sub/b.py`.
+
+### Evidence — `pr_changed_files`
+
+| Field | Meaning |
+| ----- | ------- |
+| `total_changed_files` | Total count of files reported by GitHub for the PR. |
+| `forbidden_patterns` | The patterns evaluated. |
+| `case_sensitive` | The effective flag value. |
+| `offending` | List of `{path, pattern}` for each changed file that matched at least one pattern (the pattern recorded is the first match). |
+| `matched_patterns` | Sorted unique set of patterns that produced at least one offending entry. |
+| `pagination_complete` | Always `true` on `pass`/`fail`; `unavailable` is emitted instead when pagination cannot complete. |
+| `page_count` | Number of GraphQL pages fetched to assemble the full list. |
+| `owner`, `repo`, `number`, `url` | PR coordinates (echoed from the resolver). |
+
+### Failure modes
+
+| Status | Evidence kind | When |
+| ------ | ------------- | ---- |
+| `pass` | `pr_changed_files` | No changed file matched any forbidden pattern. |
+| `fail` | `pr_changed_files` | One or more changed files matched a forbidden pattern; the offending list is populated. |
+| `unavailable` | `params_error` | `patterns` is missing, not a list, empty, contains a non-string or empty entry, or `case_sensitive` is not a bool. |
+| `unavailable` | `gh_pagination_unavailable` | The GraphQL connection truncates without a usable cursor or the page count exceeds the safety bound. |
+| `unavailable` | `gh_failure` / `gh_missing` / `gh_auth_failure` / `gh_json_error` / `gh_missing_field` / `gh_graphql_error` | Any other `gh` failure on the resolve or fetch call. |
+
+The backend never returns `pass` on a partial page set — incomplete
+pagination is treated as `unavailable` so a forbidden file added in a
+later page can never be silently skipped.
 
 ## Validation policy
 

--- a/docs/rule-ir.md
+++ b/docs/rule-ir.md
@@ -175,7 +175,7 @@ Missing or malformed `patterns` (or non-bool `case_sensitive`) produces
 | `**`  | zero or more path segments (matches across `/`) |
 | `*`   | any sequence of characters except `/` |
 | `?`   | exactly one character except `/` |
-| literal | matched verbatim (regex metacharacters are escaped) |
+| literal | matched verbatim (regular expression metacharacters are escaped) |
 
 `**/*.xlsx` matches both `data.xlsx` and `deep/nested/data.xlsx`.
 `src/*.py` matches `src/a.py` but **not** `src/sub/b.py`.

--- a/src/gate_keeper/backends/github.py
+++ b/src/gate_keeper/backends/github.py
@@ -1,20 +1,24 @@
 """GitHub backend for gate-keeper.
 
 Implements deterministic PR state, draft, label, tasklist, status-check
-rollup, review thread validation, and independent (non-author) approval
-checks using the ``gh`` CLI (issues #10–#13).
+rollup, review thread validation, independent (non-author) approval, and
+PR changed-file glob checks using the ``gh`` CLI (issues #10–#13, #147).
 
 Six rule kinds share a single ``gh pr view`` call per ``check()``
 invocation; the result is parsed once and dispatched to the appropriate
-handler.  The seventh kind (``github_threads_resolved``) makes its own
-GraphQL call via ``gh api graphql`` and does NOT use ``_fetch_pr_view``.
+handler.  Two further kinds (``github_threads_resolved``,
+``github_changed_files_absent``) make their own GraphQL calls via
+``gh api graphql`` and do NOT use ``_fetch_pr_view``.
 
 Any failure before dispatch (missing gh, auth, JSON, missing field)
-propagates as UNAVAILABLE — all paths fail closed.
+propagates as UNAVAILABLE — all paths fail closed.  The changed-file
+handler additionally treats incomplete pagination as UNAVAILABLE so a
+truncated result can never silently pass.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from gate_keeper._md import (
@@ -828,6 +832,420 @@ def _check_non_author_approval(rule: Rule, pr: PrTarget, data: dict) -> Diagnost
 
 
 # ---------------------------------------------------------------------------
+# Changed-file handler (issue #147 — github_changed_files_absent)
+# ---------------------------------------------------------------------------
+
+#: Page size for the GraphQL ``files`` connection on a PullRequest. 100 is
+#: GitHub's documented upper bound; explicit pagination guarantees we never
+#: silently miss offending files when a PR exceeds this size.
+_CHANGED_FILES_PAGE_SIZE = 100
+
+#: Hard upper bound on pagination — a defensive guard that prevents an
+#: unexpected ``hasNextPage=True`` loop from running unbounded if GitHub ever
+#: returns a malformed cursor.  10 pages × 100 files == 1000 changed files,
+#: which already exceeds GitHub's recommended PR size.  Beyond this we fail
+#: closed as UNAVAILABLE.
+_CHANGED_FILES_MAX_PAGES = 10
+
+_CHANGED_FILES_QUERY = (
+    "query($owner: String!, $repo: String!, $number: Int!, $first: Int!, $after: String) {\n"
+    "  repository(owner: $owner, name: $repo) {\n"
+    "    pullRequest(number: $number) {\n"
+    "      files(first: $first, after: $after) {\n"
+    "        nodes { path }\n"
+    "        pageInfo { hasNextPage endCursor }\n"
+    "      }\n"
+    "    }\n"
+    "  }\n"
+    "}"
+)
+
+
+def _fetch_changed_files(
+    pr: PrTarget, rule: Rule
+) -> tuple[list[str] | None, int | None, Diagnostic | None]:
+    """Fetch the *complete* list of changed file paths for *pr*.
+
+    Returns ``(filenames, page_count, None)`` on success.
+    Returns ``(None, None, diag)`` on any failure.
+
+    Pagination is explicit: we walk the GraphQL ``files`` connection until
+    ``pageInfo.hasNextPage`` is the literal boolean ``False``.  Anything
+    else (truncation, missing cursor, malformed shape, exceeding
+    ``_CHANGED_FILES_MAX_PAGES``) fails closed as UNAVAILABLE so partial
+    data can never produce a PASS.
+    """
+    filenames: list[str] = []
+    after: str | None = None
+    page_count = 0
+
+    while True:
+        page_count += 1
+        if page_count > _CHANGED_FILES_MAX_PAGES:
+            return (
+                None,
+                None,
+                gh_pagination_diag(rule, "graphql", end_cursor=after),
+            )
+
+        argv = [
+            "api",
+            "graphql",
+            "-f",
+            f"query={_CHANGED_FILES_QUERY}",
+            "-f",
+            f"owner={pr.owner}",
+            "-f",
+            f"repo={pr.repo}",
+            "-F",
+            f"number={pr.number}",
+            "-F",
+            f"first={_CHANGED_FILES_PAGE_SIZE}",
+        ]
+        if after is not None:
+            argv.extend(["-f", f"after={after}"])
+
+        result = run_gh(argv)
+        if not result.ok:
+            return None, None, failure_diag(rule, "graphql", result)
+
+        data, err = parse_json(result.stdout)
+        if err is not None:
+            return None, None, gh_json_diag(rule, "graphql", err)
+
+        # Top-level GraphQL errors → UNAVAILABLE
+        if isinstance(data, dict) and "errors" in data:
+            raw_errors = data["errors"]
+            if not isinstance(raw_errors, list):
+                raw_errors = [raw_errors]
+            summaries: list[str] = []
+            for e in raw_errors:
+                if isinstance(e, dict):
+                    msg = str(e.get("message", repr(e)))
+                else:
+                    msg = str(e)
+                msg = _redact(msg)
+                if len(msg) > _GRAPHQL_ERROR_MSG_LIMIT:
+                    msg = msg[:_GRAPHQL_ERROR_MSG_LIMIT] + "…"
+                summaries.append(msg)
+            diag = _base_gh_diag(
+                rule,
+                Status.UNAVAILABLE,
+                "gh 'graphql' returned GraphQL errors; evaluation is unavailable.",
+                [
+                    Evidence(
+                        kind="gh_graphql_error",
+                        data={
+                            "op": "graphql",
+                            "errors": summaries,
+                            "owner": pr.owner,
+                            "repo": pr.repo,
+                            "number": pr.number,
+                        },
+                    )
+                ],
+            )
+            return None, None, diag
+
+        # Navigate to data.repository.pullRequest.files
+        if not isinstance(data, dict) or "data" not in data:
+            return None, None, gh_missing_field_diag(rule, "graphql", "data")
+        repo_data = data["data"]
+        if not isinstance(repo_data, dict) or "repository" not in repo_data:
+            return None, None, gh_missing_field_diag(rule, "graphql", "data.repository")
+        repository = repo_data["repository"]
+        if not isinstance(repository, dict) or "pullRequest" not in repository:
+            return (
+                None,
+                None,
+                gh_missing_field_diag(rule, "graphql", "data.repository.pullRequest"),
+            )
+        pull_request = repository["pullRequest"]
+        if not isinstance(pull_request, dict) or "files" not in pull_request:
+            return (
+                None,
+                None,
+                gh_missing_field_diag(rule, "graphql", "data.repository.pullRequest.files"),
+            )
+        files_conn = pull_request["files"]
+        if not isinstance(files_conn, dict):
+            return (
+                None,
+                None,
+                gh_missing_field_diag(rule, "graphql", "data.repository.pullRequest.files"),
+            )
+
+        nodes = files_conn.get("nodes")
+        page_info = files_conn.get("pageInfo")
+        if not isinstance(nodes, list):
+            return (
+                None,
+                None,
+                gh_missing_field_diag(rule, "graphql", "data.repository.pullRequest.files.nodes"),
+            )
+        if not isinstance(page_info, dict):
+            return (
+                None,
+                None,
+                gh_missing_field_diag(rule, "graphql", "data.repository.pullRequest.files.pageInfo"),
+            )
+
+        for node in nodes:
+            if not isinstance(node, dict):
+                # Truncated or malformed entry — fail closed rather than
+                # silently dropping it from the offending-files set.
+                return (
+                    None,
+                    None,
+                    gh_missing_field_diag(
+                        rule, "graphql", "data.repository.pullRequest.files.nodes[].path"
+                    ),
+                )
+            path = node.get("path")
+            if not isinstance(path, str) or not path:
+                return (
+                    None,
+                    None,
+                    gh_missing_field_diag(
+                        rule, "graphql", "data.repository.pullRequest.files.nodes[].path"
+                    ),
+                )
+            filenames.append(path)
+
+        has_next = page_info.get("hasNextPage")
+        if has_next is False:
+            return filenames, page_count, None
+
+        # Pagination must continue: extract a usable cursor.  Anything other
+        # than ``hasNextPage = True`` with a string ``endCursor`` is treated
+        # as truncated → UNAVAILABLE.
+        end_cursor = page_info.get("endCursor")
+        if has_next is not True or not isinstance(end_cursor, str) or not end_cursor:
+            cursor_for_evidence = end_cursor if isinstance(end_cursor, str) else None
+            return (
+                None,
+                None,
+                gh_pagination_diag(rule, "graphql", end_cursor=cursor_for_evidence),
+            )
+        after = end_cursor
+
+
+def _validate_changed_files_params(rule: Rule) -> tuple[list[str], bool] | Diagnostic:
+    """Validate and normalize ``rule.params`` for ``github_changed_files_absent``.
+
+    Returns ``(patterns, case_sensitive)`` on success, or an UNAVAILABLE
+    Diagnostic with ``params_error`` evidence when params are missing or
+    malformed.
+
+    Contract:
+
+    - ``patterns`` is required and must be a non-empty list of non-empty
+      glob strings.
+    - ``case_sensitive`` is optional, defaults to ``True``, and must be a
+      bool when present.
+    """
+    params = rule.params
+    if "patterns" not in params:
+        return _params_error_diag(rule, "patterns is required", missing="patterns")
+
+    raw_patterns = params["patterns"]
+    if not isinstance(raw_patterns, list) or not raw_patterns:
+        return _params_error_diag(
+            rule,
+            "patterns must be a non-empty list of glob strings",
+            field="patterns",
+            actual_type=type(raw_patterns).__name__,
+        )
+
+    patterns: list[str] = []
+    for idx, item in enumerate(raw_patterns):
+        if not isinstance(item, str) or not item:
+            return _params_error_diag(
+                rule,
+                "patterns must contain only non-empty strings",
+                field=f"patterns[{idx}]",
+                actual_type=type(item).__name__,
+            )
+        patterns.append(item)
+
+    case_sensitive: bool = True
+    if "case_sensitive" in params:
+        raw_cs = params["case_sensitive"]
+        if not isinstance(raw_cs, bool):
+            return _params_error_diag(
+                rule,
+                "case_sensitive must be a boolean",
+                field="case_sensitive",
+                actual_type=type(raw_cs).__name__,
+            )
+        case_sensitive = raw_cs
+
+    return patterns, case_sensitive
+
+
+def _params_error_diag(rule: Rule, reason: str, **extra: object) -> Diagnostic:
+    """Build an UNAVAILABLE diagnostic with ``params_error`` evidence."""
+    data: dict[str, object] = {"rule_id": rule.id, "reason": reason}
+    data.update(extra)
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=Backend.GITHUB,
+        status=Status.UNAVAILABLE,
+        severity=rule.severity,
+        message=f"rule {rule.id!r} has invalid params for github_changed_files_absent: {reason}",
+        evidence=[Evidence(kind="params_error", data=data)],
+    )
+
+
+def _glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Translate a path glob to a regex.
+
+    Semantics
+    ---------
+    - ``**`` matches zero or more path segments, including separators.
+      The ``/**/`` form collapses to "zero or more directories" so that
+      ``**/*.xlsx`` matches both ``data.xlsx`` and ``deep/data.xlsx``,
+      and ``a/**/b`` matches ``a/b`` as well as ``a/x/b`` or ``a/x/y/b``.
+    - Single ``*`` matches any sequence of characters except ``/``.
+    - ``?`` matches exactly one non-``/`` character.
+    - All other characters are matched literally (regex metacharacters
+      are escaped).
+    """
+    i = 0
+    n = len(pattern)
+    out: list[str] = []
+    while i < n:
+        c = pattern[i]
+        if c == "*":
+            # ``**`` — possibly cross-segment match.
+            if i + 1 < n and pattern[i + 1] == "*":
+                # Leading ``**/`` → optional zero-or-more directories.
+                if i == 0 and i + 2 < n and pattern[i + 2] == "/":
+                    out.append("(?:.*/)?")
+                    i += 3
+                    continue
+                # ``/**/`` between segments → optional zero-or-more directories.
+                if (
+                    out
+                    and out[-1] == "/"
+                    and i + 2 < n
+                    and pattern[i + 2] == "/"
+                ):
+                    out.pop()  # remove the preceding ``/``
+                    out.append("(?:/.*)?/")
+                    i += 3
+                    continue
+                # Trailing or standalone ``**`` matches the rest of the path.
+                out.append(".*")
+                i += 2
+                continue
+            # Single ``*`` — any chars except path separator.
+            out.append("[^/]*")
+            i += 1
+            continue
+        if c == "?":
+            out.append("[^/]")
+            i += 1
+            continue
+        if c in r".+()|^$\{}[]":
+            out.append(re.escape(c))
+            i += 1
+            continue
+        if c == "\\":
+            out.append(re.escape(c))
+            i += 1
+            continue
+        out.append(c)
+        i += 1
+    return re.compile("^" + "".join(out) + "$")
+
+
+def _match_glob(filename: str, pattern: str, *, case_sensitive: bool) -> bool:
+    """Return True if *filename* matches the glob *pattern*.
+
+    ``**`` matches zero or more path segments (including ``/``); ``*``
+    matches anything except ``/``; ``?`` matches a single non-``/`` char.
+    Case folding is controlled by *case_sensitive*.
+
+    The translator is always used (not only when ``**`` is present) so
+    ``/`` is treated as a path separator under all path globs.  Plain
+    ``fnmatch`` would treat ``*`` as "any sequence including ``/``",
+    which is the wrong semantics for changed-file path globs.
+    """
+    regex = _glob_to_regex(pattern)
+    flags = 0 if case_sensitive else re.IGNORECASE
+    return re.match(regex.pattern, filename, flags) is not None
+
+
+def _check_changed_files_absent(rule: Rule, pr: PrTarget) -> Diagnostic:
+    """Pass when no PR changed file matches any forbidden glob; fail otherwise.
+
+    Evidence kind: ``pr_changed_files``.
+
+    - Missing/invalid ``patterns`` → UNAVAILABLE / ``params_error``.
+    - Incomplete pagination → UNAVAILABLE / ``gh_pagination_unavailable``.
+    - Any GitHub failure → UNAVAILABLE.
+    - Otherwise compares each repository-relative changed filename against
+      the configured glob patterns.  Offending filenames are listed
+      alongside the patterns that matched them.
+    """
+    validated = _validate_changed_files_params(rule)
+    if isinstance(validated, Diagnostic):
+        return validated
+    patterns, case_sensitive = validated
+
+    filenames, page_count, fetch_diag = _fetch_changed_files(pr, rule)
+    if fetch_diag is not None:
+        return fetch_diag
+    assert filenames is not None
+    assert page_count is not None
+
+    offending: list[dict[str, object]] = []
+    matched_patterns: set[str] = set()
+    for name in filenames:
+        for pattern in patterns:
+            if _match_glob(name, pattern, case_sensitive=case_sensitive):
+                offending.append({"path": name, "pattern": pattern})
+                matched_patterns.add(pattern)
+                break  # one pattern is enough; record the first match
+
+    evidence_data: dict[str, object] = {
+        "total_changed_files": len(filenames),
+        "forbidden_patterns": list(patterns),
+        "case_sensitive": case_sensitive,
+        "offending": offending,
+        "matched_patterns": sorted(matched_patterns),
+        "pagination_complete": True,
+        "page_count": page_count,
+        **_pr_coords(pr),
+    }
+    evidence = [Evidence(kind="pr_changed_files", data=evidence_data)]
+
+    if not offending:
+        return _diag(
+            rule,
+            Status.PASS,
+            (
+                f"PR {pr.owner}/{pr.repo}#{pr.number}: 0 of "
+                f"{len(filenames)} changed file(s) match forbidden patterns."
+            ),
+            evidence,
+        )
+
+    offending_paths = [str(entry["path"]) for entry in offending]
+    return _diag(
+        rule,
+        Status.FAIL,
+        (
+            f"PR {pr.owner}/{pr.repo}#{pr.number}: {len(offending_paths)} of "
+            f"{len(filenames)} changed file(s) match forbidden patterns: {offending_paths!r}."
+        ),
+        evidence,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Dispatch tables
 # ---------------------------------------------------------------------------
 
@@ -844,6 +1262,7 @@ _PR_VIEW_HANDLERS = {
 # Handlers that make their own gh call directly (takes rule, pr only).
 _DIRECT_HANDLERS = {
     RuleKind.GITHUB_THREADS_RESOLVED: _check_threads_resolved,
+    RuleKind.GITHUB_CHANGED_FILES_ABSENT: _check_changed_files_absent,
 }
 
 # ---------------------------------------------------------------------------

--- a/src/gate_keeper/backends/github.py
+++ b/src/gate_keeper/backends/github.py
@@ -861,9 +861,7 @@ _CHANGED_FILES_QUERY = (
 )
 
 
-def _fetch_changed_files(
-    pr: PrTarget, rule: Rule
-) -> tuple[list[str] | None, int | None, Diagnostic | None]:
+def _fetch_changed_files(pr: PrTarget, rule: Rule) -> tuple[list[str] | None, int | None, Diagnostic | None]:
     """Fetch the *complete* list of changed file paths for *pr*.
 
     Returns ``(filenames, page_count, None)`` on success.
@@ -997,18 +995,14 @@ def _fetch_changed_files(
                 return (
                     None,
                     None,
-                    gh_missing_field_diag(
-                        rule, "graphql", "data.repository.pullRequest.files.nodes[].path"
-                    ),
+                    gh_missing_field_diag(rule, "graphql", "data.repository.pullRequest.files.nodes[].path"),
                 )
             path = node.get("path")
             if not isinstance(path, str) or not path:
                 return (
                     None,
                     None,
-                    gh_missing_field_diag(
-                        rule, "graphql", "data.repository.pullRequest.files.nodes[].path"
-                    ),
+                    gh_missing_field_diag(rule, "graphql", "data.repository.pullRequest.files.nodes[].path"),
                 )
             filenames.append(path)
 
@@ -1126,12 +1120,7 @@ def _glob_to_regex(pattern: str) -> re.Pattern[str]:
                     i += 3
                     continue
                 # ``/**/`` between segments → optional zero-or-more directories.
-                if (
-                    out
-                    and out[-1] == "/"
-                    and i + 2 < n
-                    and pattern[i + 2] == "/"
-                ):
+                if out and out[-1] == "/" and i + 2 < n and pattern[i + 2] == "/":
                     out.pop()  # remove the preceding ``/``
                     out.append("(?:/.*)?/")
                     i += 3

--- a/src/gate_keeper/classifier.py
+++ b/src/gate_keeper/classifier.py
@@ -65,18 +65,28 @@ _PR_TASK_HIGH_RE = re.compile(
 )
 
 # Changed-file glob policy: only match when the rule explicitly mentions a PR
-# (``PR``/``PRs``/``pull request``) AND a file-modification verb
-# (``change``/``modify``/``add``/``create``/``commit``/``include``/``introduce``/
-# ``touch``).  This narrow phrasing avoids misrouting plain filesystem rules
-# (e.g. ``the README must not contain TODO``) into the GitHub backend.
+# (``PR``/``PRs``/``pull request``) AND a strictly path/tree-mutation verb.
+# The verb list is intentionally narrow (``change``/``modify``/``add``/
+# ``create``/``touch``/``delete``/``remove``) so generic content rules such
+# as "PRs must not include TODO comments" or "PRs must not introduce new
+# global state" are NOT misrouted to ``github_changed_files_absent`` (which
+# requires ``params.patterns`` and would otherwise become ``unavailable``).
+#
+# The negation handles two grammatical shapes consistently:
+#   - ``must|should|may`` followed by an explicit ``not``
+#   - ``cannot|can not`` as the standalone negation (no second ``not``)
+# Earlier wording required ``cannot not …``, which never matches natural PR
+# prose like "PRs cannot change generated outputs".
 #
 # Wording examples that match (from issue #147):
 #   - "PRs must not change generated workbook outputs."
 #   - "PRs must not create context/researcher/raw/ as a tracked path."
 #   - "PRs must not add raw Office/PDF artifacts."
+#   - "PRs cannot change generated outputs."
 _CHANGED_FILES_HIGH_RE = re.compile(
-    r"\b(?:prs?|pull\s+requests?)\b\s+(?:must|should|may|cannot|can\s*not)\s+not\s+"
-    r"(?:change|modify|add|create|commit|include|introduce|touch)\b",
+    r"\b(?:prs?|pull\s+requests?)\b\s+"
+    r"(?:(?:must|should|may)\s+not|cannot|can\s*not)\s+"
+    r"(?:change|modify|add|create|touch|delete|remove)\b",
     re.IGNORECASE,
 )
 

--- a/src/gate_keeper/classifier.py
+++ b/src/gate_keeper/classifier.py
@@ -64,6 +64,22 @@ _PR_TASK_HIGH_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Changed-file glob policy: only match when the rule explicitly mentions a PR
+# (``PR``/``PRs``/``pull request``) AND a file-modification verb
+# (``change``/``modify``/``add``/``create``/``commit``/``include``/``introduce``/
+# ``touch``).  This narrow phrasing avoids misrouting plain filesystem rules
+# (e.g. ``the README must not contain TODO``) into the GitHub backend.
+#
+# Wording examples that match (from issue #147):
+#   - "PRs must not change generated workbook outputs."
+#   - "PRs must not create context/researcher/raw/ as a tracked path."
+#   - "PRs must not add raw Office/PDF artifacts."
+_CHANGED_FILES_HIGH_RE = re.compile(
+    r"\b(?:prs?|pull\s+requests?)\b\s+(?:must|should|may|cannot|can\s*not)\s+not\s+"
+    r"(?:change|modify|add|create|commit|include|introduce|touch)\b",
+    re.IGNORECASE,
+)
+
 # Heading that signals this item belongs to a PR/GitHub section
 _PR_HEADING_RE = re.compile(
     r"\b(?:pr|pull\s+request|merge\s+gate|merge\s+check|github)\b",
@@ -190,6 +206,15 @@ def _classify_rule(rule: Rule) -> Rule:
             Backend.GITHUB,
             Confidence.HIGH,
             "explicit PR task/checklist reference",
+        )
+
+    if _CHANGED_FILES_HIGH_RE.search(text):
+        return _make(
+            rule,
+            RuleKind.GITHUB_CHANGED_FILES_ABSENT,
+            Backend.GITHUB,
+            Confidence.HIGH,
+            "explicit PR changed-file forbid wording",
         )
 
     # --- Medium-confidence GitHub (keyword signals without full explicit phrasing) ---

--- a/src/gate_keeper/models.py
+++ b/src/gate_keeper/models.py
@@ -53,6 +53,7 @@ class RuleKind(str, enum.Enum):
     GITHUB_CHECKS_SUCCESS = "github_checks_success"
     GITHUB_THREADS_RESOLVED = "github_threads_resolved"
     GITHUB_NON_AUTHOR_APPROVAL = "github_non_author_approval"
+    GITHUB_CHANGED_FILES_ABSENT = "github_changed_files_absent"
     SEMANTIC_RUBRIC = "semantic_rubric"
     EXTERNAL_CHECK = "external_check"
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -119,6 +119,51 @@ class TestGithubHighConfidence:
 
 
 # ---------------------------------------------------------------------------
+# Changed-file classifier — issue #147 (codex review regressions)
+# ---------------------------------------------------------------------------
+
+
+class TestChangedFilesClassifier:
+    def test_pr_must_not_change_routes_to_changed_files(self):
+        rule = _classify_text("PRs must not change generated workbook outputs.")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_CHANGED_FILES_ABSENT
+        assert rule.confidence is Confidence.HIGH
+
+    def test_pr_cannot_change_without_double_not(self):
+        # Regression for codex feedback: ``cannot`` is a standalone negation;
+        # the regex must not also require an explicit ``not`` after it.
+        rule = _classify_text("PRs cannot change generated outputs.")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_CHANGED_FILES_ABSENT
+        assert rule.confidence is Confidence.HIGH
+
+    def test_pr_can_not_change(self):
+        rule = _classify_text("PRs can not change generated outputs.")
+        assert rule.backend_hint is Backend.GITHUB
+        assert rule.kind is RuleKind.GITHUB_CHANGED_FILES_ABSENT
+
+    def test_pr_must_not_include_does_not_route_to_changed_files(self):
+        # Regression for codex feedback: ``include`` is a content verb, not a
+        # path-mutation verb. "PRs must not include TODO comments" is a
+        # text-content rule that needs ``params.patterns`` it cannot supply,
+        # so routing it to ``github_changed_files_absent`` would surface as
+        # ``unavailable`` with ``params_error`` — a user-visible regression.
+        rule = _classify_text("PRs must not include TODO comments.")
+        assert rule.kind is not RuleKind.GITHUB_CHANGED_FILES_ABSENT
+
+    def test_pr_must_not_introduce_does_not_route_to_changed_files(self):
+        rule = _classify_text("PRs must not introduce new global state.")
+        assert rule.kind is not RuleKind.GITHUB_CHANGED_FILES_ABSENT
+
+    def test_pr_must_not_commit_does_not_route_to_changed_files(self):
+        # ``commit`` is too broad: "PRs must not commit to outdated APIs" is
+        # not a path policy. Drop it from the verb list per codex feedback.
+        rule = _classify_text("PRs must not commit to outdated APIs.")
+        assert rule.kind is not RuleKind.GITHUB_CHANGED_FILES_ABSENT
+
+
+# ---------------------------------------------------------------------------
 # GitHub routing — medium confidence
 # ---------------------------------------------------------------------------
 

--- a/tests/test_github_changed_files.py
+++ b/tests/test_github_changed_files.py
@@ -1,0 +1,637 @@
+"""Tests for the ``github_changed_files_absent`` rule kind (issue #147).
+
+Mirrors the structure of ``test_github_threads.py``: each test patches
+``gate_keeper.backends._target.run_gh`` (the resolver) and
+``gate_keeper.backends.github.run_gh`` (the changed-file fetcher) using a
+sequenced fake so the two ``gh`` calls receive distinct responses.
+
+Coverage:
+- pass (no changed files match)
+- fail (one or more changed files match)
+- params_error (missing/invalid ``patterns``, invalid ``case_sensitive``)
+- GitHub unavailable (``gh`` failure, GraphQL errors, JSON parse error)
+- pagination across multiple pages, including a hard truncation case
+- glob semantics (``**``, single ``*``, ``?``, case folding)
+"""
+
+from __future__ import annotations
+
+import json
+
+from gate_keeper.backends import _gh, _target
+from gate_keeper.backends import github as gh_backend
+from gate_keeper.diagnostics import EXIT_FAIL, EXIT_OK, compute_exit_code
+from gate_keeper.models import (
+    Backend,
+    Confidence,
+    Diagnostic,
+    Rule,
+    RuleKind,
+    RuleSet,
+    Severity,
+    SourceLocation,
+    Status,
+)
+from gate_keeper.validator import validate
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_RESOLVE_OK = json.dumps({"number": 42, "url": "https://github.com/owner/repo/pull/42"})
+
+
+def _ok(stdout: str) -> _gh.GhResult:
+    return _gh.GhResult(ok=True, stdout=stdout, stderr="", returncode=0, cmd=("gh",))
+
+
+def _fail(stderr: str = "error", returncode: int = 1, binary_missing: bool = False) -> _gh.GhResult:
+    return _gh.GhResult(
+        ok=False,
+        stdout="",
+        stderr=stderr,
+        returncode=returncode,
+        cmd=("gh",),
+        binary_missing=binary_missing,
+    )
+
+
+def _make_rule(
+    patterns: object = ("outputs/**", "**/*.xlsx"),
+    case_sensitive: object | None = None,
+    *,
+    omit_patterns: bool = False,
+) -> Rule:
+    params: dict[str, object] = {}
+    if not omit_patterns:
+        params["patterns"] = list(patterns) if isinstance(patterns, (list, tuple)) else patterns
+    if case_sensitive is not None:
+        params["case_sensitive"] = case_sensitive
+    return Rule(
+        id="changed-files-rule",
+        title="PRs must not change generated workbook outputs",
+        source=SourceLocation(path="rules.md", line=1),
+        text="PRs must not change generated workbook outputs.",
+        kind=RuleKind.GITHUB_CHANGED_FILES_ABSENT,
+        severity=Severity.ERROR,
+        backend_hint=Backend.GITHUB,
+        confidence=Confidence.HIGH,
+        params=params,
+    )
+
+
+def _make_run_gh_sequence(results: list[_gh.GhResult]):
+    queue = list(results)
+
+    def _fake(args, **kwargs):
+        if queue:
+            return queue.pop(0)
+        raise AssertionError(f"run_gh called more times than expected; args={args!r}")
+
+    return _fake
+
+
+def _patch_with_pages(monkeypatch, resolve_result: _gh.GhResult, pages: list[_gh.GhResult]):
+    monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([resolve_result]))
+    monkeypatch.setattr(gh_backend, "run_gh", _make_run_gh_sequence(pages))
+
+
+def _files_response(
+    paths: list[str],
+    *,
+    has_next_page: bool = False,
+    end_cursor: str | None = None,
+) -> str:
+    """Build a single-page GraphQL response for the files connection."""
+    return json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "files": {
+                            "nodes": [{"path": p} for p in paths],
+                            "pageInfo": {
+                                "hasNextPage": has_next_page,
+                                "endCursor": end_cursor,
+                            },
+                        }
+                    }
+                }
+            }
+        }
+    )
+
+
+def _check(monkeypatch, paths: list[str], rule: Rule | None = None) -> Diagnostic:
+    """Run a single-page check against *paths* with default patterns."""
+    rule = rule or _make_rule()
+    _patch_with_pages(
+        monkeypatch,
+        _ok(_RESOLVE_OK),
+        [_ok(_files_response(paths, has_next_page=False))],
+    )
+    return gh_backend.check(rule, "owner/repo#42")
+
+
+# ---------------------------------------------------------------------------
+# PASS — no offending file
+# ---------------------------------------------------------------------------
+
+
+class TestPass:
+    def test_no_offending_files_passes(self, monkeypatch):
+        diag = _check(monkeypatch, ["src/foo.py", "README.md"])
+        assert diag.status is Status.PASS
+        ev = diag.evidence[0]
+        assert ev.kind == "pr_changed_files"
+        assert ev.data["total_changed_files"] == 2
+        assert ev.data["offending"] == []
+        assert ev.data["pagination_complete"] is True
+        assert ev.data["page_count"] == 1
+        assert ev.data["forbidden_patterns"] == ["outputs/**", "**/*.xlsx"]
+
+    def test_zero_changed_files_passes(self, monkeypatch):
+        diag = _check(monkeypatch, [])
+        assert diag.status is Status.PASS
+        ev = diag.evidence[0]
+        assert ev.data["total_changed_files"] == 0
+        assert ev.data["offending"] == []
+
+    def test_pass_includes_pr_coords(self, monkeypatch):
+        diag = _check(monkeypatch, ["src/foo.py"])
+        ev = diag.evidence[0]
+        assert ev.data["owner"] == "owner"
+        assert ev.data["repo"] == "repo"
+        assert ev.data["number"] == 42
+        assert ev.data["url"] == "https://github.com/owner/repo/pull/42"
+
+
+# ---------------------------------------------------------------------------
+# FAIL — offending paths matched
+# ---------------------------------------------------------------------------
+
+
+class TestFail:
+    def test_single_offending_file_fails(self, monkeypatch):
+        diag = _check(monkeypatch, ["outputs/results.xlsx"])
+        assert diag.status is Status.FAIL
+        ev = diag.evidence[0]
+        assert ev.data["total_changed_files"] == 1
+        assert len(ev.data["offending"]) == 1
+        offending = ev.data["offending"][0]
+        assert offending["path"] == "outputs/results.xlsx"
+        # Either pattern is acceptable since the matcher records the first hit.
+        assert offending["pattern"] in {"outputs/**", "**/*.xlsx"}
+
+    def test_multiple_offending_files_fails(self, monkeypatch):
+        diag = _check(
+            monkeypatch,
+            ["src/foo.py", "outputs/a.csv", "data.xlsx", "README.md"],
+        )
+        assert diag.status is Status.FAIL
+        ev = diag.evidence[0]
+        assert ev.data["total_changed_files"] == 4
+        assert len(ev.data["offending"]) == 2
+        paths = {entry["path"] for entry in ev.data["offending"]}
+        assert paths == {"outputs/a.csv", "data.xlsx"}
+
+    def test_fail_message_lists_offending_paths(self, monkeypatch):
+        diag = _check(monkeypatch, ["outputs/x"])
+        assert "outputs/x" in diag.message
+        assert "1 of 1" in diag.message
+
+    def test_matched_patterns_recorded(self, monkeypatch):
+        diag = _check(monkeypatch, ["outputs/x", "y.xlsx"])
+        ev = diag.evidence[0]
+        assert set(ev.data["matched_patterns"]) == {"outputs/**", "**/*.xlsx"}
+
+
+# ---------------------------------------------------------------------------
+# Params error — missing or invalid `patterns` / `case_sensitive`
+# ---------------------------------------------------------------------------
+
+
+class TestParamsError:
+    def test_missing_patterns_unavailable(self, monkeypatch):
+        rule = _make_rule(omit_patterns=True)
+        # Patches not strictly needed since params are validated before any
+        # gh call; provide them anyway so an unexpected gh call would fail.
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "params_error"
+        assert ev.data["missing"] == "patterns"
+
+    def test_empty_patterns_list_unavailable(self, monkeypatch):
+        rule = _make_rule(patterns=[])
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "params_error"
+        assert ev.data["field"] == "patterns"
+
+    def test_patterns_not_a_list_unavailable(self, monkeypatch):
+        rule = _make_rule(patterns="outputs/**")  # bare string, not a list
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "params_error"
+        assert ev.data["field"] == "patterns"
+
+    def test_patterns_with_non_string_unavailable(self, monkeypatch):
+        rule = _make_rule(patterns=["outputs/**", 7])
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "params_error"
+        assert ev.data["field"] == "patterns[1]"
+
+    def test_patterns_with_empty_string_unavailable(self, monkeypatch):
+        rule = _make_rule(patterns=["outputs/**", ""])
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "params_error"
+        assert ev.data["field"] == "patterns[1]"
+
+    def test_invalid_case_sensitive_unavailable(self, monkeypatch):
+        rule = _make_rule(case_sensitive="yes")
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "params_error"
+        assert ev.data["field"] == "case_sensitive"
+
+
+# ---------------------------------------------------------------------------
+# GitHub unavailable — gh failures / GraphQL errors / JSON errors
+# ---------------------------------------------------------------------------
+
+
+class TestGithubUnavailable:
+    def test_gh_nonzero_exit_unavailable(self, monkeypatch):
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [_fail(stderr="rate limit exceeded", returncode=1)],
+        )
+        rule = _make_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_failure"
+
+    def test_gh_binary_missing_unavailable(self, monkeypatch):
+        # The resolver detects binary-missing first.
+        monkeypatch.setattr(
+            _target,
+            "run_gh",
+            _make_run_gh_sequence(
+                [_fail(stderr="gh binary not found", returncode=127, binary_missing=True)]
+            ),
+        )
+        rule = _make_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_missing"
+
+    def test_graphql_errors_unavailable(self, monkeypatch):
+        body = json.dumps({"errors": [{"message": "Could not resolve to a Repository"}]})
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [_ok(body)])
+        rule = _make_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "gh_graphql_error"
+        assert ev.data["op"] == "graphql"
+        assert "Repository" in ev.data["errors"][0]
+
+    def test_malformed_json_unavailable(self, monkeypatch):
+        bad_json = _gh.GhResult(
+            ok=True, stdout="not valid json {{{", stderr="", returncode=0, cmd=("gh",)
+        )
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [bad_json])
+        rule = _make_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_json_error"
+
+    def test_missing_files_field_unavailable(self, monkeypatch):
+        body = json.dumps({"data": {"repository": {"pullRequest": {"other": "stuff"}}}})
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [_ok(body)])
+        rule = _make_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "gh_missing_field"
+        assert "files" in ev.data["field"]
+
+    def test_node_missing_path_unavailable(self, monkeypatch):
+        body = json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "files": {
+                                "nodes": [{"path": "ok.py"}, {"other": "thing"}],
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            }
+                        }
+                    }
+                }
+            }
+        )
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [_ok(body)])
+        rule = _make_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "gh_missing_field"
+        assert "nodes[].path" in ev.data["field"]
+
+
+# ---------------------------------------------------------------------------
+# Pagination — two pages succeed, partial pagination is UNAVAILABLE
+# ---------------------------------------------------------------------------
+
+
+class TestPagination:
+    def test_two_pages_succeed(self, monkeypatch):
+        page1 = _ok(
+            _files_response(
+                ["src/a.py", "src/b.py"],
+                has_next_page=True,
+                end_cursor="cursor-1",
+            )
+        )
+        page2 = _ok(_files_response(["outputs/c.csv"], has_next_page=False, end_cursor=None))
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [page1, page2])
+        rule = _make_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        ev = diag.evidence[0]
+        assert ev.data["total_changed_files"] == 3
+        assert ev.data["page_count"] == 2
+        assert ev.data["pagination_complete"] is True
+        offending_paths = {entry["path"] for entry in ev.data["offending"]}
+        assert offending_paths == {"outputs/c.csv"}
+
+    def test_three_pages_with_no_offending_passes(self, monkeypatch):
+        pages = [
+            _ok(_files_response(["a.py", "b.py"], has_next_page=True, end_cursor="c1")),
+            _ok(_files_response(["c.py", "d.py"], has_next_page=True, end_cursor="c2")),
+            _ok(_files_response(["e.py"], has_next_page=False, end_cursor=None)),
+        ]
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), pages)
+        rule = _make_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.PASS
+        ev = diag.evidence[0]
+        assert ev.data["total_changed_files"] == 5
+        assert ev.data["page_count"] == 3
+        assert ev.data["pagination_complete"] is True
+
+    def test_pagination_continues_with_endcursor_from_previous_page(self, monkeypatch):
+        captured: list[list[str]] = []
+
+        def fake_fetcher(args, **kwargs):
+            captured.append(list(args))
+            # First call → has next page, cursor "c1"; second call → end.
+            if len(captured) == 1:
+                return _ok(
+                    _files_response(["a.py"], has_next_page=True, end_cursor="cursor-A")
+                )
+            return _ok(_files_response(["b.py"], has_next_page=False, end_cursor=None))
+
+        monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([_ok(_RESOLVE_OK)]))
+        monkeypatch.setattr(gh_backend, "run_gh", fake_fetcher)
+
+        rule = _make_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.PASS
+        # First request: no after; second request: after=cursor-A.
+        assert not any(arg.startswith("after=") for arg in captured[0])
+        assert any(arg == "after=cursor-A" for arg in captured[1])
+
+    def test_has_next_true_with_missing_cursor_unavailable(self, monkeypatch):
+        body = _files_response(["src/a.py"], has_next_page=True, end_cursor=None)
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [_ok(body)])
+        rule = _make_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_pagination_unavailable"
+
+    def test_has_next_non_bool_unavailable(self, monkeypatch):
+        body = json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "files": {
+                                "nodes": [{"path": "a.py"}],
+                                "pageInfo": {"hasNextPage": "yes", "endCursor": "c"},
+                            }
+                        }
+                    }
+                }
+            }
+        )
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [_ok(body)])
+        rule = _make_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_pagination_unavailable"
+
+    def test_pagination_runaway_capped_at_max_pages(self, monkeypatch):
+        # Every page reports has_next_page=True with a fresh cursor; the
+        # backend must stop after _CHANGED_FILES_MAX_PAGES and return
+        # UNAVAILABLE rather than loop forever.
+        def fake_fetcher(args, **kwargs):
+            return _ok(_files_response(["a.py"], has_next_page=True, end_cursor="c"))
+
+        monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([_ok(_RESOLVE_OK)]))
+        monkeypatch.setattr(gh_backend, "run_gh", fake_fetcher)
+        rule = _make_rule()
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "gh_pagination_unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Glob semantics
+# ---------------------------------------------------------------------------
+
+
+class TestGlobSemantics:
+    def test_globstar_matches_nested_paths(self, monkeypatch):
+        rule = _make_rule(patterns=["context/researcher/raw/**"])
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [
+                _ok(
+                    _files_response(
+                        [
+                            "context/researcher/raw/a.txt",
+                            "context/researcher/raw/sub/b.txt",
+                            "src/foo.py",
+                        ]
+                    )
+                )
+            ],
+        )
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        offending = {e["path"] for e in diag.evidence[0].data["offending"]}
+        assert offending == {
+            "context/researcher/raw/a.txt",
+            "context/researcher/raw/sub/b.txt",
+        }
+
+    def test_double_star_matches_any_xlsx(self, monkeypatch):
+        rule = _make_rule(patterns=["**/*.xlsx"])
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [_ok(_files_response(["report.xlsx", "deep/nested/data.xlsx", "src/x.py"]))],
+        )
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        offending = {e["path"] for e in diag.evidence[0].data["offending"]}
+        assert offending == {"report.xlsx", "deep/nested/data.xlsx"}
+
+    def test_single_star_does_not_cross_segments(self, monkeypatch):
+        # Single ``*`` should not match across path separators, so
+        # ``deep/nested/x.py`` must NOT match ``src/*.py`` or ``*.py``
+        # if those would require crossing slashes.
+        rule = _make_rule(patterns=["src/*.py"])
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [_ok(_files_response(["src/a.py", "src/sub/b.py"]))],
+        )
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        offending = {e["path"] for e in diag.evidence[0].data["offending"]}
+        assert offending == {"src/a.py"}
+
+    def test_question_mark_matches_single_char(self, monkeypatch):
+        rule = _make_rule(patterns=["log?.txt"])
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [_ok(_files_response(["log1.txt", "log10.txt"]))],
+        )
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        offending = {e["path"] for e in diag.evidence[0].data["offending"]}
+        assert offending == {"log1.txt"}
+
+    def test_case_sensitive_default(self, monkeypatch):
+        rule = _make_rule(patterns=["**/*.XLSX"])
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [_ok(_files_response(["data.xlsx", "DATA.XLSX"]))],
+        )
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        offending = {e["path"] for e in diag.evidence[0].data["offending"]}
+        assert offending == {"DATA.XLSX"}
+
+    def test_case_insensitive_matches_either(self, monkeypatch):
+        rule = _make_rule(patterns=["**/*.XLSX"], case_sensitive=False)
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [_ok(_files_response(["data.xlsx", "DATA.XLSX"]))],
+        )
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        offending = {e["path"] for e in diag.evidence[0].data["offending"]}
+        assert offending == {"data.xlsx", "DATA.XLSX"}
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic round-trip and end-to-end integration
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTripAndIntegration:
+    def test_pass_round_trips(self, monkeypatch):
+        diag = _check(monkeypatch, ["src/foo.py"])
+        rt = Diagnostic.from_dict(diag.to_dict())
+        assert rt.status is Status.PASS
+        assert rt.evidence[0].kind == "pr_changed_files"
+
+    def test_fail_round_trips(self, monkeypatch):
+        diag = _check(monkeypatch, ["outputs/x"])
+        rt = Diagnostic.from_dict(diag.to_dict())
+        assert rt.status is Status.FAIL
+        assert rt.evidence[0].data["offending"][0]["path"] == "outputs/x"
+
+    def test_validate_pass_returns_exit_ok(self, monkeypatch):
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [_ok(_files_response(["src/foo.py"]))],
+        )
+        rule = _make_rule()
+        ruleset = RuleSet(rules=[rule])
+        report = validate(ruleset, "owner/repo#42", backend="auto")
+        assert len(report.diagnostics) == 1
+        assert report.diagnostics[0].status is Status.PASS
+        assert compute_exit_code(report.diagnostics) == EXIT_OK
+
+    def test_validate_fail_returns_exit_fail(self, monkeypatch):
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [_ok(_files_response(["outputs/forbidden.csv"]))],
+        )
+        rule = _make_rule()
+        ruleset = RuleSet(rules=[rule])
+        report = validate(ruleset, "owner/repo#42", backend="auto")
+        assert len(report.diagnostics) == 1
+        assert report.diagnostics[0].status is Status.FAIL
+        assert compute_exit_code(report.diagnostics) == EXIT_FAIL
+
+
+# ---------------------------------------------------------------------------
+# Command construction — argv shape for the GraphQL call
+# ---------------------------------------------------------------------------
+
+
+class TestCommandConstruction:
+    def test_first_page_argv_shape(self, monkeypatch):
+        captured: list[str] = []
+
+        def fake_fetcher(args, **kwargs):
+            captured.extend(args)
+            return _ok(_files_response([]))
+
+        monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([_ok(_RESOLVE_OK)]))
+        monkeypatch.setattr(gh_backend, "run_gh", fake_fetcher)
+
+        rule = _make_rule()
+        gh_backend.check(rule, "owner/repo#42")
+
+        assert "api" in captured
+        assert "graphql" in captured
+        # The query arg must reference the files connection, not threads.
+        query_arg = next((a for a in captured if "files(first: $first" in a), None)
+        assert query_arg is not None
+        assert "reviewThreads" not in query_arg
+        # owner/repo/number/first variables must appear.
+        assert any(a == "owner=owner" for a in captured)
+        assert any(a == "repo=repo" for a in captured)
+        assert "-F" in captured
+        assert any(a == "number=42" for a in captured)
+        assert any(a == "first=100" for a in captured)
+        # First request must NOT include an ``after`` cursor.
+        assert not any(a.startswith("after=") for a in captured)

--- a/tests/test_github_changed_files.py
+++ b/tests/test_github_changed_files.py
@@ -291,9 +291,7 @@ class TestGithubUnavailable:
         monkeypatch.setattr(
             _target,
             "run_gh",
-            _make_run_gh_sequence(
-                [_fail(stderr="gh binary not found", returncode=127, binary_missing=True)]
-            ),
+            _make_run_gh_sequence([_fail(stderr="gh binary not found", returncode=127, binary_missing=True)]),
         )
         rule = _make_rule()
         diag = gh_backend.check(rule, "owner/repo#42")
@@ -312,9 +310,7 @@ class TestGithubUnavailable:
         assert "Repository" in ev.data["errors"][0]
 
     def test_malformed_json_unavailable(self, monkeypatch):
-        bad_json = _gh.GhResult(
-            ok=True, stdout="not valid json {{{", stderr="", returncode=0, cmd=("gh",)
-        )
+        bad_json = _gh.GhResult(ok=True, stdout="not valid json {{{", stderr="", returncode=0, cmd=("gh",))
         _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [bad_json])
         rule = _make_rule()
         diag = gh_backend.check(rule, "owner/repo#42")
@@ -403,9 +399,7 @@ class TestPagination:
             captured.append(list(args))
             # First call → has next page, cursor "c1"; second call → end.
             if len(captured) == 1:
-                return _ok(
-                    _files_response(["a.py"], has_next_page=True, end_cursor="cursor-A")
-                )
+                return _ok(_files_response(["a.py"], has_next_page=True, end_cursor="cursor-A"))
             return _ok(_files_response(["b.py"], has_next_page=False, end_cursor=None))
 
         monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([_ok(_RESOLVE_OK)]))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -59,6 +59,7 @@ def test_rule_kind_members():
         "github_checks_success",
         "github_threads_resolved",
         "github_non_author_approval",
+        "github_changed_files_absent",
         "semantic_rubric",
         "external_check",
     }


### PR DESCRIPTION
## Summary

- Adds `RuleKind.GITHUB_CHANGED_FILES_ABSENT` with `params.patterns` (required, non-empty list of globs) and optional `params.case_sensitive` (default `true`); missing/invalid params produce `unavailable` / `params_error`.
- New GitHub backend handler walks the GraphQL `pullRequest.files` connection page-by-page and treats incomplete pagination as `unavailable` so a forbidden path added in a later page can never be silently skipped. Evidence kind `pr_changed_files` records total changed-file count, forbidden patterns, offending paths, matched patterns, pagination completeness, page count, and PR coordinates.
- Glob semantics tuned for changed-file paths: `**` crosses path segments, `*` stays within a segment, `?` matches one non-`/` char.
- Classifier routes only explicit PR-+-file-modification wording (e.g. *PRs must not change/add/create…*) to keep ambiguous filesystem rules on the filesystem backend.
- Docs updated: `rule-ir.md` (params + evidence + failure modes table), `cli-reference.md` (per-rule note), `example-rules.md` (new annotated walkthrough).

## Test plan

- [x] `uv run pytest` (829 passed)
- [x] `uvx ruff check .` (clean)
- [x] `uv run pyright` (0 errors)
- [x] New `tests/test_github_changed_files.py` covers: pass, fail, params_error (missing/empty/non-list/non-string entry/empty entry/invalid case_sensitive), gh failures (binary missing, non-zero exit, GraphQL errors, JSON parse error, missing fields), multi-page pagination success, partial-pagination unavailable, runaway-pagination cap, glob semantics (`**`, single `*`, `?`, case folding), diagnostic round-trip, end-to-end via `validate`, argv shape.

Closes #147

@codex please review this PR