### PR TITLE
feat(llm-rubric): per-provider model override from dotenv (#157)

### DIFF
--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -69,12 +69,16 @@ Setup:
    ```sh
    GATE_KEEPER_LLM_PROVIDER=anthropic
    ANTHROPIC_API_KEY=sk-ant-...
+   # optional model override; defaults to claude-haiku-4-5
+   GATE_KEEPER_ANTHROPIC_MODEL=claude-opus-4-7
    ```
 
    **OpenAI:**
    ```sh
    GATE_KEEPER_LLM_PROVIDER=openai
    OPENAI_API_KEY=sk-...
+   # optional model override; defaults to gpt-4o-mini
+   GATE_KEEPER_OPENAI_MODEL=gpt-4o
    ```
 
 3. (container, automatic) `gate-keeper` reads the file via `python-dotenv`
@@ -83,6 +87,33 @@ Setup:
 If `GATE_KEEPER_LLM_PROVIDER` is missing, set to a value other than
 `anthropic` or `openai`, or the corresponding API key is absent, behavior
 falls back to the unconfigured `unavailable` diagnostic above.
+
+### Model selection
+
+Provider model selection is also dotenv-driven. The active model is
+resolved from the same per-project file (no `os.environ` lookup) using:
+
+| Provider | Override variable | Default |
+| --- | --- | --- |
+| `anthropic` | `GATE_KEEPER_ANTHROPIC_MODEL` | `claude-haiku-4-5` |
+| `openai` | `GATE_KEEPER_OPENAI_MODEL` | `gpt-4o-mini` |
+
+Behavior:
+
+- An unset, missing, or whitespace-only override falls back to the source
+  default constant.
+- The provider-specific override only applies when the matching provider
+  is active (e.g. `GATE_KEEPER_OPENAI_MODEL` is ignored when the provider
+  is `anthropic`).
+- The actual model used is recorded in `llm_judgment.evidence[0].data.model`
+  on every successful run.
+- If the override names a model that is not in the static `_MODEL_PRICING`
+  snapshot above, `cost_estimate_usd` will be `null` (fail-closed: cost is
+  never guessed). Telemetry fields (`latency_ms`, `tokens_in`, `tokens_out`)
+  are still recorded.
+
+`gate-keeper diagnose` surfaces the resolved model and whether it came
+from an override or the default.
 
 ### CI exception: GitHub Actions secret projection
 

--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -108,9 +108,10 @@ Behavior:
 - The actual model used is recorded in `llm_judgment.evidence[0].data.model`
   on every successful run.
 - If the override names a model that is not in the static `_MODEL_PRICING`
-  snapshot above, `cost_estimate_usd` will be `null` (fail-closed: cost is
-  never guessed). Telemetry fields (`latency_ms`, `tokens_in`, `tokens_out`)
-  are still recorded.
+  snapshot/table (see "Per-rule observability fields" below),
+  `cost_estimate_usd` will be `null` (fail-closed: cost is never guessed).
+  Telemetry fields (`latency_ms`, `tokens_in`, `tokens_out`) are still
+  recorded.
 
 `gate-keeper diagnose` surfaces the resolved model and whether it came
 from an override or the default.

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -194,9 +194,17 @@ def _load_env_file(path: Path = DOTENV_PATH) -> dict[str, str]:
     return {k: v for k, v in values.items() if v is not None}
 
 
-def _is_configured() -> bool:
-    """Return True iff a supported provider and its API key are present in the dotenv."""
-    env = _load_env_file()
+def _is_configured(env: dict[str, str] | None = None) -> bool:
+    """Return True iff a supported provider and its API key are present.
+
+    When *env* is ``None`` the dotenv is read fresh; callers that already
+    hold a snapshot should pass it in so the configured decision and any
+    follow-up access (provider, key, model override) all read from the
+    same snapshot — otherwise a concurrent dotenv edit could split the
+    decision across two reads.
+    """
+    if env is None:
+        env = _load_env_file()
     provider = env.get("GATE_KEEPER_LLM_PROVIDER")
     if provider not in _SUPPORTED_PROVIDERS:
         return False
@@ -584,14 +592,18 @@ def check(rule: Rule, target: str | Path | TargetSpec) -> Diagnostic:
 
     rubric_input = _build_rubric_input(rule, target)
 
-    if not _is_configured():
+    # Single-snapshot read: load the dotenv once and drive the configured
+    # check, provider lookup, and model resolution all from the same dict.
+    # Reading twice would let a concurrent dotenv edit split the decision
+    # (e.g. configured=True at first read, provider=None at second read).
+    env = _load_env_file()
+    if not _is_configured(env):
         return _unavailable_unconfigured(rule, rubric_input)
 
-    env = _load_env_file()
     provider = env["GATE_KEEPER_LLM_PROVIDER"]
+    model = _resolve_model(provider, env)
     system, user = _build_prompt(rule, target)
 
-    model = _resolve_model(provider, env)
     try:
         if provider == "anthropic":
             response_text, telemetry = _call_anthropic(env["ANTHROPIC_API_KEY"], system, user, model)

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -204,6 +204,23 @@ def _is_configured() -> bool:
     return bool(env.get(key_var))
 
 
+def _resolve_model(provider: str, env: dict[str, str]) -> str:
+    """Return the model identifier to use for *provider*.
+
+    Reads ``GATE_KEEPER_<PROVIDER>_MODEL`` from the dotenv snapshot when set
+    and non-empty (after stripping); otherwise falls back to the source
+    default constant. Empty / whitespace-only overrides are ignored so a
+    blank line in the dotenv does not silently produce an invalid model id.
+    """
+    if provider == "anthropic":
+        override = env.get("GATE_KEEPER_ANTHROPIC_MODEL", "").strip()
+        return override or ANTHROPIC_DEFAULT_MODEL
+    if provider == "openai":
+        override = env.get("GATE_KEEPER_OPENAI_MODEL", "").strip()
+        return override or OPENAI_DEFAULT_MODEL
+    raise ValueError(f"unsupported provider: {provider!r}")
+
+
 # ---------------------------------------------------------------------------
 # Rubric input builder
 # ---------------------------------------------------------------------------
@@ -574,12 +591,11 @@ def check(rule: Rule, target: str | Path | TargetSpec) -> Diagnostic:
     provider = env["GATE_KEEPER_LLM_PROVIDER"]
     system, user = _build_prompt(rule, target)
 
+    model = _resolve_model(provider, env)
     try:
         if provider == "anthropic":
-            model = ANTHROPIC_DEFAULT_MODEL
             response_text, telemetry = _call_anthropic(env["ANTHROPIC_API_KEY"], system, user, model)
         else:
-            model = OPENAI_DEFAULT_MODEL
             response_text, telemetry = _call_openai(env["OPENAI_API_KEY"], system, user, model)
     except Exception as exc:  # noqa: BLE001 — fail-closed: any provider error → unavailable
         return _unavailable_provider_error(rule, rubric_input, provider, type(exc).__name__, str(exc))

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -646,6 +646,9 @@ def _cmd_diagnose(args: argparse.Namespace) -> int:
         else:
             print("ANTHROPIC_API_KEY: <unset>")
         configured = bool(key_value)
+        model = llm_rubric._resolve_model("anthropic", env)
+        override = env.get("GATE_KEEPER_ANTHROPIC_MODEL", "").strip()
+        print(f"model:              {model} ({'override' if override else 'default'})")
     elif provider == "openai":
         key_value = env.get("OPENAI_API_KEY")
         if key_value:
@@ -653,6 +656,9 @@ def _cmd_diagnose(args: argparse.Namespace) -> int:
         else:
             print("OPENAI_API_KEY: <unset>")
         configured = bool(key_value)
+        model = llm_rubric._resolve_model("openai", env)
+        override = env.get("GATE_KEEPER_OPENAI_MODEL", "").strip()
+        print(f"model:              {model} ({'override' if override else 'default'})")
     else:
         print("api key:            <unsupported provider; no key reported>")
         configured = False

--- a/tests/test_cli_diagnose.py
+++ b/tests/test_cli_diagnose.py
@@ -115,3 +115,63 @@ def test_diagnose_provider_set_but_key_unset_reports_no(monkeypatch, capsys):
     out = captured.out
     assert "OPENAI_API_KEY: <unset>" in out
     assert "provider configured: no" in out
+
+
+def test_diagnose_reports_default_model_openai(monkeypatch, capsys):
+    """Without an override, ``diagnose`` reports the default OpenAI model."""
+    env = {
+        "GATE_KEEPER_LLM_PROVIDER": "openai",
+        "OPENAI_API_KEY": "sk-test",
+    }
+    monkeypatch.setattr(llm_backend, "_load_env_file", lambda *a, **kw: env)
+
+    rc = main(["diagnose"])
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert f"model:              {llm_backend.OPENAI_DEFAULT_MODEL} (default)" in out
+
+
+def test_diagnose_reports_override_model_openai(monkeypatch, capsys):
+    """``GATE_KEEPER_OPENAI_MODEL`` is surfaced in the ``diagnose`` model line."""
+    env = {
+        "GATE_KEEPER_LLM_PROVIDER": "openai",
+        "OPENAI_API_KEY": "sk-test",
+        "GATE_KEEPER_OPENAI_MODEL": "gpt-4o",
+    }
+    monkeypatch.setattr(llm_backend, "_load_env_file", lambda *a, **kw: env)
+
+    rc = main(["diagnose"])
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "model:              gpt-4o (override)" in out
+
+
+def test_diagnose_reports_default_model_anthropic(monkeypatch, capsys):
+    env = {
+        "GATE_KEEPER_LLM_PROVIDER": "anthropic",
+        "ANTHROPIC_API_KEY": "sk-ant-test",
+    }
+    monkeypatch.setattr(llm_backend, "_load_env_file", lambda *a, **kw: env)
+
+    rc = main(["diagnose"])
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert f"model:              {llm_backend.ANTHROPIC_DEFAULT_MODEL} (default)" in out
+
+
+def test_diagnose_reports_override_model_anthropic(monkeypatch, capsys):
+    env = {
+        "GATE_KEEPER_LLM_PROVIDER": "anthropic",
+        "ANTHROPIC_API_KEY": "sk-ant-test",
+        "GATE_KEEPER_ANTHROPIC_MODEL": "claude-opus-4-7",
+    }
+    monkeypatch.setattr(llm_backend, "_load_env_file", lambda *a, **kw: env)
+
+    rc = main(["diagnose"])
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "model:              claude-opus-4-7 (override)" in out

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -253,6 +253,133 @@ def _patch_env(monkeypatch, env: dict[str, str]) -> None:
 
 
 # ---------------------------------------------------------------------------
+# _resolve_model — dotenv-driven model override (#157)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveModel:
+    """Issue #157 — provider-specific model override from the dotenv snapshot."""
+
+    def test_anthropic_override_takes_precedence(self):
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "anthropic",
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+            "GATE_KEEPER_ANTHROPIC_MODEL": "claude-opus-4-7",
+        }
+        assert llm_backend._resolve_model("anthropic", env) == "claude-opus-4-7"
+
+    def test_anthropic_unset_falls_back_to_default(self):
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "anthropic",
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+        }
+        assert llm_backend._resolve_model("anthropic", env) == llm_backend.ANTHROPIC_DEFAULT_MODEL
+
+    def test_anthropic_blank_override_falls_back_to_default(self):
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "anthropic",
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+            "GATE_KEEPER_ANTHROPIC_MODEL": "   ",
+        }
+        assert llm_backend._resolve_model("anthropic", env) == llm_backend.ANTHROPIC_DEFAULT_MODEL
+
+    def test_openai_override_takes_precedence(self):
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "openai",
+            "OPENAI_API_KEY": "sk-openai-test",
+            "GATE_KEEPER_OPENAI_MODEL": "gpt-4o",
+        }
+        assert llm_backend._resolve_model("openai", env) == "gpt-4o"
+
+    def test_openai_unset_falls_back_to_default(self):
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "openai",
+            "OPENAI_API_KEY": "sk-openai-test",
+        }
+        assert llm_backend._resolve_model("openai", env) == llm_backend.OPENAI_DEFAULT_MODEL
+
+    def test_openai_blank_override_falls_back_to_default(self):
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "openai",
+            "OPENAI_API_KEY": "sk-openai-test",
+            "GATE_KEEPER_OPENAI_MODEL": "",
+        }
+        assert llm_backend._resolve_model("openai", env) == llm_backend.OPENAI_DEFAULT_MODEL
+
+    def test_unsupported_provider_raises(self):
+        with pytest.raises(ValueError):
+            llm_backend._resolve_model("bedrock", {})
+
+    def test_cross_provider_override_does_not_apply(self):
+        """``GATE_KEEPER_OPENAI_MODEL`` must not influence the anthropic resolution."""
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "anthropic",
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+            "GATE_KEEPER_OPENAI_MODEL": "gpt-4o",
+        }
+        assert llm_backend._resolve_model("anthropic", env) == llm_backend.ANTHROPIC_DEFAULT_MODEL
+
+    def test_check_uses_anthropic_override(self, monkeypatch, tmp_path):
+        """check() must pass the override model to the provider helper and record it."""
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "anthropic",
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+            "GATE_KEEPER_ANTHROPIC_MODEL": "claude-opus-4-7",
+        }
+        _patch_env(monkeypatch, env)
+        seen: dict[str, str] = {}
+
+        def _capture(_key, _system, _user, model):
+            seen["model"] = model
+            return _stub_response(_VALID_PASS_JSON)
+
+        monkeypatch.setattr(llm_backend, "_call_anthropic", _capture)
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        assert seen["model"] == "claude-opus-4-7"
+        assert diag.evidence[0].data["model"] == "claude-opus-4-7"
+
+    def test_check_uses_openai_override(self, monkeypatch, tmp_path):
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "openai",
+            "OPENAI_API_KEY": "sk-openai-test",
+            "GATE_KEEPER_OPENAI_MODEL": "gpt-4o",
+        }
+        _patch_env(monkeypatch, env)
+        seen: dict[str, str] = {}
+
+        def _capture(_key, _system, _user, model):
+            seen["model"] = model
+            return _stub_response(_VALID_PASS_JSON)
+
+        monkeypatch.setattr(llm_backend, "_call_openai", _capture)
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        assert seen["model"] == "gpt-4o"
+        assert diag.evidence[0].data["model"] == "gpt-4o"
+
+    def test_check_unknown_override_model_yields_null_cost(self, monkeypatch, tmp_path):
+        """An override model not in ``_MODEL_PRICING`` yields ``cost_estimate_usd: None``."""
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "openai",
+            "OPENAI_API_KEY": "sk-openai-test",
+            "GATE_KEEPER_OPENAI_MODEL": "gpt-future-unknown",
+        }
+        _patch_env(monkeypatch, env)
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(
+                _VALID_PASS_JSON,
+                {"latency_ms": 100, "tokens_in": 1000, "tokens_out": 200},
+            ),
+        )
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        data = diag.evidence[0].data
+        assert data["model"] == "gpt-future-unknown"
+        assert "cost_estimate_usd" in data
+        assert data["cost_estimate_usd"] is None
+
+
+# ---------------------------------------------------------------------------
 # Provider dispatch — Anthropic (#67: updated to structured schema)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `GATE_KEEPER_ANTHROPIC_MODEL` / `GATE_KEEPER_OPENAI_MODEL` dotenv overrides for the `llm-rubric` backend, preserving the no-`os.environ` policy.
- `_resolve_model(provider, env)` reads the matching variable; empty / whitespace-only values fall back to the source default constant. Cross-provider variables are ignored.
- `diagnose` surfaces the resolved model and labels it `(default)` or `(override)`.
- Unknown override models keep `cost_estimate_usd` as `null` per the existing fail-closed pricing policy; telemetry fields are still recorded.
- `docs/llm-rubric.md` documents the new keys, the override → default fallback, and the unknown-model cost behaviour.

## Validation

- `uv run pytest -q` — 1005 passed (incl. new `TestResolveModel` and four `diagnose` model-line tests)
- `uvx ruff check .` — All checks passed
- `uvx pyright` — 17 errors, all pre-existing on `main` (`pytest` import resolution in tests); no new diagnostics

## Test plan

- [x] `_resolve_model` unit tests cover override / unset / blank / unsupported / cross-provider cases for both providers
- [x] `check()` integration tests confirm the override is forwarded to the provider helper and recorded in `evidence[0].data.model` for both providers
- [x] Unknown-model override yields `cost_estimate_usd: null`
- [x] `diagnose` reports default vs. override per provider
- [x] Existing fail-closed paths (unconfigured, provider error, missing usage) unchanged

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)