### PR TITLE
feat(cli): filesystem multi-target via --target repetition / dir / glob

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -182,7 +182,7 @@ gate-keeper validate [--rules-format {markdown,ir}]
                      [--backend {auto,filesystem,github,llm-rubric,external}]
                      [--format {text,json}] [--verbose]
                      [--reproducibility N]
-                     --target <TARGET>
+                     --target <TARGET> [--target <TARGET> ...]
                      (<rules> | --include GLOB [--include GLOB ...])
 ```
 
@@ -195,7 +195,7 @@ Provide either a single positional `rules` document **or** one or more
 |---|---|---|---|
 | `rules` | positional | — | Path to a Markdown rule document, or to a precompiled Rule IR JSON file when `--rules-format ir` is given. Omit when using `--include`. |
 | `--include GLOB` | option (repeatable) | — | Compose a policy bundle from every Markdown document matching `GLOB`. May be passed multiple times. Mutually exclusive with the positional `rules`. Not compatible with `--rules-format ir`. |
-| `--target TARGET` | option | **required** | Artifact or PR to validate. Pass a local path for filesystem rules; a GitHub PR URL or `owner/repo#N` for GitHub rules. |
+| `--target TARGET` | option (repeatable) | **required** | Artifact or PR to validate. May be specified multiple times for filesystem multi-target evaluation (see [Multi-target evaluation](#multi-target-evaluation)). Each value is a local path, directory, quoted glob, GitHub PR URL, or `owner/repo#N` shorthand. |
 | `--rules-format {markdown,ir}` | option | `markdown` | How to interpret `rules`. `markdown` (default) parses and classifies a Markdown rule document — the historical behaviour. `ir` loads a precompiled `RuleSet` JSON file (the same shape `compile` emits) using the strict IR parser and **bypasses the classifier**, so hand-authored `kind`, `backend_hint`, and `params` fields reach the validator unchanged. |
 | `--backend {auto,filesystem,github,llm-rubric,external}` | option | `auto` | Validation backend. `auto` delegates each rule to the backend the classifier (or the IR file) selected. |
 | `--format {text,json}` | option | `text` | Output format. |
@@ -338,6 +338,58 @@ Each line: `path:line: severity: [backend/status] rule_id: message [evidence]`.
   generated workbook outputs"*) to this kind; ambiguous filesystem rules
   remain on the filesystem or semantic backends. See
   [docs/rule-ir.md](rule-ir.md) for the full params and evidence shape.
+
+### Multi-target evaluation
+
+`--target` accepts multiple occurrences for filesystem rules; the resolved
+file set is deduplicated, sorted lexicographically, and evaluated as a single
+aggregated diagnostic per rule.
+
+| Form | Example | Behaviour |
+|---|---|---|
+| Single file | `--target README.md` | Unchanged from earlier releases — the path is forwarded verbatim. |
+| Repeated flag | `--target a.md --target b.md` | Both files are evaluated; one diagnostic per rule. |
+| Directory | `--target docs/` | Recursively walks the directory; only text-readable files are included. |
+| Quoted glob | `--target 'docs/**/*.md'` | Expanded by the CLI with `recursive=True`; matched directories are walked. Quote the pattern to bypass shell expansion when desired. |
+
+```sh
+# All three filesystem rules, evaluated against every text-readable file
+# under docs/:
+uv run gate-keeper validate rules.md --target docs/ --format json
+
+# Two specific files:
+uv run gate-keeper validate rules.md \
+    --target README.md --target docs/cli-reference.md
+
+# Recursive Markdown glob:
+uv run gate-keeper validate rules.md --target 'docs/**/*.md'
+```
+
+**Aggregation rules** (filesystem backend):
+
+- `pass` only when every resolved file passes.
+- `fail` when at least one file fails; the diagnostic message names the
+  first few failing paths and the `multi_target_summary` evidence record
+  carries `pass_count` / `fail_count` / `file_count`.
+- `unavailable` when the resolved file set is empty (fail-closed) or when
+  any per-file evaluation surfaces `unavailable` / `unsupported` / `error`.
+- Per-file outcomes appear as `Evidence(kind="file_result", ...)` items,
+  capped at 50; the `multi_target_summary` record reports
+  `evidence_truncated` when the cap clips the list.
+
+**File-count cap.** Expansion is bounded at **200 files** by default. When a
+directory or glob expands to more than the cap, the CLI exits with
+`EXIT_USAGE` (`2`) and prints `error: --target: target expansion produced N
+files; exceeds limit of 200.` Narrow the target or split the run.
+
+**Non-filesystem backends.** GitHub, LLM-rubric, and external backends do
+*not* support multi-target invocation in this slice. They fail closed with
+`unsupported` and a `multi_target_unsupported` evidence record listing the
+raw targets and the resolved file count, rather than silently using only one
+of the resolved paths.
+
+See [docs/design/multi-target.md](design/multi-target.md) for the design
+background; this section documents the first implemented slice.
 
 ---
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -350,7 +350,7 @@ aggregated diagnostic per rule.
 | Single file | `--target README.md` | Unchanged from earlier releases — the path is forwarded verbatim. |
 | Repeated flag | `--target a.md --target b.md` | Both files are evaluated; one diagnostic per rule. |
 | Directory | `--target docs/` | Recursively walks the directory; only text-readable files are included. |
-| Quoted glob | `--target 'docs/**/*.md'` | Expanded by the CLI with `recursive=True`; matched directories are walked. Quote the pattern to bypass shell expansion when desired. |
+| Quoted glob | `--target 'docs/**/*.md'` | Expanded by the CLI with `recursive=True`; matched directories are walked. **Quote the pattern** so your shell does not expand it before `gate-keeper` sees it — `argparse` only accepts a single value per `--target`, so an unquoted glob expanded by the shell will produce an "unexpected positional arguments" error. |
 
 ```sh
 # All three filesystem rules, evaluated against every text-readable file

--- a/docs/design/multi-target.md
+++ b/docs/design/multi-target.md
@@ -4,6 +4,28 @@
 
 Tracking issue: #74. Design phase only — no IR or backend changes in this doc.
 
+> **Implementation status (first slice).** Issue #146 implements the
+> filesystem multi-target slice of this design. Shipped in that slice:
+>
+> - `TargetSpec` internal helper (`src/gate_keeper/targets.py`).
+> - `validate --target` accepts multiple occurrences (CLI `append` action).
+> - Single literal-file targets preserve pre-#146 behaviour exactly.
+> - Directory and quoted-glob expansion (recursive, text-readable filter).
+> - Lexicographic dedup + sort across resolved paths.
+> - Filesystem backend aggregates per-file results into one Diagnostic
+>   (`pass` only if all files pass; `fail` if any fail; `unavailable` if the
+>   resolved set is empty or any file is `unavailable`/`unsupported`/`error`).
+> - Default file-count cap of 200; exceeding the cap is a CLI usage error.
+> - Non-filesystem backends (`github`, `llm-rubric`, `external`) reject
+>   multi-target inputs with `unsupported` and a `multi_target_unsupported`
+>   evidence record (fail-closed; never silently use only one target).
+>
+> **Out of slice (deferred):** LLM-rubric multi-file content assembly
+> (`params.targets`, token budgeting), external adapter multi-target
+> contract, dotenv-driven cap override, remote/non-filesystem URIs,
+> heuristic relevance ranking, streaming evaluation. The user-facing
+> reference is `docs/cli-reference.md` § "Multi-target evaluation".
+
 ---
 
 ## 1. Problem Statement

--- a/src/gate_keeper/backends/__init__.py
+++ b/src/gate_keeper/backends/__init__.py
@@ -23,9 +23,13 @@ from gate_keeper.backends import filesystem as _fs
 from gate_keeper.backends import github as _gh
 from gate_keeper.backends import llm_rubric as _llm
 from gate_keeper.models import Diagnostic, Rule
+from gate_keeper.targets import TargetSpec
 
-# Registry: name -> check callable
-_REGISTRY: dict[str, Callable[[Rule, str | Path], Diagnostic]] = {
+# Registry: name -> check callable.
+# Backends accept ``str | Path`` for single-target calls or ``TargetSpec`` for
+# multi-target calls (issue #146). Backends that do not support multi-target
+# return UNSUPPORTED diagnostics rather than silently dropping targets.
+_REGISTRY: dict[str, Callable[[Rule, str | Path | TargetSpec], Diagnostic]] = {
     _fs.name: _fs.check,
     _gh.name: _gh.check,
     _llm.name: _llm.check,
@@ -36,7 +40,7 @@ _REGISTRY: dict[str, Callable[[Rule, str | Path], Diagnostic]] = {
 BACKEND_NAMES: list[str] = sorted(_REGISTRY)
 
 
-def get(name: str) -> Callable[[Rule, str | Path], Diagnostic] | None:
+def get(name: str) -> Callable[[Rule, str | Path | TargetSpec], Diagnostic] | None:
     """Return the check callable for *name*, or ``None`` if not registered."""
     return _REGISTRY.get(name)
 

--- a/src/gate_keeper/backends/external.py
+++ b/src/gate_keeper/backends/external.py
@@ -48,6 +48,7 @@ from gate_keeper.models import (
     RuleKind,
     Status,
 )
+from gate_keeper.targets import TargetSpec
 
 name = "external"
 
@@ -132,11 +133,40 @@ def _diag(
     )
 
 
-def check(rule: Rule, target: str | Path) -> Diagnostic:
+def check(rule: Rule, target: str | Path | TargetSpec) -> Diagnostic:
     """Dispatch *rule* to the adapter named by ``rule.params['tool']``.
 
     See module docstring for the full fail-closed contract.
+
+    Multi-target inputs (``TargetSpec`` with ``is_multi=True``) are not
+    supported by the external dispatcher in the first slice (issue #146);
+    each adapter's contract is single-target today and silently using only
+    one of the resolved files would be unsafe. Multi-target calls fail
+    closed with ``UNSUPPORTED`` and a ``multi_target_unsupported`` evidence
+    record. Single-file ``TargetSpec`` values are unwrapped before dispatch
+    so the adapter sees a plain ``Path``.
     """
+    if isinstance(target, TargetSpec):
+        if target.is_multi:
+            return _diag(
+                rule,
+                Status.UNSUPPORTED,
+                (
+                    "external backend does not support multi-target evaluation; "
+                    "external adapters are single-target in the current contract."
+                ),
+                [
+                    Evidence(
+                        kind="multi_target_unsupported",
+                        data={
+                            "backend": "external",
+                            "raw_targets": list(target.raw_targets),
+                            "file_count": len(target.paths),
+                        },
+                    )
+                ],
+            )
+        target = target.paths[0] if target.paths else ""
     if rule.kind is not RuleKind.EXTERNAL_CHECK:
         return _diag(
             rule,

--- a/src/gate_keeper/backends/filesystem.py
+++ b/src/gate_keeper/backends/filesystem.py
@@ -1,6 +1,29 @@
 """Filesystem and text backend for gate-keeper.
 
 Evaluates a single compiled Rule against a local target path.
+
+Targets
+-------
+``check`` accepts either:
+
+- a single path-like target (``str`` or :class:`pathlib.Path`) — preserves the
+  pre-#146 behaviour exactly; or
+- a :class:`gate_keeper.targets.TargetSpec` carrying one or more resolved
+  paths (issue #146).  When the spec contains a single path that came from a
+  literal file argument, behaviour is identical to the single-path case.
+  Otherwise, the rule is evaluated against each resolved file and the results
+  are aggregated into a single ``Diagnostic`` per the contract documented in
+  ``docs/design/multi-target.md`` §6:
+
+  * ``PASS`` only if every per-file evaluation passes.
+  * ``FAIL`` if any per-file evaluation fails.
+  * ``UNAVAILABLE`` if the resolved file set is empty (fail-closed) or if
+    any per-file evaluation produces an ``UNAVAILABLE`` /
+    ``UNSUPPORTED`` / ``ERROR`` status.
+  * Per-file outcomes are recorded in ``Evidence(kind="file_result", ...)``
+    items, capped to keep diagnostic JSON bounded; a
+    ``multi_target_summary`` evidence record carries the file-count totals.
+
 Never raises — all exceptions are translated into diagnostics.
 """
 
@@ -33,6 +56,12 @@ from gate_keeper.models import (
     RuleKind,
     Status,
 )
+from gate_keeper.targets import TargetSpec
+
+# Cap the number of per-file evidence records included in an aggregated
+# diagnostic.  Beyond this point we summarise the remainder so the JSON output
+# stays bounded even when the file-count cap is raised in future work.
+_PER_FILE_EVIDENCE_LIMIT = 50
 
 name = "filesystem"
 
@@ -71,9 +100,26 @@ def _diag(rule: Rule, status: Status, message: str, evidence: list[Evidence]) ->
     )
 
 
-def check(rule: Rule, target: str | Path) -> Diagnostic:
-    """Evaluate *rule* against *target*. Returns a Diagnostic; never raises."""
+def check(rule: Rule, target: str | Path | TargetSpec) -> Diagnostic:
+    """Evaluate *rule* against *target*. Returns a Diagnostic; never raises.
+
+    *target* may be a single path-like value (legacy single-target call) or a
+    :class:`gate_keeper.targets.TargetSpec` (multi-target call introduced in
+    issue #146).  See the module docstring for the multi-target aggregation
+    contract.
+    """
     try:
+        if isinstance(target, TargetSpec):
+            if not target.is_multi:
+                # Single literal-file spec: preserve the per-file dispatch
+                # path exactly so existing diagnostics remain bit-identical.
+                if target.paths:
+                    return _dispatch(rule, target.paths[0])
+                # Empty single-target spec is structurally impossible (the
+                # CLI requires at least one --target) but we still fail
+                # closed defensively.
+                return _multi_unavailable_empty(rule, target)
+            return _multi_check(rule, target)
         return _dispatch(rule, Path(target))
     except Exception as exc:  # noqa: BLE001
         return _diag(
@@ -82,6 +128,149 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
             f"internal error: {exc}",
             [Evidence(kind="exception", data={"type": type(exc).__name__, "message": str(exc)})],
         )
+
+
+# ---------------------------------------------------------------------------
+# Multi-target aggregation (issue #146)
+# ---------------------------------------------------------------------------
+
+
+def _multi_unavailable_empty(rule: Rule, spec: TargetSpec) -> Diagnostic:
+    """Return an UNAVAILABLE diagnostic for an empty resolved file set."""
+    return _diag(
+        rule,
+        Status.UNAVAILABLE,
+        (
+            "multi-target evaluation resolved to zero files; "
+            "fail-closed (refine the target or check the glob)."
+        ),
+        [
+            Evidence(
+                kind="multi_target_summary",
+                data={
+                    "raw_targets": list(spec.raw_targets),
+                    "file_count": 0,
+                    "pass_count": 0,
+                    "fail_count": 0,
+                    "unavailable_count": 0,
+                },
+            )
+        ],
+    )
+
+
+def _multi_check(rule: Rule, spec: TargetSpec) -> Diagnostic:
+    """Aggregate per-file evaluations of *rule* across ``spec.paths``.
+
+    Contract is documented in the module docstring; implementation follows
+    ``docs/design/multi-target.md`` §6 (filesystem backend).
+    """
+    # Empty file set after expansion: fail-closed.
+    if not spec.paths:
+        return _multi_unavailable_empty(rule, spec)
+
+    # Special-case kinds that depend on the rule.kind being supported.  An
+    # unsupported kind never reaches per-file dispatch — emit UNSUPPORTED once.
+    if rule.kind not in _FILESYSTEM_KINDS:
+        return _diag(
+            rule,
+            Status.UNSUPPORTED,
+            f"rule kind {rule.kind.value!r} is not supported by the filesystem backend",
+            [
+                Evidence(
+                    kind="backend_capability",
+                    data={"backend": "filesystem", "kind": rule.kind.value},
+                )
+            ],
+        )
+
+    pass_count = 0
+    fail_count = 0
+    unavailable_count = 0
+    other_count = 0
+    file_results: list[Evidence] = []
+    failing_paths: list[str] = []
+    unavailable_paths: list[str] = []
+
+    for path in spec.paths:
+        per = _dispatch(rule, path)
+        status = per.status
+        if status is Status.PASS:
+            pass_count += 1
+        elif status is Status.FAIL:
+            fail_count += 1
+            failing_paths.append(str(path))
+        elif status is Status.UNAVAILABLE:
+            unavailable_count += 1
+            unavailable_paths.append(str(path))
+        else:
+            other_count += 1
+
+        if len(file_results) < _PER_FILE_EVIDENCE_LIMIT:
+            file_results.append(
+                Evidence(
+                    kind="file_result",
+                    data={
+                        "path": str(path),
+                        "status": status.value,
+                        "message": per.message,
+                    },
+                )
+            )
+
+    total = len(spec.paths)
+    truncated = total - len(file_results)
+    summary_data: dict[str, object] = {
+        "raw_targets": list(spec.raw_targets),
+        "file_count": total,
+        "pass_count": pass_count,
+        "fail_count": fail_count,
+        "unavailable_count": unavailable_count,
+    }
+    if other_count:
+        summary_data["other_count"] = other_count
+    if truncated > 0:
+        summary_data["evidence_truncated"] = truncated
+
+    evidence: list[Evidence] = [
+        Evidence(kind="multi_target_summary", data=summary_data),
+        *file_results,
+    ]
+
+    # Aggregation policy:
+    # - any UNAVAILABLE / UNSUPPORTED / ERROR result short-circuits to
+    #   UNAVAILABLE (fail-closed for evaluator-state failures).
+    # - otherwise: FAIL if any per-file FAIL; PASS only when every file PASSed.
+    if unavailable_count > 0 or other_count > 0:
+        sample_unavailable = unavailable_paths[:3]
+        message_parts = [
+            f"multi-target evaluation could not complete for {unavailable_count + other_count}",
+            f"of {total} file(s)",
+        ]
+        if sample_unavailable:
+            message_parts.append(f"(first: {', '.join(sample_unavailable)})")
+        return _diag(
+            rule,
+            Status.UNAVAILABLE,
+            " ".join(message_parts) + ".",
+            evidence,
+        )
+
+    if fail_count > 0:
+        sample_failing = failing_paths[:3]
+        msg = (
+            f"{fail_count} of {total} file(s) failed rule"
+            + (f" (first: {', '.join(sample_failing)})" if sample_failing else "")
+            + "."
+        )
+        return _diag(rule, Status.FAIL, msg, evidence)
+
+    return _diag(
+        rule,
+        Status.PASS,
+        f"all {total} file(s) passed rule.",
+        evidence,
+    )
 
 
 def _dispatch(rule: Rule, target: Path) -> Diagnostic:

--- a/src/gate_keeper/backends/github.py
+++ b/src/gate_keeper/backends/github.py
@@ -45,6 +45,7 @@ from gate_keeper.backends._target import (  # noqa: F401  (re-export)
     resolve_target,
 )
 from gate_keeper.models import Backend, Diagnostic, Evidence, Rule, RuleKind, Status
+from gate_keeper.targets import TargetSpec
 
 name = "github"
 
@@ -1259,7 +1260,7 @@ _DIRECT_HANDLERS = {
 # ---------------------------------------------------------------------------
 
 
-def check(rule: Rule, target: str | Path) -> Diagnostic:
+def check(rule: Rule, target: str | Path | TargetSpec) -> Diagnostic:
     """Resolve the target, then dispatch by rule kind.
 
     Resolution failures (bad target, missing gh, auth error, PR not found)
@@ -1268,7 +1269,36 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
     - Six rule kinds share a single ``gh pr view`` call (_PR_VIEW_HANDLERS).
     - ``github_threads_resolved`` makes its own GraphQL call (_DIRECT_HANDLERS).
     - Unrecognised kinds receive a defensive UNAVAILABLE fall-through.
+
+    Multi-target inputs (``TargetSpec`` with ``is_multi=True``) are not
+    supported by the GitHub backend; this backend operates on a single PR
+    reference at a time. Such calls fail closed with ``UNSUPPORTED`` and a
+    ``multi_target_unsupported`` evidence record (issue #146).
     """
+    if isinstance(target, TargetSpec):
+        if target.is_multi:
+            return Diagnostic(
+                rule_id=rule.id,
+                source=rule.source,
+                backend=Backend.GITHUB,
+                status=Status.UNSUPPORTED,
+                severity=rule.severity,
+                message=(
+                    "github backend does not support multi-target evaluation; "
+                    "pass a single PR URL or owner/repo#number reference."
+                ),
+                evidence=[
+                    Evidence(
+                        kind="multi_target_unsupported",
+                        data={
+                            "backend": "github",
+                            "raw_targets": list(target.raw_targets),
+                            "file_count": len(target.paths),
+                        },
+                    )
+                ],
+            )
+        target = target.paths[0] if target.paths else ""
     target_str = str(target)
     pr, diag = resolve_target(rule, target_str)
     if diag is not None:

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from gate_keeper.models import Backend, Diagnostic, Evidence, Rule, Status
+from gate_keeper.targets import TargetSpec
 
 name = "llm-rubric"
 
@@ -501,7 +502,7 @@ def _unavailable_provider_error(
 # ---------------------------------------------------------------------------
 
 
-def check(rule: Rule, target: str | Path) -> Diagnostic:
+def check(rule: Rule, target: str | Path | TargetSpec) -> Diagnostic:
     """Evaluate a semantic-rubric rule against *target*.
 
     When no provider is configured (or the env file is absent), returns
@@ -511,6 +512,14 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
     ``LlmJudgment``). Provider errors and unparseable responses map to
     ``UNAVAILABLE`` with ``provider_error`` evidence — never to a crash,
     ``pass``, or ``fail``.
+
+    Multi-target inputs (``TargetSpec`` with ``is_multi=True``) are not
+    supported by this backend in the first slice (issue #146); the call
+    returns ``UNSUPPORTED`` with a ``multi_target_unsupported`` evidence
+    record so callers can see that targets were silently dropped is *not*
+    happening — content assembly is deferred to a follow-up. Single-file
+    ``TargetSpec`` values are unwrapped to the underlying path so callers
+    can mix CLI surfaces freely.
 
     On success the ``evidence[0].data`` dict contains:
 
@@ -529,6 +538,33 @@ def check(rule: Rule, target: str | Path) -> Diagnostic:
 
     ``Diagnostic.remediation`` is set to ``suggested_action`` on fail.
     """
+    if isinstance(target, TargetSpec):
+        if target.is_multi:
+            return Diagnostic(
+                rule_id=rule.id,
+                source=rule.source,
+                backend=Backend.LLM_RUBRIC,
+                status=Status.UNSUPPORTED,
+                severity=rule.severity,
+                message=(
+                    "llm-rubric backend does not support multi-target evaluation; "
+                    "content assembly is deferred to a follow-up."
+                ),
+                evidence=[
+                    Evidence(
+                        kind="multi_target_unsupported",
+                        data={
+                            "backend": "llm-rubric",
+                            "raw_targets": list(target.raw_targets),
+                            "file_count": len(target.paths),
+                        },
+                    )
+                ],
+            )
+        # Single-file spec: unwrap so the rest of the function operates on
+        # the underlying path exactly as it did before #146.
+        target = target.paths[0] if target.paths else ""
+
     rubric_input = _build_rubric_input(rule, target)
 
     if not _is_configured():

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -207,7 +207,19 @@ def build_parser() -> argparse.ArgumentParser:
             "positional path with --rules-format ir for IR input)."
         ),
     )
-    validate_parser.add_argument("--target", required=True, help="artifact or PR to validate")
+    validate_parser.add_argument(
+        "--target",
+        required=True,
+        action="append",
+        dest="target",
+        metavar="TARGET",
+        help=(
+            "artifact or PR to validate. May be specified multiple times to evaluate "
+            "filesystem rules across several files; values may be paths, directories, "
+            "or quoted globs. Repeated values are deduplicated and sorted "
+            "lexicographically. Non-filesystem backends accept a single value only."
+        ),
+    )
     validate_parser.add_argument(
         "--rules-format",
         dest="rules_format",
@@ -436,6 +448,7 @@ def _cmd_validate(args: argparse.Namespace) -> int:
     from gate_keeper import validator
     from gate_keeper.backends import is_registered
     from gate_keeper.diagnostics import compute_exit_code, render_json, render_text
+    from gate_keeper.targets import TargetExpansionError, resolve_targets
 
     # Validate backend choice defensively (argparse choices= should catch most).
     backend = args.backend
@@ -499,8 +512,38 @@ def _cmd_validate(args: argparse.Namespace) -> int:
         )
         return EXIT_USAGE
 
+    # Resolve --target values into a single value passed to validator.
+    #
+    # Compatibility rule (issue #146): when exactly one --target is supplied
+    # and it is a plain literal (not a directory, not a glob), forward the raw
+    # string. This preserves every pre-#146 behaviour, including GitHub PR
+    # references like ``owner/repo#1`` that would otherwise fail filesystem
+    # expansion. Multi-target invocations and directory/glob single-targets
+    # are resolved into a TargetSpec; the chosen backend then either
+    # aggregates (filesystem) or fails closed (github / llm-rubric / external).
+    raw_targets: list[str] = list(args.target)
+    target: object
+    if len(raw_targets) == 1:
+        from gate_keeper.targets import looks_like_glob
+
+        sole = raw_targets[0]
+        if looks_like_glob(sole) or Path(sole).is_dir():
+            try:
+                target = resolve_targets(raw_targets)
+            except TargetExpansionError as exc:
+                print(f"error: --target: {exc}", file=sys.stderr)
+                return EXIT_USAGE
+        else:
+            target = sole
+    else:
+        try:
+            target = resolve_targets(raw_targets)
+        except TargetExpansionError as exc:
+            print(f"error: --target: {exc}", file=sys.stderr)
+            return EXIT_USAGE
+
     # Run validation.
-    report = validator.validate(ruleset, args.target, backend=backend, reproducibility=args.reproducibility)
+    report = validator.validate(ruleset, target, backend=backend, reproducibility=args.reproducibility)
 
     # Render output.
     if args.format == "json":

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -517,22 +517,45 @@ def _cmd_validate(args: argparse.Namespace) -> int:
     # Compatibility rule (issue #146): when exactly one --target is supplied
     # and it is a plain literal (not a directory, not a glob), forward the raw
     # string. This preserves every pre-#146 behaviour, including GitHub PR
-    # references like ``owner/repo#1`` that would otherwise fail filesystem
-    # expansion. Multi-target invocations and directory/glob single-targets
-    # are resolved into a TargetSpec; the chosen backend then either
-    # aggregates (filesystem) or fails closed (github / llm-rubric / external).
+    # references like ``owner/repo#1`` and PR URLs that contain ``?``/``#``
+    # (which the GitHub backend's parser tolerates). Multi-target invocations
+    # and directory/glob single-targets are resolved into a TargetSpec; the
+    # chosen backend then either aggregates (filesystem) or fails closed
+    # (github / llm-rubric / external).
     raw_targets: list[str] = list(args.target)
     target: object
     if len(raw_targets) == 1:
+        from gate_keeper.backends._target import parse_target
         from gate_keeper.targets import looks_like_glob
 
         sole = raw_targets[0]
-        if looks_like_glob(sole) or Path(sole).is_dir():
+        sole_path = Path(sole)
+
+        # Order matters: a literal directory or an existing literal file
+        # always wins over glob detection so a real filename like
+        # ``a[b].txt`` does not get mis-expanded as a pattern.
+        if sole_path.is_dir():
             try:
                 target = resolve_targets(raw_targets)
             except TargetExpansionError as exc:
                 print(f"error: --target: {exc}", file=sys.stderr)
                 return EXIT_USAGE
+        elif sole_path.is_file():
+            target = sole
+        elif looks_like_glob(sole):
+            # Token has glob metacharacters but the literal path doesn't
+            # exist. A GitHub PR URL with a query string (``?diff=split``)
+            # falls into this bucket — recognise that case explicitly so
+            # the github backend still receives the raw URL it needs.
+            pr, _ = parse_target(sole)
+            if pr is not None:
+                target = sole
+            else:
+                try:
+                    target = resolve_targets(raw_targets)
+                except TargetExpansionError as exc:
+                    print(f"error: --target: {exc}", file=sys.stderr)
+                    return EXIT_USAGE
         else:
             target = sole
     else:

--- a/src/gate_keeper/targets.py
+++ b/src/gate_keeper/targets.py
@@ -53,8 +53,8 @@ class TargetExpansionError(ValueError):
     - File-count cap exceeded.
     - (Reserved) other unrecoverable expansion errors.
 
-    The validator translates this into a per-rule ``UNAVAILABLE`` diagnostic so
-    the overall report stays well-formed.
+    The CLI translates this into a usage error (``EXIT_USAGE``); programmatic
+    callers may catch it directly when invoking :func:`resolve_targets`.
     """
 
 
@@ -158,18 +158,57 @@ def _is_text_readable(path: Path) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _expand_one(token: str, base: Path) -> list[Path]:
-    """Expand a single ``--target`` token into a list of regular files.
+def _check_cap(seen: set[str], file_limit: int) -> None:
+    """Raise :class:`TargetExpansionError` once the unique-path count exceeds *file_limit*.
 
-    - Globs (tokens with ``*``, ``?``, ``[``) are expanded via :mod:`glob` with
-      ``recursive=True``; matched directories are walked into.
+    Used by the incremental expansion path so a broad target cannot consume
+    unbounded I/O before failing closed.
+    """
+    if len(seen) > file_limit:
+        raise TargetExpansionError(
+            f"target expansion produced more than {file_limit} files; "
+            f"exceeds limit of {file_limit}. "
+            f"Narrow the target set or raise the cap (default {DEFAULT_FILE_LIMIT})."
+        )
+
+
+def _walk_directory_into(
+    directory: Path,
+    seen: set[str],
+    accumulator: list[Path],
+    file_limit: int,
+) -> None:
+    """Append text-readable regular files under *directory* to *accumulator*.
+
+    Stops as soon as *seen* exceeds *file_limit* (raises
+    :class:`TargetExpansionError`) so traversal of large trees does not
+    continue past the cap.  Sorted by ``os.fspath`` for deterministic order.
+    """
+    for entry in sorted(directory.rglob("*"), key=os.fspath):
+        if not entry.is_file() or not _is_text_readable(entry):
+            continue
+        key = os.fspath(entry)
+        if key in seen:
+            continue
+        seen.add(key)
+        accumulator.append(entry)
+        _check_cap(seen, file_limit)
+
+
+def _expand_token_into(
+    token: str,
+    base: Path,
+    seen: set[str],
+    accumulator: list[Path],
+    file_limit: int,
+) -> None:
+    """Expand *token* into *accumulator*, enforcing *file_limit* incrementally.
+
+    - Globs (tokens with ``*``, ``?``, ``[``) are expanded via :mod:`glob`
+      with ``recursive=True``; matched directories are walked into.
     - Directories are walked recursively for text-readable files.
-    - Single files are returned as-is regardless of decodability — when a
-      caller names a file directly we take that as a deliberate choice.
-    - Non-existent literal paths are returned as a single-entry list pointing
-      at the missing path; the filesystem backend already classifies that as
-      ``UNAVAILABLE`` and we want the caller-supplied path to appear in the
-      evidence record.
+    - Existing or missing literal files are appended as-is — the filesystem
+      backend handles the unavailable case.
     """
     if looks_like_glob(token):
         # Resolve relative globs against ``base`` for stability across cwd
@@ -179,36 +218,36 @@ def _expand_one(token: str, base: Path) -> list[Path]:
         else:
             search = token
         matches = sorted(glob.glob(search, recursive=True))
-        results: list[Path] = []
         for match in matches:
             p = Path(match)
             if p.is_dir():
-                results.extend(_walk_directory(p))
+                _walk_directory_into(p, seen, accumulator, file_limit)
             elif p.is_file():
                 # Globs may match binary blobs (e.g. ``*`` against a build
-                # output dir).  We trust the caller's pattern but still apply
-                # the text-readable filter so a single accidental binary
-                # match does not poison the entire run.
-                if _is_text_readable(p):
-                    results.append(p)
-        return results
+                # output dir).  We trust the caller's pattern but still
+                # apply the text-readable filter so a single accidental
+                # binary match does not poison the entire run.
+                if not _is_text_readable(p):
+                    continue
+                key = os.fspath(p)
+                if key in seen:
+                    continue
+                seen.add(key)
+                accumulator.append(p)
+                _check_cap(seen, file_limit)
+        return
 
     path = Path(token)
     if path.is_dir():
-        return _walk_directory(path)
+        _walk_directory_into(path, seen, accumulator, file_limit)
+        return
     # Either an existing file or a missing path — let the backend decide.
-    return [path]
-
-
-def _walk_directory(directory: Path) -> list[Path]:
-    """Return text-readable regular files under *directory* (recursive)."""
-    results: list[Path] = []
-    # ``Path.rglob('*')`` is deterministic on a given filesystem but we sort
-    # explicitly to avoid surprises across platforms.
-    for entry in sorted(directory.rglob("*"), key=os.fspath):
-        if entry.is_file() and _is_text_readable(entry):
-            results.append(entry)
-    return results
+    key = os.fspath(path)
+    if key in seen:
+        return
+    seen.add(key)
+    accumulator.append(path)
+    _check_cap(seen, file_limit)
 
 
 def resolve_targets(
@@ -228,7 +267,8 @@ def resolve_targets(
         Base directory for relative globs.  Defaults to the process cwd.
     file_limit:
         Hard cap on the number of resolved files; exceeding it raises
-        :class:`TargetExpansionError`.  Defaults to the module-level
+        :class:`TargetExpansionError` *during* expansion, before the full
+        tree is walked.  Defaults to the module-level
         :data:`DEFAULT_FILE_LIMIT` (looked up at call time so tests can
         monkeypatch the constant).
 
@@ -243,7 +283,9 @@ def resolve_targets(
     ValueError
         When *raw_targets* is empty.
     TargetExpansionError
-        When the resolved file set exceeds *file_limit*.
+        When the resolved file set exceeds *file_limit*.  Detection is
+        incremental: traversal stops as soon as the cap is exceeded so a
+        broad target cannot consume unbounded I/O.
     """
     if not raw_targets:
         raise ValueError("resolve_targets: at least one target is required")
@@ -261,32 +303,16 @@ def resolve_targets(
         if looks_like_glob(token) or Path(token).is_dir():
             is_multi = True
 
-    expanded: list[Path] = []
-    for token in raw_targets:
-        expanded.extend(_expand_one(token, base))
-
-    # Deduplicate while preserving the lexicographic order required by the
-    # design document.  We use ``os.fspath`` (string form) for the sort key so
-    # ``Path`` instances on case-sensitive filesystems sort identically to a
-    # ``sorted([str(p), ...])`` call.
     seen: set[str] = set()
-    unique: list[Path] = []
-    for p in expanded:
-        key = os.fspath(p)
-        if key in seen:
-            continue
-        seen.add(key)
-        unique.append(p)
-    unique.sort(key=os.fspath)
+    accumulator: list[Path] = []
+    for token in raw_targets:
+        _expand_token_into(token, base, seen, accumulator, file_limit)
 
-    if len(unique) > file_limit:
-        raise TargetExpansionError(
-            f"target expansion produced {len(unique)} files; "
-            f"exceeds limit of {file_limit}. "
-            f"Narrow the target set or raise the cap (default {DEFAULT_FILE_LIMIT})."
-        )
+    # Lexicographic sort is deterministic regardless of caller-supplied
+    # input order (deduplication already happened during expansion).
+    accumulator.sort(key=os.fspath)
 
-    return TargetSpec(paths=unique, raw_targets=list(raw_targets), is_multi=is_multi)
+    return TargetSpec(paths=accumulator, raw_targets=list(raw_targets), is_multi=is_multi)
 
 
 __all__ = [

--- a/src/gate_keeper/targets.py
+++ b/src/gate_keeper/targets.py
@@ -1,0 +1,298 @@
+"""Target specification helpers for gate-keeper.
+
+This module introduces ``TargetSpec``, the internal representation passed from
+the CLI / validator to backends when more than one filesystem path needs to be
+evaluated against a single rule (issue #146 — first slice of the multi-target
+design at ``docs/design/multi-target.md``).
+
+Scope
+-----
+This first slice is deliberately filesystem-only:
+
+- Each ``--target`` argument is treated as a literal path, a directory, or a
+  shell-style glob.
+- Directories expand to all *text-readable regular files* below them.
+- Globs expand deterministically.
+- Resolved paths are deduplicated and sorted lexicographically (using
+  ``os.fspath`` order) so backend output is stable.
+- A file-count cap (``DEFAULT_FILE_LIMIT`` = 200) protects callers from
+  accidentally selecting an unbounded set; exceeding the cap is a hard
+  error, not a silent truncation.
+
+Out of scope (deferred to later issues):
+
+- LLM-rubric multi-file content assembly and token budgeting.
+- ``params.targets`` rule-level glob lists.
+- Heuristic file-relevance ranking.
+- Remote / non-filesystem URIs.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Cap and error types
+# ---------------------------------------------------------------------------
+
+#: Default cap on the number of files a multi-target expansion may resolve to.
+#: Mirrors ``docs/design/multi-target.md`` §6.  Hardcoded for the first slice;
+#: a dotenv override (``GATE_KEEPER_TARGET_FILE_LIMIT``) is reserved as a
+#: follow-up.
+DEFAULT_FILE_LIMIT: int = 200
+
+
+class TargetExpansionError(ValueError):
+    """Raised when a target spec cannot be resolved into a usable file set.
+
+    Cases:
+
+    - File-count cap exceeded.
+    - (Reserved) other unrecoverable expansion errors.
+
+    The validator translates this into a per-rule ``UNAVAILABLE`` diagnostic so
+    the overall report stays well-formed.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TargetSpec:
+    """Resolved file set for a multi-target evaluation.
+
+    Attributes
+    ----------
+    paths:
+        Deduplicated, lexicographically sorted list of resolved paths.  Each
+        entry is a regular file (directories expand recursively into the
+        regular files below them).
+    raw_targets:
+        The original ``--target`` arguments, in the order they were supplied,
+        for diagnostic reporting.
+    is_multi:
+        ``True`` when more than one ``--target`` argument was supplied, when a
+        directory was supplied, or when a glob was supplied (even if it
+        happened to expand to a single file).  ``False`` when exactly one raw
+        argument was supplied and it pointed at a single regular file with no
+        glob metacharacters.
+    """
+
+    paths: list[Path]
+    raw_targets: list[str] = field(default_factory=list)
+    is_multi: bool = False
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial guard
+        # Defensive: callers should construct via ``resolve_targets``.  Detect
+        # accidental misuse rather than letting downstream code de-reference
+        # an unsorted list.
+        if list(self.paths) != sorted(self.paths, key=os.fspath):
+            raise ValueError("TargetSpec.paths must be sorted lexicographically")
+
+
+# ---------------------------------------------------------------------------
+# Glob detection
+# ---------------------------------------------------------------------------
+
+_GLOB_METACHARS = set("*?[")
+
+
+def looks_like_glob(token: str) -> bool:
+    """Return ``True`` when *token* contains shell-glob metacharacters."""
+    return any(ch in token for ch in _GLOB_METACHARS)
+
+
+# Backwards-compatible alias for any internal caller; the leading underscore
+# was an oversight — the helper is part of the public ``targets`` surface.
+_looks_like_glob = looks_like_glob
+
+
+# ---------------------------------------------------------------------------
+# File classification
+# ---------------------------------------------------------------------------
+
+
+def _is_text_readable(path: Path) -> bool:
+    """Heuristic: return ``True`` when *path* looks like a UTF-8 text file.
+
+    Filesystem rules read targets via ``Path.read_text(encoding="utf-8")``; a
+    binary or undecodable file would surface as ``UNAVAILABLE``.  When a
+    directory is expanded by ``--target``, we therefore filter to files that
+    decode cleanly — otherwise a single binary asset could turn an entire
+    multi-target run unavailable.
+
+    The check reads up to the first 4 KiB of the file and rejects any blob
+    that:
+
+    - cannot be opened (permission errors, broken symlinks, etc.);
+    - contains a NUL byte in the sampled prefix;
+    - fails strict UTF-8 decoding of the sampled prefix.
+
+    Any other I/O error is treated as non-text.  This is intentionally
+    conservative: a false-negative means the file is silently skipped, which
+    is acceptable for an opt-in directory walk; a false-positive would surface
+    later as an ``UNAVAILABLE`` diagnostic, which is also fail-closed.
+    """
+    try:
+        with path.open("rb") as fh:
+            chunk = fh.read(4096)
+    except OSError:
+        return False
+    if b"\x00" in chunk:
+        return False
+    try:
+        chunk.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Public resolver
+# ---------------------------------------------------------------------------
+
+
+def _expand_one(token: str, base: Path) -> list[Path]:
+    """Expand a single ``--target`` token into a list of regular files.
+
+    - Globs (tokens with ``*``, ``?``, ``[``) are expanded via :mod:`glob` with
+      ``recursive=True``; matched directories are walked into.
+    - Directories are walked recursively for text-readable files.
+    - Single files are returned as-is regardless of decodability — when a
+      caller names a file directly we take that as a deliberate choice.
+    - Non-existent literal paths are returned as a single-entry list pointing
+      at the missing path; the filesystem backend already classifies that as
+      ``UNAVAILABLE`` and we want the caller-supplied path to appear in the
+      evidence record.
+    """
+    if looks_like_glob(token):
+        # Resolve relative globs against ``base`` for stability across cwd
+        # changes.  ``Path.is_absolute`` handles already-absolute glob bases.
+        if not Path(token).is_absolute():
+            search = str(base / token)
+        else:
+            search = token
+        matches = sorted(glob.glob(search, recursive=True))
+        results: list[Path] = []
+        for match in matches:
+            p = Path(match)
+            if p.is_dir():
+                results.extend(_walk_directory(p))
+            elif p.is_file():
+                # Globs may match binary blobs (e.g. ``*`` against a build
+                # output dir).  We trust the caller's pattern but still apply
+                # the text-readable filter so a single accidental binary
+                # match does not poison the entire run.
+                if _is_text_readable(p):
+                    results.append(p)
+        return results
+
+    path = Path(token)
+    if path.is_dir():
+        return _walk_directory(path)
+    # Either an existing file or a missing path — let the backend decide.
+    return [path]
+
+
+def _walk_directory(directory: Path) -> list[Path]:
+    """Return text-readable regular files under *directory* (recursive)."""
+    results: list[Path] = []
+    # ``Path.rglob('*')`` is deterministic on a given filesystem but we sort
+    # explicitly to avoid surprises across platforms.
+    for entry in sorted(directory.rglob("*"), key=os.fspath):
+        if entry.is_file() and _is_text_readable(entry):
+            results.append(entry)
+    return results
+
+
+def resolve_targets(
+    raw_targets: list[str],
+    *,
+    base: Path | None = None,
+    file_limit: int | None = None,
+) -> TargetSpec:
+    """Resolve raw ``--target`` arguments into a deterministic ``TargetSpec``.
+
+    Parameters
+    ----------
+    raw_targets:
+        The list of ``--target`` strings, in the order they were supplied.
+        Must be non-empty (the CLI enforces this via ``argparse``).
+    base:
+        Base directory for relative globs.  Defaults to the process cwd.
+    file_limit:
+        Hard cap on the number of resolved files; exceeding it raises
+        :class:`TargetExpansionError`.  Defaults to the module-level
+        :data:`DEFAULT_FILE_LIMIT` (looked up at call time so tests can
+        monkeypatch the constant).
+
+    Returns
+    -------
+    TargetSpec
+        A frozen spec carrying the deduplicated, sorted file list and the
+        ``is_multi`` flag.
+
+    Raises
+    ------
+    ValueError
+        When *raw_targets* is empty.
+    TargetExpansionError
+        When the resolved file set exceeds *file_limit*.
+    """
+    if not raw_targets:
+        raise ValueError("resolve_targets: at least one target is required")
+
+    if base is None:
+        base = Path.cwd()
+
+    if file_limit is None:
+        file_limit = DEFAULT_FILE_LIMIT
+
+    # Track multi-ness: a single literal file is the only single-target case.
+    is_multi = len(raw_targets) > 1
+    if not is_multi:
+        token = raw_targets[0]
+        if looks_like_glob(token) or Path(token).is_dir():
+            is_multi = True
+
+    expanded: list[Path] = []
+    for token in raw_targets:
+        expanded.extend(_expand_one(token, base))
+
+    # Deduplicate while preserving the lexicographic order required by the
+    # design document.  We use ``os.fspath`` (string form) for the sort key so
+    # ``Path`` instances on case-sensitive filesystems sort identically to a
+    # ``sorted([str(p), ...])`` call.
+    seen: set[str] = set()
+    unique: list[Path] = []
+    for p in expanded:
+        key = os.fspath(p)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(p)
+    unique.sort(key=os.fspath)
+
+    if len(unique) > file_limit:
+        raise TargetExpansionError(
+            f"target expansion produced {len(unique)} files; "
+            f"exceeds limit of {file_limit}. "
+            f"Narrow the target set or raise the cap (default {DEFAULT_FILE_LIMIT})."
+        )
+
+    return TargetSpec(paths=unique, raw_targets=list(raw_targets), is_multi=is_multi)
+
+
+__all__ = [
+    "DEFAULT_FILE_LIMIT",
+    "TargetExpansionError",
+    "TargetSpec",
+    "looks_like_glob",
+    "resolve_targets",
+]

--- a/src/gate_keeper/validator.py
+++ b/src/gate_keeper/validator.py
@@ -39,6 +39,7 @@ from gate_keeper.models import (
     RuleSet,
     Status,
 )
+from gate_keeper.targets import TargetSpec
 
 
 def _backend_for(name: str) -> Backend:
@@ -86,7 +87,7 @@ def _resolve_backend_name(rule: Rule, backend_name: str) -> str:
 def _run_n(
     check_fn: Callable,
     rule: Rule,
-    target: str | Path,
+    target: str | Path | TargetSpec,
     n: int,
 ) -> Diagnostic:
     """Run *check_fn* ``n`` times and aggregate via majority vote.
@@ -133,7 +134,7 @@ def _run_n(
 
 def validate(
     ruleset: RuleSet,
-    target: str | Path,
+    target: str | Path | TargetSpec,
     backend: str = "auto",
     reproducibility: int = 1,
 ) -> DiagnosticReport:
@@ -144,7 +145,19 @@ def validate(
     ruleset:
         Compiled ``RuleSet`` (output of parse + classify).
     target:
-        Local path or GitHub PR reference passed through to the backend.
+        One of:
+
+        - a local filesystem path (``str`` or ``Path``);
+        - a GitHub PR reference (``str``);
+        - a :class:`gate_keeper.targets.TargetSpec` describing a multi-target
+          filesystem evaluation produced by ``--target`` repetition,
+          directory, or glob expansion (issue #146).
+
+        Single-target callers continue to pass a path or reference directly;
+        the value is forwarded verbatim to the backend.  Multi-target callers
+        pass a ``TargetSpec``; backends that cannot honour it must produce an
+        ``UNSUPPORTED`` / ``UNAVAILABLE`` diagnostic rather than silently
+        evaluating only one of the resolved paths.
     backend:
         ``"auto"`` dispatches each rule by its ``backend_hint``; any other
         registered name sends all rules to that single backend.

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -282,7 +282,14 @@ class TestExampleRulesSmoke:
             assert "evidence" in diag
 
     def test_example_rules_has_github_unavailable_diagnostics(self, capsys):
-        """GitHub rules in example-rules.md produce UNAVAILABLE (fail-closed)."""
+        """GitHub rules in example-rules.md produce a fail-closed status.
+
+        With ``--target <dir>`` the CLI builds a multi-target ``TargetSpec``;
+        the github backend rejects multi-target with ``unsupported`` (issue
+        #146). Either ``unavailable`` (legacy single-target rejection) or
+        ``unsupported`` (new multi-target rejection) is fail-closed and
+        acceptable.
+        """
         main(
             [
                 "validate",
@@ -298,8 +305,7 @@ class TestExampleRulesSmoke:
         captured = capsys.readouterr()
         data = json.loads(captured.out)
         statuses = {d["status"] for d in data["diagnostics"]}
-        # github stubs return unavailable → fail-closed
-        assert "unavailable" in statuses
+        assert {"unavailable", "unsupported"} & statuses
 
 
 # ---------------------------------------------------------------------------
@@ -930,3 +936,334 @@ class TestRulesFormatIR:
                 ]
             )
         assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# Multi-target evaluation (issue #146)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiTarget:
+    """``--target`` accepts multiple paths, directories, and globs."""
+
+    def _write_rules(self, tmp_path):
+        """Return a minimal rules doc that produces one ``file_exists`` rule.
+
+        ``file_exists`` is the simplest classifier-friendly kind that needs no
+        params; aggregated multi-target dispatch can therefore be exercised
+        purely from the CLI without hand-built IR.
+        """
+        rules = tmp_path / "rules.md"
+        rules.write_text(
+            "# Rules\n\n## Required Files\n\n- `README.md` must exist.\n",
+            encoding="utf-8",
+        )
+        return rules
+
+    def test_repeated_target_flags_aggregate(self, tmp_path, capsys):
+        # Use a ``file_exists`` rule because it requires no params and
+        # exercises per-file dispatch directly (each target path is the
+        # ``file_exists`` argument).
+        rules = self._write_rules(tmp_path)
+        a = tmp_path / "a.txt"
+        a.write_text("hello\n")
+        b = tmp_path / "b.txt"
+        b.write_text("hello\n")
+        rc = main(
+            [
+                "validate",
+                str(rules),
+                "--target",
+                str(a),
+                "--target",
+                str(b),
+                "--backend",
+                "filesystem",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == EXIT_OK
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        # Exactly one diagnostic per rule, regardless of file count.
+        assert len(data["diagnostics"]) == 1
+        diag = data["diagnostics"][0]
+        assert diag["status"] == "pass"
+        summary = next(e for e in diag["evidence"] if e["kind"] == "multi_target_summary")
+        assert summary["data"]["file_count"] == 2
+
+    def test_directory_target_aggregates(self, tmp_path, capsys):
+        rules = self._write_rules(tmp_path)
+        target_dir = tmp_path / "files"
+        target_dir.mkdir()
+        (target_dir / "a.md").write_text("hello\n")
+        (target_dir / "b.md").write_text("hello\n")
+        rc = main(
+            [
+                "validate",
+                str(rules),
+                "--target",
+                str(target_dir),
+                "--backend",
+                "filesystem",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == EXIT_OK
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        diag = data["diagnostics"][0]
+        assert diag["status"] == "pass"
+
+    def test_glob_target_expands(self, tmp_path, capsys):
+        rules = self._write_rules(tmp_path)
+        target_dir = tmp_path / "files"
+        target_dir.mkdir()
+        (target_dir / "a.md").write_text("hello\n")
+        (target_dir / "b.md").write_text("hello\n")
+        (target_dir / "skip.txt").write_text("skip\n")
+        glob_pattern = str(target_dir / "*.md")
+        rc = main(
+            [
+                "validate",
+                str(rules),
+                "--target",
+                glob_pattern,
+                "--backend",
+                "filesystem",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == EXIT_OK
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        diag = data["diagnostics"][0]
+        summary = next(e for e in diag["evidence"] if e["kind"] == "multi_target_summary")
+        assert summary["data"]["file_count"] == 2
+
+    def test_repeated_target_with_missing_path_fails(self, tmp_path, capsys):
+        # Mixed pass/fail: one existing target + one nonexistent target
+        # → aggregated FAIL (any per-file FAIL → overall FAIL).
+        rules = self._write_rules(tmp_path)
+        a = tmp_path / "a.txt"
+        a.write_text("hello\n")
+        ghost = tmp_path / "ghost.txt"
+        rc = main(
+            [
+                "validate",
+                str(rules),
+                "--target",
+                str(a),
+                "--target",
+                str(ghost),
+                "--backend",
+                "filesystem",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == EXIT_FAIL
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        diag = data["diagnostics"][0]
+        assert diag["status"] == "fail"
+        summary = next(e for e in diag["evidence"] if e["kind"] == "multi_target_summary")
+        assert summary["data"]["fail_count"] == 1
+        assert summary["data"]["pass_count"] == 1
+
+    def test_empty_glob_fails_closed(self, tmp_path, capsys):
+        rules = self._write_rules(tmp_path)
+        rc = main(
+            [
+                "validate",
+                str(rules),
+                "--target",
+                str(tmp_path / "no_match_*.zzz"),
+                "--backend",
+                "filesystem",
+                "--format",
+                "json",
+            ]
+        )
+        # Empty file set → UNAVAILABLE → fail-closed exit code.
+        assert rc == EXIT_FAIL
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        diag = data["diagnostics"][0]
+        assert diag["status"] == "unavailable"
+
+    def test_over_cap_emits_usage_error(self, tmp_path, capsys, monkeypatch):
+        rules = self._write_rules(tmp_path)
+        # Lower the cap via monkeypatch on the module-level constant; the CLI
+        # reads the constant on every call so this is sufficient.
+        monkeypatch.setattr("gate_keeper.targets.DEFAULT_FILE_LIMIT", 2)
+        for i in range(5):
+            (tmp_path / f"f{i}.md").write_text("hello\n")
+        rc = main(
+            [
+                "validate",
+                str(rules),
+                "--target",
+                str(tmp_path),
+                "--backend",
+                "filesystem",
+            ]
+        )
+        assert rc == EXIT_USAGE
+        captured = capsys.readouterr()
+        assert "exceeds limit" in captured.err
+
+    def test_repeated_targets_dispatched_to_non_filesystem_backend_fails_closed(
+        self, tmp_path, capsys
+    ):
+        # Force --backend external. Two targets → multi-target → external
+        # dispatcher must reject (UNSUPPORTED), not silently use one path.
+        rules = self._write_rules(tmp_path)
+        a = tmp_path / "a.txt"
+        a.write_text("uv\n")
+        b = tmp_path / "b.txt"
+        b.write_text("uv\n")
+        rc = main(
+            [
+                "validate",
+                str(rules),
+                "--target",
+                str(a),
+                "--target",
+                str(b),
+                "--backend",
+                "external",
+                "--format",
+                "json",
+            ]
+        )
+        # Exit code is FAIL because UNSUPPORTED is non-pass.
+        assert rc == EXIT_FAIL
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        diag = data["diagnostics"][0]
+        assert diag["status"] == "unsupported"
+        ev_kinds = {e["kind"] for e in diag["evidence"]}
+        assert "multi_target_unsupported" in ev_kinds
+
+    def test_single_file_target_unchanged(self, tmp_path, capsys):
+        # The sole-target compatibility path: passes the raw string straight
+        # through. We sanity-check by inspecting that no multi_target_summary
+        # evidence is emitted (legacy single-file evidence kind preserved).
+        rules = self._write_rules(tmp_path)
+        f = tmp_path / "single.md"
+        f.write_text("hello\n")
+        rc = main(
+            [
+                "validate",
+                str(rules),
+                "--target",
+                str(f),
+                "--backend",
+                "filesystem",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == EXIT_OK
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        diag = data["diagnostics"][0]
+        ev_kinds = {e["kind"] for e in diag["evidence"]}
+        assert "multi_target_summary" not in ev_kinds
+        # Legacy single-file evidence kind preserved (file_exists rule).
+        assert "file_stat" in ev_kinds
+
+    def test_determinism_across_path_orderings(self, tmp_path, capsys):
+        rules = self._write_rules(tmp_path)
+        a = tmp_path / "a.txt"
+        a.write_text("hello\n")
+        b = tmp_path / "b.txt"
+        b.write_text("hello\n")
+        c = tmp_path / "c.txt"
+        c.write_text("hello\n")
+
+        def _run(order):
+            argv = ["validate", str(rules)]
+            for p in order:
+                argv.extend(["--target", str(p)])
+            argv.extend(["--backend", "filesystem", "--format", "json"])
+            main(argv)
+            captured = capsys.readouterr()
+            return json.loads(captured.out)
+
+        def _strip_volatile(report):
+            # Drop ``raw_targets`` from each summary because it intentionally
+            # preserves caller-supplied order; compare everything else.
+            for diag in report["diagnostics"]:
+                for ev in diag["evidence"]:
+                    if ev["kind"] == "multi_target_summary":
+                        ev["data"].pop("raw_targets", None)
+            return report
+
+        first = _strip_volatile(_run([a, b, c]))
+        second = _strip_volatile(_run([c, b, a]))
+        third = _strip_volatile(_run([b, a, c]))
+        # Aggregate diagnostic content (per-file evidence + statuses) is
+        # order-independent: paths are sorted lexicographically before
+        # evaluation.
+        assert first == second == third
+
+    def test_repeated_target_with_github_backend_unsupported(self, tmp_path, capsys):
+        # github backend cannot accept multi-target — fail closed.
+        rules = self._write_rules(tmp_path)
+        a = tmp_path / "a.txt"
+        a.write_text("uv\n")
+        b = tmp_path / "b.txt"
+        b.write_text("uv\n")
+        rc = main(
+            [
+                "validate",
+                str(rules),
+                "--target",
+                str(a),
+                "--target",
+                str(b),
+                "--backend",
+                "github",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == EXIT_FAIL
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        diag = data["diagnostics"][0]
+        assert diag["status"] == "unsupported"
+        assert any(e["kind"] == "multi_target_unsupported" for e in diag["evidence"])
+
+    def test_repeated_target_with_llm_rubric_backend_unsupported(self, tmp_path, capsys):
+        # llm-rubric backend rejects multi-target in this slice.
+        rules = self._write_rules(tmp_path)
+        a = tmp_path / "a.txt"
+        a.write_text("uv\n")
+        b = tmp_path / "b.txt"
+        b.write_text("uv\n")
+        rc = main(
+            [
+                "validate",
+                str(rules),
+                "--target",
+                str(a),
+                "--target",
+                str(b),
+                "--backend",
+                "llm-rubric",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == EXIT_FAIL
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        diag = data["diagnostics"][0]
+        assert diag["status"] == "unsupported"
+        assert any(e["kind"] == "multi_target_unsupported" for e in diag["evidence"])

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -795,7 +795,7 @@ class TestRulesFormatIR:
                 "ir",
                 str(IR_TEXTLINT_RULES),
                 "--target",
-                ".",
+                str(PASS_README),
                 "--backend",
                 "auto",
             ]

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -1238,6 +1238,63 @@ class TestMultiTarget:
         assert diag["status"] == "unsupported"
         assert any(e["kind"] == "multi_target_unsupported" for e in diag["evidence"])
 
+    def test_existing_file_with_glob_chars_passes_through(self, tmp_path, capsys):
+        # Codex/Copilot follow-up: a literal filename containing ``[`` is
+        # not a glob — preserve single-target compatibility when the file
+        # actually exists on disk.
+        rules = self._write_rules(tmp_path)
+        f = tmp_path / "a[b].txt"
+        f.write_text("hello\n")
+        rc = main(
+            [
+                "validate",
+                str(rules),
+                "--target",
+                str(f),
+                "--backend",
+                "filesystem",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == EXIT_OK
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        diag = data["diagnostics"][0]
+        # No multi-target aggregation; the literal file went through the
+        # legacy single-path code path.
+        ev_kinds = {e["kind"] for e in diag["evidence"]}
+        assert "multi_target_summary" not in ev_kinds
+
+    def test_github_pr_url_with_query_routed_to_github(self, tmp_path, capsys):
+        # Codex P1: a PR URL with a ``?`` query string contains a glob
+        # metacharacter but must still reach the github backend as a raw
+        # string. Without the fix, the CLI converted it to an empty
+        # TargetSpec and the github backend returned ``unsupported``.
+        rules = self._write_rules(tmp_path)
+        rc = main(
+            [
+                "validate",
+                str(rules),
+                "--target",
+                "https://github.com/t-uda/gate-keeper/pull/1?diff=split",
+                "--backend",
+                "github",
+                "--format",
+                "json",
+            ]
+        )
+        # Will be UNAVAILABLE (real gh call against an unrelated repo) or
+        # PASS — the contract under test is "URL was not silently dropped".
+        del rc
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        diag = data["diagnostics"][0]
+        ev_kinds = {e["kind"] for e in diag["evidence"]}
+        # multi_target_unsupported would indicate the URL was wrongly
+        # routed through TargetSpec.
+        assert "multi_target_unsupported" not in ev_kinds
+
     def test_repeated_target_with_llm_rubric_backend_unsupported(self, tmp_path, capsys):
         # llm-rubric backend rejects multi-target in this slice.
         rules = self._write_rules(tmp_path)

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -1116,9 +1116,7 @@ class TestMultiTarget:
         captured = capsys.readouterr()
         assert "exceeds limit" in captured.err
 
-    def test_repeated_targets_dispatched_to_non_filesystem_backend_fails_closed(
-        self, tmp_path, capsys
-    ):
+    def test_repeated_targets_dispatched_to_non_filesystem_backend_fails_closed(self, tmp_path, capsys):
         # Force --backend external. Two targets → multi-target → external
         # dispatcher must reject (UNSUPPORTED), not silently use one path.
         rules = self._write_rules(tmp_path)

--- a/tests/test_filesystem_backend.py
+++ b/tests/test_filesystem_backend.py
@@ -14,6 +14,7 @@ from gate_keeper.models import (
     SourceLocation,
     Status,
 )
+from gate_keeper.targets import TargetSpec, resolve_targets
 
 _FIXTURES = Path(__file__).parent / "fixtures" / "filesystem"
 
@@ -545,3 +546,141 @@ class TestDiagnosticContract:
 
     def test_unsupported(self):
         self._assert_valid(check(_rule(RuleKind.GITHUB_PR_OPEN), _FIXTURES / "content.txt"))
+
+
+# ---------------------------------------------------------------------------
+# Multi-target aggregation (issue #146)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiTarget:
+    """Filesystem backend aggregates per-file results into one Diagnostic."""
+
+    def test_single_file_targetspec_preserves_behaviour(self, tmp_path):
+        # is_multi=False with a single resolved path → identical to legacy
+        # single-target call.
+        f = tmp_path / "a.txt"
+        f.write_text("uv\n")
+        spec = TargetSpec(paths=[f], raw_targets=[str(f)], is_multi=False)
+        diag_multi = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": "uv"}), spec)
+        diag_single = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": "uv"}), f)
+        assert diag_multi.status is Status.PASS
+        assert diag_single.status is Status.PASS
+        # Single-path TargetSpec must round-trip through the legacy path —
+        # diagnostics should be byte-identical (same evidence schema).
+        assert [e.kind for e in diag_multi.evidence] == [e.kind for e in diag_single.evidence]
+
+    def test_pass_when_all_files_pass(self, tmp_path):
+        a = tmp_path / "a.txt"
+        a.write_text("uv\n")
+        b = tmp_path / "b.txt"
+        b.write_text("uv elsewhere\n")
+        spec = resolve_targets([str(a), str(b)])
+        diag = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": "uv"}), spec)
+        assert diag.status is Status.PASS
+        summary = next(e for e in diag.evidence if e.kind == "multi_target_summary")
+        assert summary.data["file_count"] == 2
+        assert summary.data["pass_count"] == 2
+        assert summary.data["fail_count"] == 0
+
+    def test_fail_when_any_file_fails(self, tmp_path):
+        a = tmp_path / "a.txt"
+        a.write_text("uv\n")
+        b = tmp_path / "b.txt"
+        b.write_text("nothing here\n")
+        spec = resolve_targets([str(a), str(b)])
+        diag = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": "uv"}), spec)
+        assert diag.status is Status.FAIL
+        summary = next(e for e in diag.evidence if e.kind == "multi_target_summary")
+        assert summary.data["fail_count"] == 1
+        assert summary.data["pass_count"] == 1
+        # Per-file evidence records present.
+        file_results = [e for e in diag.evidence if e.kind == "file_result"]
+        statuses = {e.data["status"] for e in file_results}
+        assert statuses == {"pass", "fail"}
+        # Failing path appears in the diagnostic message for quick scanning.
+        assert "b.txt" in diag.message
+
+    def test_unavailable_when_any_file_unavailable(self, tmp_path):
+        # text_required on a binary file → UNAVAILABLE per-file → aggregated
+        # UNAVAILABLE (fail-closed for evaluator-state failures).
+        good = tmp_path / "a.txt"
+        good.write_text("uv\n")
+        bad = tmp_path / "b.txt"
+        bad.write_bytes(b"\xff\xfe binary \x00")
+        # ``resolve_targets`` filters binaries during directory expansion;
+        # construct the spec explicitly so the backend has to handle a binary
+        # entry that snuck in via a literal --target.
+        spec_explicit = TargetSpec(
+            paths=sorted([good, bad], key=str),
+            raw_targets=[str(good), str(bad)],
+            is_multi=True,
+        )
+        diag = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": "uv"}), spec_explicit)
+        assert diag.status is Status.UNAVAILABLE
+        summary = next(e for e in diag.evidence if e.kind == "multi_target_summary")
+        assert summary.data["unavailable_count"] >= 1
+
+    def test_unavailable_when_file_set_empty(self, tmp_path):
+        # Empty multi-target spec → UNAVAILABLE (fail-closed).
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        spec = resolve_targets([str(empty)])
+        assert spec.paths == []
+        diag = check(_rule(RuleKind.FILE_EXISTS), spec)
+        assert diag.status is Status.UNAVAILABLE
+        # Summary still emitted (file_count=0).
+        summary = next(e for e in diag.evidence if e.kind == "multi_target_summary")
+        assert summary.data["file_count"] == 0
+
+    def test_unsupported_kind_short_circuits(self, tmp_path):
+        a = tmp_path / "a.txt"
+        a.write_text("hi\n")
+        b = tmp_path / "b.txt"
+        b.write_text("hi\n")
+        spec = resolve_targets([str(a), str(b)])
+        diag = check(_rule(RuleKind.GITHUB_PR_OPEN), spec)
+        assert diag.status is Status.UNSUPPORTED
+
+    def test_directory_target_aggregates(self, tmp_path):
+        (tmp_path / "a.md").write_text("uv\n")
+        (tmp_path / "b.md").write_text("uv\n")
+        spec = resolve_targets([str(tmp_path)])
+        diag = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": "uv"}), spec)
+        assert diag.status is Status.PASS
+
+    def test_glob_target_aggregates(self, tmp_path):
+        (tmp_path / "a.md").write_text("uv\n")
+        (tmp_path / "b.md").write_text("uv\n")
+        (tmp_path / "skip.txt").write_text("nothing\n")
+        spec = resolve_targets([str(tmp_path / "*.md")])
+        diag = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": "uv"}), spec)
+        assert diag.status is Status.PASS
+        summary = next(e for e in diag.evidence if e.kind == "multi_target_summary")
+        assert summary.data["file_count"] == 2
+
+    def test_diagnostic_round_trips(self, tmp_path):
+        from gate_keeper.models import Diagnostic
+
+        a = tmp_path / "a.txt"
+        a.write_text("uv\n")
+        b = tmp_path / "b.txt"
+        b.write_text("nothing\n")
+        spec = resolve_targets([str(a), str(b)])
+        diag = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": "uv"}), spec)
+        rebuilt = Diagnostic.from_dict(diag.to_dict())
+        assert rebuilt.status is Status.FAIL
+        assert any(e.kind == "multi_target_summary" for e in rebuilt.evidence)
+
+    def test_per_file_evidence_truncates_when_over_limit(self, tmp_path):
+        # Force more files than the per-file evidence cap so the summary
+        # carries an evidence_truncated counter.
+        from gate_keeper.backends import filesystem as fsmod
+
+        for i in range(fsmod._PER_FILE_EVIDENCE_LIMIT + 5):
+            (tmp_path / f"f{i:03d}.txt").write_text("uv\n")
+        spec = resolve_targets([str(tmp_path)], file_limit=fsmod._PER_FILE_EVIDENCE_LIMIT + 10)
+        diag = check(_rule(RuleKind.TEXT_REQUIRED, {"pattern": "uv"}), spec)
+        assert diag.status is Status.PASS
+        summary = next(e for e in diag.evidence if e.kind == "multi_target_summary")
+        assert summary.data["evidence_truncated"] == 5

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -1,0 +1,222 @@
+"""Tests for ``gate_keeper.targets``: ``TargetSpec`` and ``resolve_targets``.
+
+Covers issue #146 — first slice of the multi-target design
+(``docs/design/multi-target.md``). Scope is filesystem-only: literal files,
+directories, repeated files, globs, the empty-glob fail-closed case, and the
+file-count cap.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from gate_keeper.targets import (
+    DEFAULT_FILE_LIMIT,
+    TargetExpansionError,
+    TargetSpec,
+    looks_like_glob,
+    resolve_targets,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(p: Path, content: str = "x\n") -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Single-target paths preserve current behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestSingleTarget:
+    def test_single_literal_file_is_not_multi(self, tmp_path):
+        f = _write(tmp_path / "a.txt")
+        spec = resolve_targets([str(f)])
+        assert spec.is_multi is False
+        assert spec.paths == [f]
+
+    def test_single_missing_path_passed_through(self, tmp_path):
+        # Non-existent literal: backend will surface UNAVAILABLE — but
+        # resolve_targets must not silently drop it.
+        ghost = tmp_path / "ghost.txt"
+        spec = resolve_targets([str(ghost)])
+        assert spec.is_multi is False
+        assert spec.paths == [ghost]
+
+    def test_empty_arglist_raises(self):
+        with pytest.raises(ValueError, match="at least one target"):
+            resolve_targets([])
+
+
+# ---------------------------------------------------------------------------
+# Repeated --target flags
+# ---------------------------------------------------------------------------
+
+
+class TestRepeatedFlags:
+    def test_two_files_combined_and_sorted(self, tmp_path):
+        a = _write(tmp_path / "a.txt")
+        b = _write(tmp_path / "b.txt")
+        spec = resolve_targets([str(b), str(a)])
+        assert spec.is_multi is True
+        assert spec.paths == sorted([a, b], key=os.fspath)
+
+    def test_duplicates_deduplicated(self, tmp_path):
+        a = _write(tmp_path / "a.txt")
+        spec = resolve_targets([str(a), str(a), str(a)])
+        # Duplicates collapse but is_multi stays True (caller passed >1 arg).
+        assert spec.is_multi is True
+        assert spec.paths == [a]
+
+    def test_raw_targets_preserved_in_input_order(self, tmp_path):
+        a = _write(tmp_path / "a.txt")
+        b = _write(tmp_path / "b.txt")
+        spec = resolve_targets([str(b), str(a)])
+        assert spec.raw_targets == [str(b), str(a)]
+
+
+# ---------------------------------------------------------------------------
+# Directory expansion
+# ---------------------------------------------------------------------------
+
+
+class TestDirectoryExpansion:
+    def test_directory_expands_text_files(self, tmp_path):
+        _write(tmp_path / "a.txt")
+        _write(tmp_path / "sub" / "b.md")
+        _write(tmp_path / "sub" / "c.py", "print('hi')\n")
+        spec = resolve_targets([str(tmp_path)])
+        assert spec.is_multi is True
+        assert {p.name for p in spec.paths} == {"a.txt", "b.md", "c.py"}
+
+    def test_directory_skips_binary_files(self, tmp_path):
+        _write(tmp_path / "a.txt")
+        binary = tmp_path / "blob.bin"
+        binary.write_bytes(b"\x00\xff binary data \xfe\x80")
+        spec = resolve_targets([str(tmp_path)])
+        names = {p.name for p in spec.paths}
+        assert "a.txt" in names
+        assert "blob.bin" not in names
+
+    def test_empty_directory_resolves_to_empty(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        spec = resolve_targets([str(empty)])
+        assert spec.is_multi is True
+        assert spec.paths == []
+
+    def test_directory_walk_is_deterministic(self, tmp_path):
+        _write(tmp_path / "z.txt")
+        _write(tmp_path / "a.txt")
+        _write(tmp_path / "m" / "b.txt")
+        spec = resolve_targets([str(tmp_path)])
+        # Sort key is os.fspath, so output must equal the lexicographic sort.
+        assert spec.paths == sorted(spec.paths, key=os.fspath)
+
+
+# ---------------------------------------------------------------------------
+# Glob expansion
+# ---------------------------------------------------------------------------
+
+
+class TestGlobs:
+    def test_simple_glob_expands(self, tmp_path):
+        _write(tmp_path / "a.txt")
+        _write(tmp_path / "b.txt")
+        _write(tmp_path / "c.md")
+        spec = resolve_targets([str(tmp_path / "*.txt")])
+        assert spec.is_multi is True
+        assert {p.name for p in spec.paths} == {"a.txt", "b.txt"}
+
+    def test_recursive_double_star_glob(self, tmp_path):
+        _write(tmp_path / "a.md")
+        _write(tmp_path / "sub" / "b.md")
+        _write(tmp_path / "sub" / "deep" / "c.md")
+        spec = resolve_targets([str(tmp_path / "**" / "*.md")])
+        assert spec.is_multi is True
+        assert {p.name for p in spec.paths} == {"a.md", "b.md", "c.md"}
+
+    def test_empty_glob_resolves_to_empty(self, tmp_path):
+        # Glob that matches nothing: spec is multi but paths is empty.
+        # Backend translates this to UNAVAILABLE (fail-closed) — see
+        # test_filesystem_backend.TestMultiTarget.
+        spec = resolve_targets([str(tmp_path / "no_match_*.zzz")])
+        assert spec.is_multi is True
+        assert spec.paths == []
+
+    def test_glob_is_deterministic_across_calls(self, tmp_path):
+        for n in ("z", "a", "m", "b"):
+            _write(tmp_path / f"{n}.txt")
+        s1 = resolve_targets([str(tmp_path / "*.txt")])
+        s2 = resolve_targets([str(tmp_path / "*.txt")])
+        assert s1.paths == s2.paths
+
+    def test_single_glob_token_is_multi(self, tmp_path):
+        # Even when the glob expands to one file, the spec is multi because
+        # the caller asked for set-style semantics.
+        _write(tmp_path / "only.txt")
+        spec = resolve_targets([str(tmp_path / "*.txt")])
+        assert spec.is_multi is True
+
+
+# ---------------------------------------------------------------------------
+# File-count cap
+# ---------------------------------------------------------------------------
+
+
+class TestFileCountCap:
+    def test_default_limit_is_200(self):
+        assert DEFAULT_FILE_LIMIT == 200
+
+    def test_over_cap_raises(self, tmp_path):
+        # Create more files than the limit allows.
+        cap = 5
+        for i in range(cap + 2):
+            _write(tmp_path / f"f{i:03d}.txt")
+        with pytest.raises(TargetExpansionError, match="exceeds limit of 5"):
+            resolve_targets([str(tmp_path)], file_limit=cap)
+
+    def test_exact_cap_succeeds(self, tmp_path):
+        cap = 3
+        for i in range(cap):
+            _write(tmp_path / f"f{i:03d}.txt")
+        spec = resolve_targets([str(tmp_path)], file_limit=cap)
+        assert len(spec.paths) == cap
+
+
+# ---------------------------------------------------------------------------
+# Glob detection helper
+# ---------------------------------------------------------------------------
+
+
+class TestLooksLikeGlob:
+    @pytest.mark.parametrize("token", ["*.md", "src/**/*.py", "x?.txt", "[ab].md"])
+    def test_glob_metacharacters_detected(self, token):
+        assert looks_like_glob(token) is True
+
+    @pytest.mark.parametrize("token", ["README.md", "src/file.py", "owner/repo#1"])
+    def test_plain_strings_not_globs(self, token):
+        assert looks_like_glob(token) is False
+
+
+# ---------------------------------------------------------------------------
+# TargetSpec invariants
+# ---------------------------------------------------------------------------
+
+
+class TestTargetSpecInvariants:
+    def test_paths_must_be_sorted(self, tmp_path):
+        # Direct construction with unsorted paths should raise.
+        a = _write(tmp_path / "a.txt")
+        b = _write(tmp_path / "b.txt")
+        with pytest.raises(ValueError, match="sorted lexicographically"):
+            TargetSpec(paths=[b, a], raw_targets=[], is_multi=True)

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -182,6 +182,8 @@ class TestFileCountCap:
         cap = 5
         for i in range(cap + 2):
             _write(tmp_path / f"f{i:03d}.txt")
+        # New wording matches the incremental enforcement (Codex P2):
+        # "more than N files; exceeds limit of N".
         with pytest.raises(TargetExpansionError, match="exceeds limit of 5"):
             resolve_targets([str(tmp_path)], file_limit=cap)
 
@@ -220,3 +222,30 @@ class TestTargetSpecInvariants:
         b = _write(tmp_path / "b.txt")
         with pytest.raises(ValueError, match="sorted lexicographically"):
             TargetSpec(paths=[b, a], raw_targets=[], is_multi=True)
+
+
+# ---------------------------------------------------------------------------
+# Codex review follow-ups
+# ---------------------------------------------------------------------------
+
+
+class TestIncrementalCap:
+    """The file-count cap fires *during* expansion, not after a full walk."""
+
+    def test_cap_short_circuits_walk(self, tmp_path, monkeypatch):
+        # Build a tree well above the cap. Even though there are 50 files,
+        # the cap=3 should fire long before all of them are visited.
+        for i in range(50):
+            _write(tmp_path / f"f{i:03d}.txt")
+        with pytest.raises(TargetExpansionError, match="exceeds limit of 3"):
+            resolve_targets([str(tmp_path)], file_limit=3)
+
+    def test_cap_message_does_not_lie_about_total(self, tmp_path):
+        # The error message says "more than N" rather than a precise count
+        # because we stopped early — make sure the wording is consistent.
+        for i in range(5):
+            _write(tmp_path / f"f{i:03d}.txt")
+        with pytest.raises(TargetExpansionError) as ei:
+            resolve_targets([str(tmp_path)], file_limit=2)
+        assert "more than 2 files" in str(ei.value)
+        assert "exceeds limit of 2" in str(ei.value)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -221,3 +221,58 @@ class TestReturnContract:
         report = validate(_make_ruleset(r1, r2), tmp_path)
         ids = [d.rule_id for d in report.diagnostics]
         assert ids == ["alpha", "beta"]
+
+
+# ---------------------------------------------------------------------------
+# Multi-target target argument (issue #146)
+# ---------------------------------------------------------------------------
+
+
+class TestTargetSpecArgument:
+    """``validate`` accepts a ``TargetSpec`` and forwards it to the backend."""
+
+    def test_targetspec_forwarded_to_filesystem_backend(self, tmp_path):
+        from gate_keeper.targets import TargetSpec
+
+        a = tmp_path / "a.txt"
+        a.write_text("x\n")
+        b = tmp_path / "b.txt"
+        b.write_text("x\n")
+        spec = TargetSpec(
+            paths=sorted([a, b], key=str),
+            raw_targets=[str(a), str(b)],
+            is_multi=True,
+        )
+        rule = _rule(kind=RuleKind.FILE_EXISTS, backend_hint=Backend.FILESYSTEM)
+        report = validate(_make_ruleset(rule), spec, backend="filesystem")
+        diag = report.diagnostics[0]
+        assert diag.status is Status.PASS
+        assert any(e.kind == "multi_target_summary" for e in diag.evidence)
+
+    def test_targetspec_forwarded_to_github_backend_unsupported(self, tmp_path):
+        from gate_keeper.targets import TargetSpec
+
+        spec = TargetSpec(
+            paths=[tmp_path / "a.txt"],
+            raw_targets=[str(tmp_path / "a.txt"), str(tmp_path / "b.txt")],
+            is_multi=True,
+        )
+        rule = _rule(kind=RuleKind.GITHUB_PR_OPEN, backend_hint=Backend.GITHUB)
+        report = validate(_make_ruleset(rule), spec, backend="github")
+        diag = report.diagnostics[0]
+        assert diag.status is Status.UNSUPPORTED
+        assert any(e.kind == "multi_target_unsupported" for e in diag.evidence)
+
+    def test_targetspec_forwarded_to_llm_rubric_backend_unsupported(self, tmp_path):
+        from gate_keeper.targets import TargetSpec
+
+        spec = TargetSpec(
+            paths=[tmp_path / "a.txt"],
+            raw_targets=[str(tmp_path / "a.txt"), str(tmp_path / "b.txt")],
+            is_multi=True,
+        )
+        rule = _rule(kind=RuleKind.SEMANTIC_RUBRIC, backend_hint=Backend.LLM_RUBRIC)
+        report = validate(_make_ruleset(rule), spec, backend="llm-rubric")
+        diag = report.diagnostics[0]
+        assert diag.status is Status.UNSUPPORTED
+        assert any(e.kind == "multi_target_unsupported" for e in diag.evidence)


### PR DESCRIPTION
## Summary

Closes #146

Implements the first slice of the multi-target design
(`docs/design/multi-target.md`) — filesystem backend only.

- `TargetSpec` helper + `resolve_targets()` in `src/gate_keeper/targets.py`
  (deduplicated, lexicographically sorted; recursive directory walk
  filtered to text-readable files; `glob.glob(recursive=True)` for
  globs; default file-count cap of 200).
- `validate --target` accepts repeated occurrences via argparse
  `append`. A single literal-file `--target` keeps pre-#146 behaviour
  exactly (raw string forwarded), preserving GitHub PR references like
  `owner/repo#NN`.
- Filesystem backend aggregates per-file results into one `Diagnostic`
  (`pass` iff all files pass; `fail` on any file fail; `unavailable`
  when the resolved set is empty or any file is
  `unavailable`/`unsupported`/`error`). Per-file outcomes appear as
  `file_result` evidence (capped at 50) plus a `multi_target_summary`
  record carrying counts and `raw_targets`.
- Over-cap expansion is a CLI usage error with a clear message.
- Non-filesystem backends (`github`, `llm-rubric`, `external`) fail
  closed on multi-target inputs (`UNSUPPORTED` +
  `multi_target_unsupported` evidence) — never silently use only one
  resolved path.
- Out of scope (deferred): LLM-rubric multi-file content assembly,
  token budgeting, external adapter multi-target contract, remote
  paths, relevance ranking, streaming. The design doc records the
  shipped slice; the user-facing reference lives in
  `docs/cli-reference.md` § "Multi-target evaluation".

## Test plan

- [x] `uv sync`
- [x] `uvx ruff check .` — clean
- [x] `uv run pytest` — 843 passing (was 793; +50 new tests)
- [x] `uvx pyright` — 15 pre-existing import errors only (no new diagnostics)
- [x] New tests cover: single file, repeated `--target`, directory,
      glob, empty glob (fail-closed), over-cap, non-filesystem backend
      rejection (github / llm-rubric / external), Diagnostic
      round-trip, determinism across caller-supplied path orderings.
- [x] Manual smoke: `validate ... --target docs/`,
      `--target a.md --target b.md`, `--target 'docs/*.md'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)