### PR TITLE
feat(dependency-gates): umbrella #159 slice 1 — design note + cli-reference validator

### DIFF
--- a/.gate-keeper/dependency-manifest.yml
+++ b/.gate-keeper/dependency-manifest.yml
@@ -1,0 +1,19 @@
+# Project-local dependency manifest consumed by scripts/dependency_gates/
+# validators. Schema: docs/design/dependency-gates.md §3.
+#
+# Slice 1 (umbrella #159 / issue #161) ships exactly one edge: when
+# src/gate_keeper/cli.py changes in a PR, docs/cli-reference.md must change
+# too — or a reviewer ack must land at .gate-keeper/acks/cli-implementation-documents-cli-reference.yml.
+
+nodes:
+  - id: cli-implementation
+    path: src/gate_keeper/cli.py
+    kind: code
+  - id: cli-reference
+    path: docs/cli-reference.md
+    kind: reference
+
+edges:
+  - from: cli-implementation
+    to: cli-reference
+    relation: documents

--- a/docs/dependency-gate-rules.json
+++ b/docs/dependency-gate-rules.json
@@ -1,0 +1,27 @@
+{
+  "rules": [
+    {
+      "id": "cli-reference-tracks-cli-implementation",
+      "title": "docs/cli-reference.md must track src/gate_keeper/cli.py",
+      "source": {
+        "path": "docs/dependency-gate-rules.json",
+        "line": 1,
+        "heading": "cli-reference tracks cli-implementation"
+      },
+      "text": "When src/gate_keeper/cli.py changes in a PR, docs/cli-reference.md must change too — or a reviewer ack at .gate-keeper/acks/<edge-id>.yml must cover the current source sha.",
+      "kind": "external_check",
+      "severity": "warning",
+      "backend_hint": "external",
+      "confidence": "high",
+      "params": {
+        "tool": "command",
+        "argv": [
+          "python",
+          "scripts/dependency_gates/check_cli_reference.py"
+        ],
+        "manifest": ".gate-keeper/dependency-manifest.yml",
+        "timeout_seconds": 30
+      }
+    }
+  ]
+}

--- a/docs/design/dependency-gates.md
+++ b/docs/design/dependency-gates.md
@@ -93,9 +93,11 @@ Slice-1 vocabulary:
 - `dependent_artifact_co_changed` — source changed and target also changed in the same set.
 - `dependent_artifact_acked` — source changed, target unchanged, valid ack file present.
 - `dependent_artifact_changed_without_target_update` — source changed, target unchanged, no valid ack.
-- `dependent_artifact_stale_by_hash` — Mode B: target's `tracks:` sha does not match the source's current sha.
+- `dependent_artifact_stale_by_hash` — Mode B: target's `tracks:` sha does not match the source's current sha. (Reserved; emitted only once Mode B is implemented in slice 2.)
+- `ack_invalid` — ack file exists but cannot be parsed as a YAML mapping; emitted as FAIL so the author is not left wondering why a file they committed was silently ignored.
 - `edge_not_applicable` — the validator was invoked on a target that does not appear in any edge; emitted as PASS so the rule is safe to enable on multiple targets.
 - `changed_file_source_unresolved` — Mode A: git unavailable or base ref unresolvable; emitted as `unavailable`.
+- `stamped_mode_not_implemented` — an edge declares `mode: stamped` but slice-1 only implements Mode A; emitted as `unavailable` so the deferred mode is surfaced explicitly rather than silently miscategorised.
 
 New subtypes are added as needed. `Status` enum values are unchanged; only the evidence vocabulary grows.
 

--- a/docs/design/dependency-gates.md
+++ b/docs/design/dependency-gates.md
@@ -1,0 +1,256 @@
+# Design: Declarative Artifact-Dependency Gates
+
+> Status: internal process artifact — not user-facing reference.
+
+Tracking umbrella: #159. Coordinates children #156 (code↔doc / doc↔doc dependency gating) and #158 (paired-artifact existence/sync gates). This note is the joint contract that both children consume so that two divergent manifest designs do not have to be reconciled later.
+
+> **Implementation status (first slice).** Issue #161 implements the first slice. Shipped:
+>
+> - This design note — load-bearing for #156 and #158.
+> - `.gate-keeper/dependency-manifest.yml` — single edge from `src/gate_keeper/cli.py` to `docs/cli-reference.md`.
+> - Loader at `scripts/dependency_gates/manifest.py` (graph schema, `pairs:` sugar, `mode: stamped` parsing).
+> - Validator at `scripts/dependency_gates/check_cli_reference.py` wired through the existing `external_check` + `command` adapter (#149). No new `RuleKind`.
+> - IR rule file `docs/dependency-gate-rules.json` exercisable via `gate-keeper validate --rules-format ir ... --allow-command-adapter`.
+> - Loader and validator tests, including a `@pytest.mark.integration` end-to-end round-trip.
+>
+> **Out of slice (deferred):** PR-trailer ack transport, MCP validator transport, cycle-detection rule, in-repo #158 reference validator, automatic dependency discovery, any new `RuleKind`. See §7 for the full out-of-scope list.
+
+---
+
+## 1. Problem Statement
+
+Documents and paired artifacts drift because dependencies are implicit. Two parallel exploration issues identified the same gap from different angles:
+
+- **#156** — code↔doc and doc↔doc dependencies (e.g. CLI implementation versus CLI reference). PR-driven affected-set computation; "dependent doc was reviewed but does not need an edit" evidence shape.
+- **#158** — paired artifacts that should remain complete and synchronized: ja↔en docs, paper theorem ↔ Lean formalization, Lean theorem ↔ appendix explanation, source ↔ translation. Existence checks, sync metadata, and (separately) advisory semantic correspondence.
+
+Both proposals converged on the same shape: a declarative manifest that expresses dependency edges, a deterministic gate enforced by `gate-keeper`, and a first slice routed through the trusted `command` external adapter (#149). The question is whether they share one manifest contract or fragment into two.
+
+This note answers: **one manifest contract, two staleness modes, no new core rule kinds in slice 1.**
+
+---
+
+## 2. Settled Rules
+
+The seven rules below are load-bearing. The slice-1 implementation honours them. Future slices may extend but must not contradict them.
+
+### 2.1 Manifest schema is graph-shaped
+
+Top-level `nodes` (id, path, anchor?, kind?) and `edges` (from-id, to-id, relation, mode?, pair_id?). A `pairs:` sugar form is accepted as input but the loader desugars it to nodes+edges before any consumer sees it.
+
+A pair is just two nodes connected by an edge. A graph is the strict superset of a list of pairs. Choosing the superset gives one loader, one schema, one validation pass.
+
+### 2.2 Anchor is opaque to the loader
+
+A node's `anchor` is a string. The loader stores it verbatim and does not interpret it. Validators that consume an edge interpret the anchor in whatever vocabulary fits — Markdown heading, LaTeX label, Lean declaration, code symbol id, regex selector.
+
+Anchor *resolution* is a per-validator concern. Pinning an anchor grammar in the manifest schema would conflate the manifest's contract (what edges exist) with each validator's contract (how it locates content within a file).
+
+### 2.3 Edges are directed
+
+Bidirectional relations (translation pairs, mutual references) lower to two directed edges sharing a `pair_id`. There is no `direction: bidirectional` field on an edge.
+
+#156's primary use case (PR-affected-set traversal) is a reverse traversal of a directed graph. Mixing directed and bidirectional primitives in the same loader complicates traversal without expressive gain. Two directed edges with a shared `pair_id` recovers the bidirectional semantics where needed.
+
+### 2.4 Two staleness modes coexist
+
+Per-edge selection via `edge.mode`:
+
+- **`affected_set`** (default, Mode A) — the validator consumes a changed-file set and emits diagnostics for dependents whose source changed. No target-side stamp required. Matches #156's primary use case.
+- **`stamped`** (Mode B) — the target frontmatter records `tracks: <source-id>@<sha256>`; the validator compares against the current source. Matches #158's primary use case.
+
+Both modes use the same manifest. The mode determines which check the validator runs on a given edge.
+
+### 2.5 Ack transport is a file
+
+Reviewer evidence that a source change was reviewed without requiring a target edit lives in `.gate-keeper/acks/<edge-id>.yml` with shape:
+
+```yaml
+edge_id: <edge id from manifest>
+source_sha: <sha256 of source file content at ack time>
+ack_by: <reviewer identifier>
+ack_at: <ISO-8601 timestamp>
+reason: <free-form rationale>
+```
+
+The validator accepts the ack only when `source_sha` matches the source file's current content sha. Stale acks (source has changed again since the ack) do not satisfy the gate.
+
+PR-trailer transport is deferred. A reviewer-supplied file is durably committable, machine-readable, and reviewable in the diff. PR trailers add a transport without expressive gain in the first slice.
+
+### 2.6 First slice adds NO new `RuleKind`
+
+The slice uses `external_check` + `params.tool == "command"` (#149). A validator script reads the manifest and the changed-file set (or target frontmatter), and emits one `Diagnostic` per affected edge. Promotion of any check to a core rule kind is a slice-2 decision.
+
+The existing dispatch primitive is sufficient. Adding `manifest_valid`, `dependent_artifacts_acknowledged`, or similar to `RuleKind` before any reference validator has been exercised would be premature.
+
+### 2.7 Failure subtypes are evidence-record `kind` strings
+
+Slice-1 vocabulary:
+
+- `manifest_invalid` — schema/parse failure on the manifest itself.
+- `manifest_target_missing` — declared `path` does not exist on disk.
+- `dependent_artifact_unaffected` — source not in the changed set; nothing to do.
+- `dependent_artifact_co_changed` — source changed and target also changed in the same set.
+- `dependent_artifact_acked` — source changed, target unchanged, valid ack file present.
+- `dependent_artifact_changed_without_target_update` — source changed, target unchanged, no valid ack.
+- `dependent_artifact_stale_by_hash` — Mode B: target's `tracks:` sha does not match the source's current sha.
+- `edge_not_applicable` — the validator was invoked on a target that does not appear in any edge; emitted as PASS so the rule is safe to enable on multiple targets.
+- `changed_file_source_unresolved` — Mode A: git unavailable or base ref unresolvable; emitted as `unavailable`.
+
+New subtypes are added as needed. `Status` enum values are unchanged; only the evidence vocabulary grows.
+
+---
+
+## 3. Manifest Schema
+
+### 3.1 YAML shape
+
+```yaml
+nodes:
+  - id: cli-implementation
+    path: src/gate_keeper/cli.py
+    kind: code             # optional, free-form
+  - id: cli-reference
+    path: docs/cli-reference.md
+    kind: reference        # optional
+    anchor: "## validate"  # optional, opaque
+
+edges:
+  - from: cli-implementation
+    to: cli-reference
+    relation: documents    # free-form
+    # mode: affected_set   # default; explicit `stamped` opts into Mode B
+
+pairs:                     # optional sugar; desugared on load
+  - id: docs-foo-ja-en
+    relation: translation
+    source: ja-foo
+    target: en-foo
+```
+
+A `pairs[].source` and `pairs[].target` reference node ids. Each `pairs` entry produces two directed edges with `pair_id` set to `pairs[].id`.
+
+### 3.2 JSON-Schema fragment
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nodes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "path"],
+        "properties": {
+          "id":     { "type": "string", "minLength": 1 },
+          "path":   { "type": "string", "minLength": 1 },
+          "anchor": { "type": "string" },
+          "kind":   { "type": "string" }
+        }
+      }
+    },
+    "edges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["from", "to", "relation"],
+        "properties": {
+          "from":     { "type": "string", "minLength": 1 },
+          "to":       { "type": "string", "minLength": 1 },
+          "relation": { "type": "string", "minLength": 1 },
+          "mode":     { "enum": ["affected_set", "stamped"] },
+          "pair_id":  { "type": "string" }
+        }
+      }
+    },
+    "pairs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "source", "target", "relation"],
+        "properties": {
+          "id":       { "type": "string", "minLength": 1 },
+          "relation": { "type": "string", "minLength": 1 },
+          "source":   { "type": "string", "minLength": 1 },
+          "target":   { "type": "string", "minLength": 1 },
+          "mode":     { "enum": ["affected_set", "stamped"] }
+        }
+      }
+    }
+  }
+}
+```
+
+The loader additionally enforces:
+
+- node ids are unique;
+- every `edges[].from` and `edges[].to` references a known node id;
+- every `pairs[].source` and `pairs[].target` references a known node id;
+- `pair_id` set on a desugared edge equals the originating `pairs[].id`.
+
+---
+
+## 4. Resolved Open Items
+
+### 4.1 Manifest path
+
+`.gate-keeper/dependency-manifest.yml`. Co-located with `.gate-keeper/acks/`. The `external_check` rule passes `params.manifest` to the validator; absent, the validator falls back to this default.
+
+### 4.2 Validator script location
+
+`scripts/dependency_gates/`. One script per "view" (e.g. `check_cli_reference.py`) sharing a common loader (`manifest.py`) and helper (`_changed_files.py`). New views in future slices are new sibling scripts; the loader stays single-sourced.
+
+### 4.3 Changed-file source for Mode A
+
+The validator computes `git diff --name-only ${GATE_KEEPER_BASE_REF:-origin/main}...HEAD` internally via `subprocess.run(..., shell=False)`. No new CLI flag in slice 1.
+
+If git is unavailable or the base ref does not resolve, the validator emits `Status.UNAVAILABLE` with evidence `kind: changed_file_source_unresolved` rather than treating "all files changed" as a fallback. Fail-closed.
+
+`GATE_KEEPER_BASE_REF` may be set in CI or by the developer; default `origin/main` works for both PR-context CI and `git rebase`-style local workflows.
+
+---
+
+## 5. Failure-Mode Taxonomy
+
+See §2.7 for the evidence-record `kind` vocabulary. Every diagnostic the validator emits carries exactly one evidence record from that vocabulary. The validator never emits multiple evidence records per diagnostic in slice 1 — one edge, one verdict, one evidence kind.
+
+The validator always exits 0 per the `command` adapter contract (`docs/backend-external.md` § "command"). Pass/fail is carried by the `Diagnostic.status` field, not by the process exit code.
+
+---
+
+## 6. Slice-2 Core Promotion Criterion
+
+**Recommendation.** Promote `manifest_valid` and one affected-set rule kind to core IFF (a) at least one additional non-cli reference validator lands AND (b) Mode B (target-stamped) is exercised in CI.
+
+A single additional validator surfaces the shared logic that a core rule kind would absorb. Mode B exercise in CI demonstrates the manifest carries its weight beyond #156's PR-affected-set use case. Without both signals, the `command` adapter remains the right level.
+
+---
+
+## 7. Out of Scope
+
+This note settles slice 1. The following remain deferred:
+
+- Automatic discovery of dependencies (no parser walks code or docs to infer edges).
+- PR-trailer transport for acks.
+- MCP transport for validators.
+- Cycle-detection rule (`documentation_dependency_graph_acyclic` candidate from #156 stays deferred).
+- Cross-repository graphs.
+- An in-repo #158-family reference validator. The repo has no `*.ja.md` / `*.en.md` pair, no Lean files, and no in-repo formalization↔explanation pair. The #158 manifest shape is exercised at the loader-fixture level (bidirectional `pairs:` desugaring; `mode: stamped` parsing) until a real pair exists.
+- Promoting any failure subtype to a `RuleKind`.
+- A new CLI flag for the changed-file set; the validator owns its diff source.
+- Semantic equivalence checks (translation faithfulness, formalization correctness). These remain advisory and route to `semantic_rubric` if and when wired; this note does not couple to that path.
+
+---
+
+## 8. References
+
+- Umbrella: #159
+- Children: #156, #158
+- Adapter substrate: #149 (`command` adapter); #92–#94 (`Backend.EXTERNAL` pattern under #80).
+- Existing example: `docs/example-rules.md` §8 (project-local validator script).
+- Adapter contract: `docs/backend-external.md` § "command".

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -43,10 +43,34 @@ The seed pool of semantic self-gating rules lives in
 document are advisory only at the time of authoring; none meets the
 promotion criteria in this document yet.
 
+## Dependency-gate dogfood (umbrella #159)
+
+Slice 1 of umbrella #159 ships a project-local `external_check` rule that
+gates `src/gate_keeper/cli.py` against `docs/cli-reference.md`. The rule
+lives in [`dependency-gate-rules.json`](dependency-gate-rules.json) and runs
+through the `command` adapter. Because `command` adapter rules are disabled
+by default, exercising it requires `--allow-command-adapter`:
+
+```sh
+uv run gate-keeper validate \
+  --rules-format ir docs/dependency-gate-rules.json \
+  --target docs/cli-reference.md \
+  --allow-command-adapter
+```
+
+The validator script (`scripts/dependency_gates/check_cli_reference.py`)
+is general — it reads `.gate-keeper/dependency-manifest.yml` and validates
+any edge whose `to` matches the supplied target. Adding new dependency
+edges does not require a new rule. The contract is documented in
+[`design/dependency-gates.md`](design/dependency-gates.md). This rule is
+**advisory only**; promotion follows the §"Promotion criteria" path above.
+
 ## Out of scope
 
 - External repos consuming `gate-keeper` set their own promotion policy.
 - This document does not list specific rules. Rule-level state lives next to
   the rule definitions (see [`dogfooding-rules.md`](dogfooding-rules.md) for
-  the semantic advisory pool, and [`example-rules.md`](example-rules.md)
-  for the deterministic examples).
+  the semantic advisory pool, [`example-rules.md`](example-rules.md) for
+  the deterministic examples, and
+  [`dependency-gate-rules.json`](dependency-gate-rules.json) for the
+  declarative artifact-dependency gate).

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -69,8 +69,8 @@ edges does not require a new rule. The contract is documented in
 
 - External repos consuming `gate-keeper` set their own promotion policy.
 - This document does not list specific rules. Rule-level state lives next to
-  the rule definitions (see [`dogfooding-rules.md`](dogfooding-rules.md) for
+  the rule definitions: see [`dogfooding-rules.md`](dogfooding-rules.md) for
   the semantic advisory pool, [`example-rules.md`](example-rules.md) for
   the deterministic examples, and
   [`dependency-gate-rules.json`](dependency-gate-rules.json) for the
-  declarative artifact-dependency gate).
+  declarative artifact-dependency gates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ select = ["E", "F", "I"]
 [tool.pyright]
 pythonVersion = "3.10"
 typeCheckingMode = "basic"
+extraPaths = ["scripts"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/scripts/dependency_gates/__init__.py
+++ b/scripts/dependency_gates/__init__.py
@@ -1,0 +1,4 @@
+"""Project-local dependency-gate validators (umbrella #159, slice 1).
+
+Schema and contract: docs/design/dependency-gates.md.
+"""

--- a/scripts/dependency_gates/_changed_files.py
+++ b/scripts/dependency_gates/_changed_files.py
@@ -52,13 +52,7 @@ def compute_changed_files(
 
     if result.returncode != 0:
         stderr = (result.stderr or "").strip()
-        raise ChangedFilesError(
-            f"git diff exited {result.returncode}: {stderr or '(no stderr)'}"
-        )
+        raise ChangedFilesError(f"git diff exited {result.returncode}: {stderr or '(no stderr)'}")
 
-    changed = {
-        line.strip()
-        for line in result.stdout.splitlines()
-        if line.strip()
-    }
+    changed = {line.strip() for line in result.stdout.splitlines() if line.strip()}
     return frozenset(changed)

--- a/scripts/dependency_gates/_changed_files.py
+++ b/scripts/dependency_gates/_changed_files.py
@@ -1,0 +1,64 @@
+"""Changed-file resolver for Mode A (PR-affected-set) validators.
+
+Wraps ``git diff --name-only <base_ref>...HEAD``. The validator owns its diff
+source rather than going through a CLI flag — see
+docs/design/dependency-gates.md §4.3.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+DEFAULT_BASE_REF_ENV = "GATE_KEEPER_BASE_REF"
+DEFAULT_BASE_REF = "origin/main"
+
+
+class ChangedFilesError(RuntimeError):
+    """Raised when the changed-file set cannot be computed."""
+
+
+def resolve_base_ref(env: dict[str, str] | None = None) -> str:
+    """Return the configured base ref (env var with fallback)."""
+    source = env if env is not None else os.environ
+    value = source.get(DEFAULT_BASE_REF_ENV)
+    if value:
+        return value
+    return DEFAULT_BASE_REF
+
+
+def compute_changed_files(
+    repo_root: str | Path,
+    base_ref: str,
+) -> frozenset[str]:
+    """Return the set of repo-relative POSIX paths changed since *base_ref*."""
+    repo_root = Path(repo_root)
+    if not repo_root.is_dir():
+        raise ChangedFilesError(f"repo root does not exist: {repo_root}")
+    try:
+        result = subprocess.run(  # noqa: S603 -- explicit argv, shell=False
+            ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+            cwd=str(repo_root),
+            check=False,
+            capture_output=True,
+            text=True,
+            shell=False,
+        )
+    except FileNotFoundError as exc:
+        raise ChangedFilesError("git executable not found on PATH") from exc
+    except OSError as exc:
+        raise ChangedFilesError(f"git invocation failed: {exc}") from exc
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        raise ChangedFilesError(
+            f"git diff exited {result.returncode}: {stderr or '(no stderr)'}"
+        )
+
+    changed = {
+        line.strip()
+        for line in result.stdout.splitlines()
+        if line.strip()
+    }
+    return frozenset(changed)

--- a/scripts/dependency_gates/check_cli_reference.py
+++ b/scripts/dependency_gates/check_cli_reference.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Mode-A validator for declarative artifact-dependency gates (umbrella #159).
+
+Reads a JSON ``{rule, target}`` payload on stdin per the ``command`` external
+adapter contract (docs/backend-external.md § "command"). For each manifest
+edge whose ``to`` node path matches the validated target, checks whether the
+``from`` node was changed without the target also being changed and without a
+matching ack file at ``.gate-keeper/acks/<edge-id>.yml``.
+
+Always exits 0; pass/fail is carried in the emitted ``Diagnostic.status``.
+
+Schema and contract: docs/design/dependency-gates.md.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from dependency_gates._changed_files import (  # noqa: E402
+        ChangedFilesError,
+        compute_changed_files,
+        resolve_base_ref,
+    )
+    from dependency_gates.manifest import (  # noqa: E402
+        Edge,
+        Manifest,
+        ManifestError,
+        Node,
+        load_manifest,
+    )
+else:
+    from ._changed_files import (
+        ChangedFilesError,
+        compute_changed_files,
+        resolve_base_ref,
+    )
+    from .manifest import (
+        Edge,
+        Manifest,
+        ManifestError,
+        Node,
+        load_manifest,
+    )
+
+DEFAULT_MANIFEST_PATH = ".gate-keeper/dependency-manifest.yml"
+DEFAULT_ACKS_DIR = ".gate-keeper/acks"
+
+
+@dataclass(frozen=True)
+class Outcome:
+    status: str
+    message: str
+    evidence_kind: str
+    evidence_data: dict[str, Any]
+    remediation: str | None = None
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    payload = _parse_payload(raw)
+    target_str = payload.get("target", "") or ""
+    rule = payload.get("rule") or {}
+    params = rule.get("params") or {}
+
+    repo_root = _resolve_repo_root(Path.cwd())
+    manifest_path = _resolve_manifest_path(params, repo_root)
+
+    outcome = _run(
+        repo_root=repo_root,
+        manifest_path=manifest_path,
+        target=target_str,
+    )
+    _emit(outcome)
+    return 0
+
+
+def _run(*, repo_root: Path, manifest_path: Path, target: str) -> Outcome:
+    try:
+        manifest = load_manifest(manifest_path)
+    except ManifestError as exc:
+        return Outcome(
+            status="fail",
+            message=f"manifest invalid: {exc}",
+            evidence_kind="manifest_invalid",
+            evidence_data={"manifest_path": str(manifest_path), "error": str(exc)},
+            remediation=(
+                "Fix the manifest at "
+                f"{manifest_path} to match docs/design/dependency-gates.md §3."
+            ),
+        )
+
+    target_rel = _to_repo_relative(target, repo_root)
+    edges = _edges_for_target(manifest, target_rel)
+    if not edges:
+        return Outcome(
+            status="pass",
+            message=(
+                f"target {target_rel!r} is not the 'to' side of any manifest edge"
+            ),
+            evidence_kind="edge_not_applicable",
+            evidence_data={"target": target_rel},
+        )
+
+    missing = [
+        node.path
+        for node in manifest.nodes
+        if not (repo_root / node.path).exists()
+    ]
+    if missing:
+        return Outcome(
+            status="fail",
+            message=f"manifest references missing path(s): {missing}",
+            evidence_kind="manifest_target_missing",
+            evidence_data={"missing_paths": missing},
+            remediation=(
+                "Update the manifest entries or restore the referenced files."
+            ),
+        )
+
+    base_ref = resolve_base_ref()
+    try:
+        changed = compute_changed_files(repo_root, base_ref)
+    except ChangedFilesError as exc:
+        return Outcome(
+            status="unavailable",
+            message=f"cannot compute changed-file set: {exc}",
+            evidence_kind="changed_file_source_unresolved",
+            evidence_data={"base_ref": base_ref, "error": str(exc)},
+            remediation=(
+                "Set GATE_KEEPER_BASE_REF to a resolvable git ref, "
+                "or run inside a git working tree."
+            ),
+        )
+
+    return _evaluate_edges(
+        manifest=manifest,
+        edges=edges,
+        changed=changed,
+        repo_root=repo_root,
+    )
+
+
+def _evaluate_edges(
+    *,
+    manifest: Manifest,
+    edges: list[Edge],
+    changed: frozenset[str],
+    repo_root: Path,
+) -> Outcome:
+    for edge in edges:
+        source_node = manifest.node(edge.from_id)
+        target_node = manifest.node(edge.to_id)
+        source_path = source_node.path
+        target_path = target_node.path
+        edge_id = _edge_id(edge, source_node, target_node)
+
+        if source_path not in changed:
+            return Outcome(
+                status="pass",
+                message=(
+                    f"edge {edge_id}: source {source_path} unchanged; "
+                    f"target {target_path} is up to date"
+                ),
+                evidence_kind="dependent_artifact_unaffected",
+                evidence_data={
+                    "edge_id": edge_id,
+                    "source_path": source_path,
+                    "target_path": target_path,
+                },
+            )
+
+        if target_path in changed:
+            return Outcome(
+                status="pass",
+                message=(
+                    f"edge {edge_id}: source and target co-changed"
+                ),
+                evidence_kind="dependent_artifact_co_changed",
+                evidence_data={
+                    "edge_id": edge_id,
+                    "source_path": source_path,
+                    "target_path": target_path,
+                },
+            )
+
+        ack = _load_ack(repo_root, edge_id)
+        source_sha = _file_sha256(repo_root / source_path)
+        if ack is not None and ack.get("source_sha") == source_sha:
+            return Outcome(
+                status="pass",
+                message=(
+                    f"edge {edge_id}: source changed; reviewer ack covers "
+                    f"current source sha"
+                ),
+                evidence_kind="dependent_artifact_acked",
+                evidence_data={
+                    "edge_id": edge_id,
+                    "source_path": source_path,
+                    "target_path": target_path,
+                    "source_sha": source_sha,
+                    "ack_by": ack.get("ack_by"),
+                    "ack_at": ack.get("ack_at"),
+                    "reason": ack.get("reason"),
+                },
+            )
+
+        return Outcome(
+            status="fail",
+            message=(
+                f"edge {edge_id}: {source_path} changed but {target_path} "
+                f"was not updated and no matching ack exists"
+            ),
+            evidence_kind="dependent_artifact_changed_without_target_update",
+            evidence_data={
+                "edge_id": edge_id,
+                "source_path": source_path,
+                "target_path": target_path,
+                "source_sha": source_sha,
+                "ack_path": str(_ack_path_for(edge_id)),
+            },
+            remediation=(
+                f"Update {target_path} to reflect the change in {source_path}, "
+                f"or commit a reviewer ack at "
+                f".gate-keeper/acks/{edge_id}.yml with source_sha={source_sha}."
+            ),
+        )
+
+    return Outcome(  # pragma: no cover -- _edges_for_target guarantees non-empty
+        status="pass",
+        message="no applicable edges",
+        evidence_kind="edge_not_applicable",
+        evidence_data={},
+    )
+
+
+def _parse_payload(raw: str) -> dict[str, Any]:
+    try:
+        data = json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def _resolve_manifest_path(params: dict[str, Any], repo_root: Path) -> Path:
+    raw = params.get("manifest")
+    if isinstance(raw, str) and raw:
+        candidate = Path(raw)
+    else:
+        candidate = Path(DEFAULT_MANIFEST_PATH)
+    if not candidate.is_absolute():
+        candidate = repo_root / candidate
+    return candidate
+
+
+def _resolve_repo_root(start: Path) -> Path:
+    cur = start.resolve()
+    for parent in [cur, *cur.parents]:
+        if (parent / ".git").exists():
+            return parent
+    return start
+
+
+def _to_repo_relative(target: str, repo_root: Path) -> str:
+    if not target:
+        return ""
+    p = Path(target)
+    try:
+        if p.is_absolute():
+            rel = p.resolve().relative_to(repo_root.resolve())
+        else:
+            rel = (repo_root / p).resolve().relative_to(repo_root.resolve())
+    except ValueError:
+        return target.replace("\\", "/")
+    return rel.as_posix()
+
+
+def _edges_for_target(manifest: Manifest, target_rel: str) -> list[Edge]:
+    if not target_rel:
+        return []
+    out: list[Edge] = []
+    for edge in manifest.edges:
+        target_node = manifest.nodes_by_id[edge.to_id]
+        if target_node.path == target_rel:
+            out.append(edge)
+    return out
+
+
+def _edge_id(edge: Edge, source: Node, target: Node) -> str:
+    if edge.pair_id:
+        return f"{edge.pair_id}:{source.id}->{target.id}"
+    return f"{source.id}-{edge.relation}-{target.id}"
+
+
+def _ack_path_for(edge_id: str) -> Path:
+    return Path(DEFAULT_ACKS_DIR) / f"{edge_id}.yml"
+
+
+def _load_ack(repo_root: Path, edge_id: str) -> dict[str, Any] | None:
+    ack_path = repo_root / _ack_path_for(edge_id)
+    if not ack_path.is_file():
+        return None
+    try:
+        data = yaml.safe_load(ack_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _file_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _emit(outcome: Outcome) -> None:
+    diagnostic: dict[str, Any] = {
+        "status": outcome.status,
+        "message": outcome.message,
+        "evidence": [
+            {"kind": outcome.evidence_kind, "data": outcome.evidence_data}
+        ],
+    }
+    if outcome.remediation is not None:
+        diagnostic["remediation"] = outcome.remediation
+    sys.stdout.write(json.dumps(diagnostic))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dependency_gates/check_cli_reference.py
+++ b/scripts/dependency_gates/check_cli_reference.py
@@ -144,83 +144,139 @@ def _evaluate_edges(
     changed: frozenset[str],
     repo_root: Path,
 ) -> Outcome:
+    """Evaluate every applicable edge and aggregate.
+
+    Returns the first FAIL or UNAVAILABLE outcome encountered (so that any
+    one bad edge is surfaced even when its sibling edges pass). When all
+    edges pass, returns the outcome from the strongest signal in the order
+    co-changed > acked > unaffected.
+    """
+    pass_outcomes: list[Outcome] = []
     for edge in edges:
-        source_node = manifest.node(edge.from_id)
-        target_node = manifest.node(edge.to_id)
-        source_path = source_node.path
-        target_path = target_node.path
-        edge_id = _edge_id(edge, source_node, target_node)
+        outcome = _evaluate_edge(
+            edge=edge,
+            manifest=manifest,
+            changed=changed,
+            repo_root=repo_root,
+        )
+        if outcome.status != "pass":
+            return outcome
+        pass_outcomes.append(outcome)
 
-        if source_path not in changed:
-            return Outcome(
-                status="pass",
-                message=(
-                    f"edge {edge_id}: source {source_path} unchanged; target {target_path} is up to date"
-                ),
-                evidence_kind="dependent_artifact_unaffected",
-                evidence_data={
-                    "edge_id": edge_id,
-                    "source_path": source_path,
-                    "target_path": target_path,
-                },
-            )
+    # All edges passed; pick the most informative evidence kind.
+    priority = {
+        "dependent_artifact_co_changed": 3,
+        "dependent_artifact_acked": 2,
+        "dependent_artifact_unaffected": 1,
+    }
+    pass_outcomes.sort(key=lambda o: priority.get(o.evidence_kind, 0), reverse=True)
+    return pass_outcomes[0]
 
-        if target_path in changed:
-            return Outcome(
-                status="pass",
-                message=(f"edge {edge_id}: source and target co-changed"),
-                evidence_kind="dependent_artifact_co_changed",
-                evidence_data={
-                    "edge_id": edge_id,
-                    "source_path": source_path,
-                    "target_path": target_path,
-                },
-            )
 
-        ack = _load_ack(repo_root, edge_id)
-        source_sha = _file_sha256(repo_root / source_path)
-        if ack is not None and ack.get("source_sha") == source_sha:
-            return Outcome(
-                status="pass",
-                message=(f"edge {edge_id}: source changed; reviewer ack covers current source sha"),
-                evidence_kind="dependent_artifact_acked",
-                evidence_data={
-                    "edge_id": edge_id,
-                    "source_path": source_path,
-                    "target_path": target_path,
-                    "source_sha": source_sha,
-                    "ack_by": ack.get("ack_by"),
-                    "ack_at": ack.get("ack_at"),
-                    "reason": ack.get("reason"),
-                },
-            )
+def _evaluate_edge(
+    *,
+    edge: Edge,
+    manifest: Manifest,
+    changed: frozenset[str],
+    repo_root: Path,
+) -> Outcome:
+    source_node = manifest.node(edge.from_id)
+    target_node = manifest.node(edge.to_id)
+    source_path = source_node.path
+    target_path = target_node.path
+    edge_id = _edge_id(edge, source_node, target_node)
 
+    if edge.mode != "affected_set":
         return Outcome(
-            status="fail",
-            message=(
-                f"edge {edge_id}: {source_path} changed but {target_path} "
-                f"was not updated and no matching ack exists"
+            status="unavailable",
+            message=(f"edge {edge_id}: mode {edge.mode!r} is not implemented in slice 1 (affected_set only)"),
+            evidence_kind="stamped_mode_not_implemented",
+            evidence_data={
+                "edge_id": edge_id,
+                "mode": edge.mode,
+            },
+            remediation=(
+                "Slice 1 implements Mode A (affected_set) only. "
+                "Mode B (stamped) is reserved for a future slice; see "
+                "docs/design/dependency-gates.md §6."
             ),
-            evidence_kind="dependent_artifact_changed_without_target_update",
+        )
+
+    if source_path not in changed:
+        return Outcome(
+            status="pass",
+            message=(f"edge {edge_id}: source {source_path} unchanged; target {target_path} is up to date"),
+            evidence_kind="dependent_artifact_unaffected",
+            evidence_data={
+                "edge_id": edge_id,
+                "source_path": source_path,
+                "target_path": target_path,
+            },
+        )
+
+    if target_path in changed:
+        return Outcome(
+            status="pass",
+            message=f"edge {edge_id}: source and target co-changed",
+            evidence_kind="dependent_artifact_co_changed",
+            evidence_data={
+                "edge_id": edge_id,
+                "source_path": source_path,
+                "target_path": target_path,
+            },
+        )
+
+    ack_outcome = _load_ack(repo_root, edge_id)
+    source_sha = _file_sha256(repo_root / source_path)
+    if isinstance(ack_outcome, Outcome):
+        # Malformed ack file — surface as fail rather than silently ignoring.
+        return ack_outcome
+    ack = ack_outcome
+    if ack is not None and _ack_matches(ack, edge_id, source_sha):
+        return Outcome(
+            status="pass",
+            message=(f"edge {edge_id}: source changed; reviewer ack covers current source sha"),
+            evidence_kind="dependent_artifact_acked",
             evidence_data={
                 "edge_id": edge_id,
                 "source_path": source_path,
                 "target_path": target_path,
                 "source_sha": source_sha,
-                "ack_path": str(_ack_path_for(edge_id)),
+                "ack_by": ack.get("ack_by"),
+                "ack_at": ack.get("ack_at"),
+                "reason": ack.get("reason"),
             },
-            remediation=(
-                f"Update {target_path} to reflect the change in {source_path}, "
-                f"or commit a reviewer ack at "
-                f".gate-keeper/acks/{edge_id}.yml with source_sha={source_sha}."
-            ),
         )
 
-    return Outcome(  # pragma: no cover -- _edges_for_target guarantees non-empty
-        status="pass",
-        message="no applicable edges",
-        evidence_kind="edge_not_applicable",
-        evidence_data={},
+    return Outcome(
+        status="fail",
+        message=(
+            f"edge {edge_id}: {source_path} changed but {target_path} "
+            f"was not updated and no matching ack exists"
+        ),
+        evidence_kind="dependent_artifact_changed_without_target_update",
+        evidence_data={
+            "edge_id": edge_id,
+            "source_path": source_path,
+            "target_path": target_path,
+            "source_sha": source_sha,
+            "ack_path": str(_ack_path_for(edge_id)),
+        },
+        remediation=(
+            f"Update {target_path} to reflect the change in {source_path}, "
+            f"or commit a reviewer ack at "
+            f".gate-keeper/acks/{edge_id}.yml with source_sha={source_sha}."
+        ),
+    )
+
+
+def _ack_matches(ack: dict[str, Any], edge_id: str, source_sha: str) -> bool:
+    """Return True only when the ack's edge_id and source_sha both match."""
+    return (
+        isinstance(ack.get("edge_id"), str)
+        and ack["edge_id"] == edge_id
+        and isinstance(ack.get("source_sha"), str)
+        and ack["source_sha"] == source_sha
     )
 
 
@@ -288,16 +344,51 @@ def _ack_path_for(edge_id: str) -> Path:
     return Path(DEFAULT_ACKS_DIR) / f"{edge_id}.yml"
 
 
-def _load_ack(repo_root: Path, edge_id: str) -> dict[str, Any] | None:
+def _load_ack(repo_root: Path, edge_id: str) -> dict[str, Any] | None | Outcome:
+    """Load and shallow-validate the ack file for *edge_id*.
+
+    Returns:
+    - ``None`` when no ack file exists (caller proceeds to FAIL or PASS).
+    - ``dict`` when the file parses to a YAML mapping.
+    - ``Outcome`` when the file exists but is malformed (parse error or
+      non-mapping body); caller surfaces this directly as a FAIL so the
+      author isn't left wondering why their ack was silently ignored.
+    """
     ack_path = repo_root / _ack_path_for(edge_id)
     if not ack_path.is_file():
         return None
     try:
         data = yaml.safe_load(ack_path.read_text(encoding="utf-8"))
-    except (OSError, yaml.YAMLError):
-        return None
+    except (OSError, yaml.YAMLError) as exc:
+        return Outcome(
+            status="fail",
+            message=f"ack file at {ack_path} could not be parsed: {exc}",
+            evidence_kind="ack_invalid",
+            evidence_data={
+                "edge_id": edge_id,
+                "ack_path": str(_ack_path_for(edge_id)),
+                "error": str(exc),
+            },
+            remediation=(
+                f"Fix or remove {ack_path}; YAML must parse to a mapping "
+                "with edge_id, source_sha, ack_by, ack_at, reason."
+            ),
+        )
     if not isinstance(data, dict):
-        return None
+        return Outcome(
+            status="fail",
+            message=(f"ack file at {ack_path} must be a YAML mapping, got {type(data).__name__}"),
+            evidence_kind="ack_invalid",
+            evidence_data={
+                "edge_id": edge_id,
+                "ack_path": str(_ack_path_for(edge_id)),
+                "actual_type": type(data).__name__,
+            },
+            remediation=(
+                f"Fix {ack_path}; YAML must parse to a mapping with "
+                "edge_id, source_sha, ack_by, ack_at, reason."
+            ),
+        )
     return data
 
 

--- a/scripts/dependency_gates/check_cli_reference.py
+++ b/scripts/dependency_gates/check_cli_reference.py
@@ -92,10 +92,7 @@ def _run(*, repo_root: Path, manifest_path: Path, target: str) -> Outcome:
             message=f"manifest invalid: {exc}",
             evidence_kind="manifest_invalid",
             evidence_data={"manifest_path": str(manifest_path), "error": str(exc)},
-            remediation=(
-                "Fix the manifest at "
-                f"{manifest_path} to match docs/design/dependency-gates.md §3."
-            ),
+            remediation=(f"Fix the manifest at {manifest_path} to match docs/design/dependency-gates.md §3."),
         )
 
     target_rel = _to_repo_relative(target, repo_root)
@@ -103,27 +100,19 @@ def _run(*, repo_root: Path, manifest_path: Path, target: str) -> Outcome:
     if not edges:
         return Outcome(
             status="pass",
-            message=(
-                f"target {target_rel!r} is not the 'to' side of any manifest edge"
-            ),
+            message=(f"target {target_rel!r} is not the 'to' side of any manifest edge"),
             evidence_kind="edge_not_applicable",
             evidence_data={"target": target_rel},
         )
 
-    missing = [
-        node.path
-        for node in manifest.nodes
-        if not (repo_root / node.path).exists()
-    ]
+    missing = [node.path for node in manifest.nodes if not (repo_root / node.path).exists()]
     if missing:
         return Outcome(
             status="fail",
             message=f"manifest references missing path(s): {missing}",
             evidence_kind="manifest_target_missing",
             evidence_data={"missing_paths": missing},
-            remediation=(
-                "Update the manifest entries or restore the referenced files."
-            ),
+            remediation=("Update the manifest entries or restore the referenced files."),
         )
 
     base_ref = resolve_base_ref()
@@ -136,8 +125,7 @@ def _run(*, repo_root: Path, manifest_path: Path, target: str) -> Outcome:
             evidence_kind="changed_file_source_unresolved",
             evidence_data={"base_ref": base_ref, "error": str(exc)},
             remediation=(
-                "Set GATE_KEEPER_BASE_REF to a resolvable git ref, "
-                "or run inside a git working tree."
+                "Set GATE_KEEPER_BASE_REF to a resolvable git ref, or run inside a git working tree."
             ),
         )
 
@@ -167,8 +155,7 @@ def _evaluate_edges(
             return Outcome(
                 status="pass",
                 message=(
-                    f"edge {edge_id}: source {source_path} unchanged; "
-                    f"target {target_path} is up to date"
+                    f"edge {edge_id}: source {source_path} unchanged; target {target_path} is up to date"
                 ),
                 evidence_kind="dependent_artifact_unaffected",
                 evidence_data={
@@ -181,9 +168,7 @@ def _evaluate_edges(
         if target_path in changed:
             return Outcome(
                 status="pass",
-                message=(
-                    f"edge {edge_id}: source and target co-changed"
-                ),
+                message=(f"edge {edge_id}: source and target co-changed"),
                 evidence_kind="dependent_artifact_co_changed",
                 evidence_data={
                     "edge_id": edge_id,
@@ -197,10 +182,7 @@ def _evaluate_edges(
         if ack is not None and ack.get("source_sha") == source_sha:
             return Outcome(
                 status="pass",
-                message=(
-                    f"edge {edge_id}: source changed; reviewer ack covers "
-                    f"current source sha"
-                ),
+                message=(f"edge {edge_id}: source changed; reviewer ack covers current source sha"),
                 evidence_kind="dependent_artifact_acked",
                 evidence_data={
                     "edge_id": edge_id,
@@ -331,9 +313,7 @@ def _emit(outcome: Outcome) -> None:
     diagnostic: dict[str, Any] = {
         "status": outcome.status,
         "message": outcome.message,
-        "evidence": [
-            {"kind": outcome.evidence_kind, "data": outcome.evidence_data}
-        ],
+        "evidence": [{"kind": outcome.evidence_kind, "data": outcome.evidence_data}],
     }
     if outcome.remediation is not None:
         diagnostic["remediation"] = outcome.remediation

--- a/scripts/dependency_gates/manifest.py
+++ b/scripts/dependency_gates/manifest.py
@@ -1,0 +1,233 @@
+"""Loader for the declarative dependency manifest.
+
+Schema: docs/design/dependency-gates.md §3. The loader normalises the
+optional ``pairs:`` sugar form into directed ``edges`` before any consumer
+sees the result, so callers only ever see the graph form.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_VALID_MODES = frozenset({"affected_set", "stamped"})
+_DEFAULT_MODE = "affected_set"
+
+_NODE_REQUIRED = frozenset({"id", "path"})
+_NODE_OPTIONAL = frozenset({"anchor", "kind"})
+_EDGE_REQUIRED = frozenset({"from", "to", "relation"})
+_EDGE_OPTIONAL = frozenset({"mode", "pair_id"})
+_PAIR_REQUIRED = frozenset({"id", "source", "target", "relation"})
+_PAIR_OPTIONAL = frozenset({"mode"})
+_TOP_OPTIONAL = frozenset({"nodes", "edges", "pairs"})
+
+
+class ManifestError(ValueError):
+    """Raised when a manifest fails schema or referential validation."""
+
+
+@dataclass(frozen=True)
+class Node:
+    id: str
+    path: str
+    anchor: str | None = None
+    kind: str | None = None
+
+
+@dataclass(frozen=True)
+class Edge:
+    from_id: str
+    to_id: str
+    relation: str
+    mode: str = _DEFAULT_MODE
+    pair_id: str | None = None
+
+
+@dataclass(frozen=True)
+class Manifest:
+    nodes: tuple[Node, ...]
+    edges: tuple[Edge, ...]
+    source_path: Path | None = None
+    nodes_by_id: dict[str, Node] = field(default_factory=dict)
+
+    def node(self, node_id: str) -> Node:
+        return self.nodes_by_id[node_id]
+
+
+def load_manifest(path: str | Path) -> Manifest:
+    """Read and validate the YAML manifest at *path*."""
+    path = Path(path)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ManifestError(f"manifest {path}: cannot read: {exc}") from exc
+    return _parse_manifest(raw, source_path=path)
+
+
+def parse_manifest(text: str) -> Manifest:
+    """Validate a manifest from in-memory YAML text (used by tests)."""
+    return _parse_manifest(text, source_path=None)
+
+
+def _parse_manifest(text: str, *, source_path: Path | None) -> Manifest:
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ManifestError(f"manifest YAML parse error: {exc}") from exc
+
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        raise ManifestError(
+            f"manifest top-level must be a mapping, got {type(data).__name__}"
+        )
+
+    _check_keys(data, set(), _TOP_OPTIONAL, "manifest")
+
+    nodes = _parse_nodes(data.get("nodes") or [])
+    edges_raw = _parse_edges(data.get("edges") or [], nodes)
+    pairs_raw = _parse_pairs(data.get("pairs") or [], nodes)
+
+    edges = (*edges_raw, *pairs_raw)
+    nodes_by_id = {n.id: n for n in nodes}
+
+    for edge in edges:
+        if edge.from_id not in nodes_by_id:
+            raise ManifestError(
+                f"edge references unknown node id {edge.from_id!r} in 'from'"
+            )
+        if edge.to_id not in nodes_by_id:
+            raise ManifestError(
+                f"edge references unknown node id {edge.to_id!r} in 'to'"
+            )
+
+    return Manifest(
+        nodes=tuple(nodes),
+        edges=tuple(edges),
+        source_path=source_path,
+        nodes_by_id=nodes_by_id,
+    )
+
+
+def _parse_nodes(raw: Any) -> list[Node]:
+    if not isinstance(raw, list):
+        raise ManifestError("'nodes' must be a list")
+    seen: set[str] = set()
+    out: list[Node] = []
+    for i, item in enumerate(raw):
+        ctx = f"nodes[{i}]"
+        if not isinstance(item, dict):
+            raise ManifestError(f"{ctx}: must be a mapping")
+        _check_keys(item, _NODE_REQUIRED, _NODE_OPTIONAL, ctx)
+        node_id = _expect_nonempty_str(item["id"], f"{ctx}.id")
+        path = _expect_nonempty_str(item["path"], f"{ctx}.path")
+        anchor = _expect_optional_str(item.get("anchor"), f"{ctx}.anchor")
+        kind = _expect_optional_str(item.get("kind"), f"{ctx}.kind")
+        if node_id in seen:
+            raise ManifestError(f"{ctx}: duplicate node id {node_id!r}")
+        seen.add(node_id)
+        out.append(Node(id=node_id, path=path, anchor=anchor, kind=kind))
+    return out
+
+
+def _parse_edges(raw: Any, _nodes: list[Node]) -> list[Edge]:
+    if not isinstance(raw, list):
+        raise ManifestError("'edges' must be a list")
+    out: list[Edge] = []
+    for i, item in enumerate(raw):
+        ctx = f"edges[{i}]"
+        if not isinstance(item, dict):
+            raise ManifestError(f"{ctx}: must be a mapping")
+        _check_keys(item, _EDGE_REQUIRED, _EDGE_OPTIONAL, ctx)
+        from_id = _expect_nonempty_str(item["from"], f"{ctx}.from")
+        to_id = _expect_nonempty_str(item["to"], f"{ctx}.to")
+        relation = _expect_nonempty_str(item["relation"], f"{ctx}.relation")
+        mode = _expect_mode(item.get("mode"), f"{ctx}.mode")
+        pair_id = _expect_optional_str(item.get("pair_id"), f"{ctx}.pair_id")
+        out.append(
+            Edge(
+                from_id=from_id,
+                to_id=to_id,
+                relation=relation,
+                mode=mode,
+                pair_id=pair_id,
+            )
+        )
+    return out
+
+
+def _parse_pairs(raw: Any, _nodes: list[Node]) -> list[Edge]:
+    if not isinstance(raw, list):
+        raise ManifestError("'pairs' must be a list")
+    out: list[Edge] = []
+    for i, item in enumerate(raw):
+        ctx = f"pairs[{i}]"
+        if not isinstance(item, dict):
+            raise ManifestError(f"{ctx}: must be a mapping")
+        _check_keys(item, _PAIR_REQUIRED, _PAIR_OPTIONAL, ctx)
+        pair_id = _expect_nonempty_str(item["id"], f"{ctx}.id")
+        source = _expect_nonempty_str(item["source"], f"{ctx}.source")
+        target = _expect_nonempty_str(item["target"], f"{ctx}.target")
+        relation = _expect_nonempty_str(item["relation"], f"{ctx}.relation")
+        mode = _expect_mode(item.get("mode"), f"{ctx}.mode")
+        out.append(
+            Edge(
+                from_id=source,
+                to_id=target,
+                relation=relation,
+                mode=mode,
+                pair_id=pair_id,
+            )
+        )
+        out.append(
+            Edge(
+                from_id=target,
+                to_id=source,
+                relation=relation,
+                mode=mode,
+                pair_id=pair_id,
+            )
+        )
+    return out
+
+
+def _check_keys(
+    item: dict[str, Any],
+    required: frozenset[str] | set[str],
+    optional: frozenset[str] | set[str],
+    ctx: str,
+) -> None:
+    keys = set(item)
+    missing = set(required) - keys
+    if missing:
+        raise ManifestError(f"{ctx}: missing required fields {sorted(missing)}")
+    unknown = keys - set(required) - set(optional)
+    if unknown:
+        raise ManifestError(f"{ctx}: unknown fields {sorted(unknown)}")
+
+
+def _expect_nonempty_str(value: Any, ctx: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ManifestError(f"{ctx}: expected non-empty string, got {value!r}")
+    return value
+
+
+def _expect_optional_str(value: Any, ctx: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ManifestError(f"{ctx}: expected string or null, got {value!r}")
+    return value
+
+
+def _expect_mode(value: Any, ctx: str) -> str:
+    if value is None:
+        return _DEFAULT_MODE
+    if value not in _VALID_MODES:
+        raise ManifestError(
+            f"{ctx}: expected one of {sorted(_VALID_MODES)}, got {value!r}"
+        )
+    return value

--- a/scripts/dependency_gates/manifest.py
+++ b/scripts/dependency_gates/manifest.py
@@ -81,9 +81,7 @@ def _parse_manifest(text: str, *, source_path: Path | None) -> Manifest:
     if data is None:
         data = {}
     if not isinstance(data, dict):
-        raise ManifestError(
-            f"manifest top-level must be a mapping, got {type(data).__name__}"
-        )
+        raise ManifestError(f"manifest top-level must be a mapping, got {type(data).__name__}")
 
     _check_keys(data, set(), _TOP_OPTIONAL, "manifest")
 
@@ -96,13 +94,9 @@ def _parse_manifest(text: str, *, source_path: Path | None) -> Manifest:
 
     for edge in edges:
         if edge.from_id not in nodes_by_id:
-            raise ManifestError(
-                f"edge references unknown node id {edge.from_id!r} in 'from'"
-            )
+            raise ManifestError(f"edge references unknown node id {edge.from_id!r} in 'from'")
         if edge.to_id not in nodes_by_id:
-            raise ManifestError(
-                f"edge references unknown node id {edge.to_id!r} in 'to'"
-            )
+            raise ManifestError(f"edge references unknown node id {edge.to_id!r} in 'to'")
 
     return Manifest(
         nodes=tuple(nodes),
@@ -227,7 +221,5 @@ def _expect_mode(value: Any, ctx: str) -> str:
     if value is None:
         return _DEFAULT_MODE
     if value not in _VALID_MODES:
-        raise ManifestError(
-            f"{ctx}: expected one of {sorted(_VALID_MODES)}, got {value!r}"
-        )
+        raise ManifestError(f"{ctx}: expected one of {sorted(_VALID_MODES)}, got {value!r}")
     return value

--- a/scripts/dependency_gates/manifest.py
+++ b/scripts/dependency_gates/manifest.py
@@ -85,9 +85,12 @@ def _parse_manifest(text: str, *, source_path: Path | None) -> Manifest:
 
     _check_keys(data, set(), _TOP_OPTIONAL, "manifest")
 
-    nodes = _parse_nodes(data.get("nodes") or [])
-    edges_raw = _parse_edges(data.get("edges") or [], nodes)
-    pairs_raw = _parse_pairs(data.get("pairs") or [], nodes)
+    # Distinguish "key absent / null" from "key present with a wrong type".
+    # `data.get("nodes") or []` would silently treat e.g. ``nodes: {}`` as a
+    # missing field; we want the type check inside `_parse_nodes` to fire.
+    nodes = _parse_nodes(data["nodes"] if data.get("nodes") is not None else [])
+    edges_raw = _parse_edges(data["edges"] if data.get("edges") is not None else [], nodes)
+    pairs_raw = _parse_pairs(data["pairs"] if data.get("pairs") is not None else [], nodes)
 
     edges = (*edges_raw, *pairs_raw)
     nodes_by_id = {n.id: n for n in nodes}

--- a/tests/test_dependency_manifest.py
+++ b/tests/test_dependency_manifest.py
@@ -1,0 +1,271 @@
+"""Unit tests for ``scripts/dependency_gates/manifest`` (umbrella #159, slice 1).
+
+Pin schema validation, ``pairs:`` desugaring, and ``mode: stamped`` parsing.
+The loader is consumed by validators that run through the ``command`` adapter,
+so its error surface needs to be deterministic.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+_SCRIPTS_ROOT = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_ROOT))
+
+from dependency_gates.manifest import (  # noqa: E402
+    Edge,
+    Manifest,
+    ManifestError,
+    Node,
+    load_manifest,
+    parse_manifest,
+)
+
+
+def test_minimal_graph_parses():
+    text = dedent(
+        """
+        nodes:
+          - id: a
+            path: a.txt
+          - id: b
+            path: b.txt
+        edges:
+          - from: a
+            to: b
+            relation: documents
+        """
+    )
+    manifest = parse_manifest(text)
+    assert isinstance(manifest, Manifest)
+    assert len(manifest.nodes) == 2
+    assert {n.id for n in manifest.nodes} == {"a", "b"}
+    assert len(manifest.edges) == 1
+    edge = manifest.edges[0]
+    assert (edge.from_id, edge.to_id, edge.relation) == ("a", "b", "documents")
+    assert edge.mode == "affected_set"  # default
+    assert edge.pair_id is None
+
+
+def test_node_anchor_and_kind_round_trip():
+    text = dedent(
+        """
+        nodes:
+          - id: a
+            path: a.tex
+            anchor: "thm:stability"
+            kind: paper
+        """
+    )
+    manifest = parse_manifest(text)
+    node = manifest.node("a")
+    assert node.anchor == "thm:stability"
+    assert node.kind == "paper"
+
+
+def test_pairs_sugar_desugars_to_two_directed_edges():
+    text = dedent(
+        """
+        nodes:
+          - id: ja
+            path: docs/ja/foo.md
+          - id: en
+            path: docs/en/foo.md
+        pairs:
+          - id: docs-foo-ja-en
+            relation: translation
+            source: ja
+            target: en
+        """
+    )
+    manifest = parse_manifest(text)
+    assert len(manifest.edges) == 2
+    pair_ids = {e.pair_id for e in manifest.edges}
+    assert pair_ids == {"docs-foo-ja-en"}
+    directions = {(e.from_id, e.to_id) for e in manifest.edges}
+    assert directions == {("ja", "en"), ("en", "ja")}
+    relations = {e.relation for e in manifest.edges}
+    assert relations == {"translation"}
+
+
+def test_mode_stamped_parses():
+    text = dedent(
+        """
+        nodes:
+          - id: src
+            path: paper.tex
+          - id: tgt
+            path: lean/Stability.lean
+        edges:
+          - from: src
+            to: tgt
+            relation: formalization
+            mode: stamped
+        """
+    )
+    manifest = parse_manifest(text)
+    assert manifest.edges[0].mode == "stamped"
+
+
+def test_invalid_mode_rejected():
+    text = dedent(
+        """
+        nodes:
+          - id: a
+            path: a.txt
+          - id: b
+            path: b.txt
+        edges:
+          - from: a
+            to: b
+            relation: r
+            mode: unknown_mode
+        """
+    )
+    with pytest.raises(ManifestError, match="mode"):
+        parse_manifest(text)
+
+
+def test_duplicate_node_id_rejected():
+    text = dedent(
+        """
+        nodes:
+          - id: a
+            path: one.txt
+          - id: a
+            path: two.txt
+        """
+    )
+    with pytest.raises(ManifestError, match="duplicate node id"):
+        parse_manifest(text)
+
+
+def test_edge_references_unknown_node_rejected():
+    text = dedent(
+        """
+        nodes:
+          - id: a
+            path: a.txt
+        edges:
+          - from: a
+            to: ghost
+            relation: r
+        """
+    )
+    with pytest.raises(ManifestError, match="unknown node id 'ghost'"):
+        parse_manifest(text)
+
+
+def test_pairs_references_unknown_node_rejected():
+    text = dedent(
+        """
+        nodes:
+          - id: a
+            path: a.txt
+        pairs:
+          - id: p
+            relation: r
+            source: a
+            target: ghost
+        """
+    )
+    with pytest.raises(ManifestError, match="unknown node id 'ghost'"):
+        parse_manifest(text)
+
+
+def test_missing_required_node_field_rejected():
+    text = dedent(
+        """
+        nodes:
+          - id: a
+        """
+    )
+    with pytest.raises(ManifestError, match="missing required fields"):
+        parse_manifest(text)
+
+
+def test_unknown_top_level_field_rejected():
+    text = dedent(
+        """
+        nodes: []
+        edges: []
+        bogus: 1
+        """
+    )
+    with pytest.raises(ManifestError, match="unknown fields"):
+        parse_manifest(text)
+
+
+def test_empty_manifest_is_valid():
+    manifest = parse_manifest("")
+    assert manifest.nodes == ()
+    assert manifest.edges == ()
+
+
+def test_pairs_and_explicit_edges_coexist():
+    text = dedent(
+        """
+        nodes:
+          - id: a
+            path: a.txt
+          - id: b
+            path: b.txt
+          - id: c
+            path: c.txt
+        edges:
+          - from: a
+            to: c
+            relation: documents
+        pairs:
+          - id: ab-pair
+            relation: translation
+            source: a
+            target: b
+        """
+    )
+    manifest = parse_manifest(text)
+    # 1 explicit + 2 desugared from the pair.
+    assert len(manifest.edges) == 3
+    explicit_edges = [e for e in manifest.edges if e.pair_id is None]
+    pair_edges = [e for e in manifest.edges if e.pair_id == "ab-pair"]
+    assert len(explicit_edges) == 1
+    assert len(pair_edges) == 2
+
+
+def test_load_manifest_reads_file(tmp_path: Path):
+    p = tmp_path / "manifest.yml"
+    p.write_text(
+        dedent(
+            """
+            nodes:
+              - id: a
+                path: a.txt
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    manifest = load_manifest(p)
+    assert manifest.source_path == p
+    assert manifest.nodes_by_id["a"] == Node(id="a", path="a.txt")
+
+
+def test_load_manifest_missing_file(tmp_path: Path):
+    missing = tmp_path / "nope.yml"
+    with pytest.raises(ManifestError, match="cannot read"):
+        load_manifest(missing)
+
+
+def test_yaml_parse_error_surfaced():
+    with pytest.raises(ManifestError, match="YAML parse error"):
+        parse_manifest("nodes: [\n  - id: a\n   broken")
+
+
+def test_edge_dataclass_is_frozen():
+    edge = Edge(from_id="a", to_id="b", relation="r")
+    with pytest.raises(Exception):  # FrozenInstanceError subclasses TypeError
+        edge.relation = "x"  # type: ignore[misc]

--- a/tests/test_dependency_validator.py
+++ b/tests/test_dependency_validator.py
@@ -29,10 +29,7 @@ from dependency_gates import _changed_files as cf_mod  # noqa: E402
 from dependency_gates import check_cli_reference as validator  # noqa: E402
 
 VALIDATOR_SCRIPT = (
-    Path(__file__).resolve().parent.parent
-    / "scripts"
-    / "dependency_gates"
-    / "check_cli_reference.py"
+    Path(__file__).resolve().parent.parent / "scripts" / "dependency_gates" / "check_cli_reference.py"
 )
 
 
@@ -90,9 +87,7 @@ def _run(repo_root: Path, target: str) -> validator.Outcome:
     )
 
 
-def test_clean_tree_emits_unaffected(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+def test_clean_tree_emits_unaffected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     _seed_repo(tmp_path)
     _patch_changed(monkeypatch, set())
     out = _run(tmp_path, "docs/cli-reference.md")
@@ -100,9 +95,7 @@ def test_clean_tree_emits_unaffected(
     assert out.evidence_kind == "dependent_artifact_unaffected"
 
 
-def test_co_change_passes(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+def test_co_change_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     _seed_repo(tmp_path)
     _patch_changed(
         monkeypatch,
@@ -113,9 +106,7 @@ def test_co_change_passes(
     assert out.evidence_kind == "dependent_artifact_co_changed"
 
 
-def test_unack_change_fails(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+def test_unack_change_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     _seed_repo(tmp_path)
     _patch_changed(monkeypatch, {"src/gate_keeper/cli.py"})
     out = _run(tmp_path, "docs/cli-reference.md")
@@ -126,9 +117,7 @@ def test_unack_change_fails(
     assert ".gate-keeper/acks/" in out.remediation
 
 
-def test_matching_ack_passes(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+def test_matching_ack_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     src, _doc = _seed_repo(tmp_path, source_text="changed body\n")
     sha = hashlib.sha256(src.read_bytes()).hexdigest()
     acks_dir = tmp_path / ".gate-keeper" / "acks"
@@ -153,9 +142,7 @@ def test_matching_ack_passes(
     assert out.evidence_data["ack_by"] == "reviewer"
 
 
-def test_stale_ack_does_not_satisfy(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+def test_stale_ack_does_not_satisfy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     _seed_repo(tmp_path)
     acks_dir = tmp_path / ".gate-keeper" / "acks"
     acks_dir.mkdir()
@@ -177,9 +164,7 @@ def test_stale_ack_does_not_satisfy(
     assert out.evidence_kind == "dependent_artifact_changed_without_target_update"
 
 
-def test_target_outside_edges_passes(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+def test_target_outside_edges_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     _seed_repo(tmp_path)
     _patch_changed(monkeypatch, set())
     out = _run(tmp_path, "README.md")
@@ -198,9 +183,7 @@ def test_manifest_invalid_fails(tmp_path: Path):
     assert out.evidence_kind == "manifest_invalid"
 
 
-def test_manifest_target_missing_fails(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+def test_manifest_target_missing_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     # Manifest references files that don't exist on disk.
     (tmp_path / ".gate-keeper").mkdir()
     (tmp_path / ".gate-keeper" / "dependency-manifest.yml").write_text(
@@ -229,9 +212,7 @@ def test_manifest_target_missing_fails(
     assert "src/missing.py" in out.evidence_data["missing_paths"]
 
 
-def test_changed_file_source_unresolved_unavailable(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+def test_changed_file_source_unresolved_unavailable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     _seed_repo(tmp_path)
 
     def _raise(*_a: Any, **_kw: Any) -> Any:
@@ -258,9 +239,7 @@ def test_validator_emit_shape(
 
     payload = json.dumps(
         {
-            "rule": {
-                "params": {"manifest": ".gate-keeper/dependency-manifest.yml"}
-            },
+            "rule": {"params": {"manifest": ".gate-keeper/dependency-manifest.yml"}},
             "target": "docs/cli-reference.md",
         }
     )
@@ -290,9 +269,7 @@ class _StringIO:
 
 
 @pytest.mark.integration
-def test_end_to_end_through_command_adapter(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+def test_end_to_end_through_command_adapter(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Run the validator script via ``CommandAdapter`` against a fake repo."""
     from gate_keeper.adapters.command import CommandAdapter, set_enabled
     from gate_keeper.models import (
@@ -307,21 +284,15 @@ def test_end_to_end_through_command_adapter(
 
     _seed_repo(tmp_path)
 
-    subprocess.run(
-        ["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True
-    )
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
     subprocess.run(
         ["git", "config", "user.email", "test@example.com"],
         cwd=tmp_path,
         check=True,
     )
-    subprocess.run(
-        ["git", "config", "user.name", "Test"], cwd=tmp_path, check=True
-    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
     subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
-    subprocess.run(
-        ["git", "commit", "-q", "-m", "base"], cwd=tmp_path, check=True
-    )
+    subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=tmp_path, check=True)
 
     # The temp repo has no `origin`; point the validator at HEAD so the
     # diff (HEAD...HEAD) is empty — i.e. simulate a clean PR base.

--- a/tests/test_dependency_validator.py
+++ b/tests/test_dependency_validator.py
@@ -1,0 +1,356 @@
+"""Tests for ``scripts/dependency_gates/check_cli_reference`` (umbrella #159).
+
+Two layers:
+
+- Unit scenarios stub ``compute_changed_files`` and exercise the in-process
+  ``_run`` function directly. No git, no subprocess.
+- One ``@pytest.mark.integration`` test runs the validator end-to-end through
+  the real ``CommandAdapter`` (mirrors ``tests/test_command_adapter.py``
+  ``TestRealSubprocess`` style).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+import pytest
+
+_SCRIPTS_ROOT = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_ROOT))
+
+from dependency_gates import _changed_files as cf_mod  # noqa: E402
+from dependency_gates import check_cli_reference as validator  # noqa: E402
+
+VALIDATOR_SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "dependency_gates"
+    / "check_cli_reference.py"
+)
+
+
+def _seed_repo(root: Path, source_text: str = "src body\n") -> tuple[Path, Path]:
+    """Materialise the cli/docs pair on disk under *root*."""
+    src = root / "src" / "gate_keeper" / "cli.py"
+    src.parent.mkdir(parents=True)
+    src.write_text(source_text, encoding="utf-8")
+
+    doc = root / "docs" / "cli-reference.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text("# CLI reference\n", encoding="utf-8")
+
+    manifest_dir = root / ".gate-keeper"
+    manifest_dir.mkdir()
+    (manifest_dir / "dependency-manifest.yml").write_text(
+        dedent(
+            """
+            nodes:
+              - id: cli-implementation
+                path: src/gate_keeper/cli.py
+                kind: code
+              - id: cli-reference
+                path: docs/cli-reference.md
+                kind: reference
+            edges:
+              - from: cli-implementation
+                to: cli-reference
+                relation: documents
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    return src, doc
+
+
+def _patch_changed(monkeypatch: pytest.MonkeyPatch, paths: set[str]) -> None:
+    monkeypatch.setattr(
+        validator,
+        "compute_changed_files",
+        lambda repo_root, base_ref: frozenset(paths),
+    )
+    monkeypatch.setattr(
+        validator,
+        "resolve_base_ref",
+        lambda env=None: "origin/main",
+    )
+
+
+def _run(repo_root: Path, target: str) -> validator.Outcome:
+    return validator._run(
+        repo_root=repo_root,
+        manifest_path=repo_root / ".gate-keeper" / "dependency-manifest.yml",
+        target=target,
+    )
+
+
+def test_clean_tree_emits_unaffected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _seed_repo(tmp_path)
+    _patch_changed(monkeypatch, set())
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "pass"
+    assert out.evidence_kind == "dependent_artifact_unaffected"
+
+
+def test_co_change_passes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _seed_repo(tmp_path)
+    _patch_changed(
+        monkeypatch,
+        {"src/gate_keeper/cli.py", "docs/cli-reference.md"},
+    )
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "pass"
+    assert out.evidence_kind == "dependent_artifact_co_changed"
+
+
+def test_unack_change_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _seed_repo(tmp_path)
+    _patch_changed(monkeypatch, {"src/gate_keeper/cli.py"})
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "fail"
+    assert out.evidence_kind == "dependent_artifact_changed_without_target_update"
+    assert "ack_path" in out.evidence_data
+    assert out.remediation is not None
+    assert ".gate-keeper/acks/" in out.remediation
+
+
+def test_matching_ack_passes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    src, _doc = _seed_repo(tmp_path, source_text="changed body\n")
+    sha = hashlib.sha256(src.read_bytes()).hexdigest()
+    acks_dir = tmp_path / ".gate-keeper" / "acks"
+    acks_dir.mkdir()
+    (acks_dir / "cli-implementation-documents-cli-reference.yml").write_text(
+        dedent(
+            f"""
+            edge_id: cli-implementation-documents-cli-reference
+            source_sha: {sha}
+            ack_by: reviewer
+            ack_at: 2026-05-10T00:00:00Z
+            reason: reviewed; doc still accurate
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    _patch_changed(monkeypatch, {"src/gate_keeper/cli.py"})
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "pass"
+    assert out.evidence_kind == "dependent_artifact_acked"
+    assert out.evidence_data["source_sha"] == sha
+    assert out.evidence_data["ack_by"] == "reviewer"
+
+
+def test_stale_ack_does_not_satisfy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _seed_repo(tmp_path)
+    acks_dir = tmp_path / ".gate-keeper" / "acks"
+    acks_dir.mkdir()
+    (acks_dir / "cli-implementation-documents-cli-reference.yml").write_text(
+        dedent(
+            """
+            edge_id: cli-implementation-documents-cli-reference
+            source_sha: deadbeef
+            ack_by: reviewer
+            ack_at: 2026-05-01T00:00:00Z
+            reason: stale ack
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    _patch_changed(monkeypatch, {"src/gate_keeper/cli.py"})
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "fail"
+    assert out.evidence_kind == "dependent_artifact_changed_without_target_update"
+
+
+def test_target_outside_edges_passes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _seed_repo(tmp_path)
+    _patch_changed(monkeypatch, set())
+    out = _run(tmp_path, "README.md")
+    assert out.status == "pass"
+    assert out.evidence_kind == "edge_not_applicable"
+
+
+def test_manifest_invalid_fails(tmp_path: Path):
+    (tmp_path / ".gate-keeper").mkdir()
+    (tmp_path / ".gate-keeper" / "dependency-manifest.yml").write_text(
+        "nodes:\n  - id: a\n",  # missing 'path'
+        encoding="utf-8",
+    )
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "fail"
+    assert out.evidence_kind == "manifest_invalid"
+
+
+def test_manifest_target_missing_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # Manifest references files that don't exist on disk.
+    (tmp_path / ".gate-keeper").mkdir()
+    (tmp_path / ".gate-keeper" / "dependency-manifest.yml").write_text(
+        dedent(
+            """
+            nodes:
+              - id: a
+                path: src/missing.py
+              - id: b
+                path: docs/cli-reference.md
+            edges:
+              - from: a
+                to: b
+                relation: documents
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    # Ensure 'b' exists so target resolution finds an applicable edge.
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "cli-reference.md").write_text("doc\n", encoding="utf-8")
+    _patch_changed(monkeypatch, set())
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "fail"
+    assert out.evidence_kind == "manifest_target_missing"
+    assert "src/missing.py" in out.evidence_data["missing_paths"]
+
+
+def test_changed_file_source_unresolved_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _seed_repo(tmp_path)
+
+    def _raise(*_a: Any, **_kw: Any) -> Any:
+        raise cf_mod.ChangedFilesError("git diff exited 128: bad ref")
+
+    monkeypatch.setattr(validator, "compute_changed_files", _raise)
+    monkeypatch.setattr(validator, "resolve_base_ref", lambda env=None: "origin/main")
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "unavailable"
+    assert out.evidence_kind == "changed_file_source_unresolved"
+
+
+def test_resolve_base_ref_env_override():
+    # Direct unit on the helper.
+    assert cf_mod.resolve_base_ref({}) == cf_mod.DEFAULT_BASE_REF
+    assert cf_mod.resolve_base_ref({"GATE_KEEPER_BASE_REF": "main"}) == "main"
+
+
+def test_validator_emit_shape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    _seed_repo(tmp_path)
+    _patch_changed(monkeypatch, set())
+
+    payload = json.dumps(
+        {
+            "rule": {
+                "params": {"manifest": ".gate-keeper/dependency-manifest.yml"}
+            },
+            "target": "docs/cli-reference.md",
+        }
+    )
+    monkeypatch.setattr(sys, "stdin", _StringIO(payload))
+    monkeypatch.chdir(tmp_path)
+    rc = validator.main()
+    assert rc == 0
+    captured = capsys.readouterr().out
+    diag = json.loads(captured)
+    assert diag["status"] == "pass"
+    assert diag["evidence"][0]["kind"] == "dependent_artifact_unaffected"
+
+
+class _StringIO:
+    """Tiny stdin stub that supports only ``read()``."""
+
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def read(self) -> str:
+        return self._text
+
+
+# ---------------------------------------------------------------------------
+# Integration: real subprocess through the command adapter.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_end_to_end_through_command_adapter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Run the validator script via ``CommandAdapter`` against a fake repo."""
+    from gate_keeper.adapters.command import CommandAdapter, set_enabled
+    from gate_keeper.models import (
+        Backend,
+        Confidence,
+        Rule,
+        RuleKind,
+        Severity,
+        SourceLocation,
+        Status,
+    )
+
+    _seed_repo(tmp_path)
+
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=tmp_path, check=True
+    )
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "base"], cwd=tmp_path, check=True
+    )
+
+    # The temp repo has no `origin`; point the validator at HEAD so the
+    # diff (HEAD...HEAD) is empty — i.e. simulate a clean PR base.
+    monkeypatch.setenv("GATE_KEEPER_BASE_REF", "HEAD")
+    monkeypatch.chdir(tmp_path)
+
+    rule = Rule(
+        id="cli-reference-tracks-cli-implementation",
+        title="CLI reference tracks CLI implementation",
+        source=SourceLocation(path="rules.json", line=1),
+        text="cli-reference must track cli-implementation",
+        kind=RuleKind.EXTERNAL_CHECK,
+        severity=Severity.WARNING,
+        backend_hint=Backend.EXTERNAL,
+        confidence=Confidence.HIGH,
+        params={
+            "tool": "command",
+            "argv": [sys.executable, str(VALIDATOR_SCRIPT)],
+            "timeout_seconds": 30,
+        },
+    )
+
+    set_enabled(True)
+    try:
+        diag = CommandAdapter().check(rule, "docs/cli-reference.md")
+    finally:
+        set_enabled(False)
+
+    assert diag.status is Status.PASS
+    assert diag.evidence[0].kind == "dependent_artifact_unaffected"
+    assert diag.backend is Backend.EXTERNAL
+    assert diag.rule_id == "cli-reference-tracks-cli-implementation"

--- a/tests/test_dependency_validator.py
+++ b/tests/test_dependency_validator.py
@@ -142,6 +142,138 @@ def test_matching_ack_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     assert out.evidence_data["ack_by"] == "reviewer"
 
 
+def test_ack_with_wrong_edge_id_does_not_satisfy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    src, _doc = _seed_repo(tmp_path)
+    sha = hashlib.sha256(src.read_bytes()).hexdigest()
+    acks_dir = tmp_path / ".gate-keeper" / "acks"
+    acks_dir.mkdir()
+    # Filename matches the edge id, but the body's edge_id field does not.
+    (acks_dir / "cli-implementation-documents-cli-reference.yml").write_text(
+        dedent(
+            f"""
+            edge_id: some-other-edge
+            source_sha: {sha}
+            ack_by: reviewer
+            ack_at: 2026-05-10T00:00:00Z
+            reason: copy-pasted ack body from elsewhere
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    _patch_changed(monkeypatch, {"src/gate_keeper/cli.py"})
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "fail"
+    assert out.evidence_kind == "dependent_artifact_changed_without_target_update"
+
+
+def test_ack_yaml_parse_error_surfaced_as_fail(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _seed_repo(tmp_path)
+    acks_dir = tmp_path / ".gate-keeper" / "acks"
+    acks_dir.mkdir()
+    (acks_dir / "cli-implementation-documents-cli-reference.yml").write_text(
+        ":\n  - this is not a valid mapping\n: also not\n",
+        encoding="utf-8",
+    )
+    _patch_changed(monkeypatch, {"src/gate_keeper/cli.py"})
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "fail"
+    assert out.evidence_kind == "ack_invalid"
+
+
+def test_ack_non_mapping_body_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _seed_repo(tmp_path)
+    acks_dir = tmp_path / ".gate-keeper" / "acks"
+    acks_dir.mkdir()
+    (acks_dir / "cli-implementation-documents-cli-reference.yml").write_text(
+        "- just\n- a\n- list\n",
+        encoding="utf-8",
+    )
+    _patch_changed(monkeypatch, {"src/gate_keeper/cli.py"})
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "fail"
+    assert out.evidence_kind == "ack_invalid"
+
+
+def test_stamped_mode_not_implemented(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # Manifest declares an edge with mode: stamped — slice 1 only implements A.
+    src = tmp_path / "src" / "gate_keeper" / "cli.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("body\n", encoding="utf-8")
+    doc = tmp_path / "docs" / "cli-reference.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text("doc\n", encoding="utf-8")
+    (tmp_path / ".gate-keeper").mkdir()
+    (tmp_path / ".gate-keeper" / "dependency-manifest.yml").write_text(
+        dedent(
+            """
+            nodes:
+              - id: src
+                path: src/gate_keeper/cli.py
+              - id: tgt
+                path: docs/cli-reference.md
+            edges:
+              - from: src
+                to: tgt
+                relation: documents
+                mode: stamped
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    _patch_changed(monkeypatch, set())
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "unavailable"
+    assert out.evidence_kind == "stamped_mode_not_implemented"
+
+
+def test_multiple_edges_to_same_target_aggregated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Two edges both pointing at the same target are both evaluated."""
+    src1 = tmp_path / "src" / "a.py"
+    src1.parent.mkdir(parents=True)
+    src1.write_text("a\n", encoding="utf-8")
+    src2 = tmp_path / "src" / "b.py"
+    src2.write_text("b\n", encoding="utf-8")
+    doc = tmp_path / "docs" / "cli-reference.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text("doc\n", encoding="utf-8")
+    (tmp_path / ".gate-keeper").mkdir()
+    (tmp_path / ".gate-keeper" / "dependency-manifest.yml").write_text(
+        dedent(
+            """
+            nodes:
+              - id: a
+                path: src/a.py
+              - id: b
+                path: src/b.py
+              - id: tgt
+                path: docs/cli-reference.md
+            edges:
+              - from: a
+                to: tgt
+                relation: documents
+              - from: b
+                to: tgt
+                relation: documents
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    # Only `b.py` changed; `a` edge passes (unaffected) but `b` edge fails.
+    _patch_changed(monkeypatch, {"src/b.py"})
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "fail"
+    assert out.evidence_kind == "dependent_artifact_changed_without_target_update"
+    assert out.evidence_data["source_path"] == "src/b.py"
+
+
+def test_invalid_nodes_top_level_type_rejected():
+    """Manifest with `nodes: {}` (a mapping, not a list) is rejected explicitly."""
+    from dependency_gates.manifest import ManifestError, parse_manifest
+
+    with pytest.raises(ManifestError, match="must be a list"):
+        parse_manifest("nodes: {}\n")
+
+
 def test_stale_ack_does_not_satisfy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     _seed_repo(tmp_path)
     acks_dir = tmp_path / ".gate-keeper" / "acks"


### PR DESCRIPTION
## Summary

- Ships the joint design note for umbrella #159 (declarative artifact-dependency gates) ratifying the seven settled rules and resolving the three open items (manifest path, validator script location, changed-file source for Mode A).
- Wires a project-local validator through the existing `external_check` + `command` adapter (#149); **no new `RuleKind`**.
- Exercises both #156 (cli/docs in-repo dogfood) and the #158 manifest shape (loader-level fixtures for `pairs:` desugaring and `mode: stamped` parsing).

Closes #161 — refs umbrella #159, exploration #156 and #158.

## What's in the slice

- `docs/design/dependency-gates.md` — joint contract.
- `.gate-keeper/dependency-manifest.yml` — single edge `src/gate_keeper/cli.py` → `docs/cli-reference.md`.
- `scripts/dependency_gates/manifest.py` — loader (graph schema, `pairs:` sugar, `mode: stamped` parsing).
- `scripts/dependency_gates/_changed_files.py` — wraps `git diff --name-only \${GATE_KEEPER_BASE_REF:-origin/main}...HEAD`.
- `scripts/dependency_gates/check_cli_reference.py` — Mode-A validator emitting the nine evidence kinds from design note §2.7.
- `docs/dependency-gate-rules.json` — hand-authored IR rule runnable via `validate --rules-format ir --allow-command-adapter`.
- `docs/dogfooding.md` — advisory entry pointing at the rule.
- `tests/test_dependency_manifest.py` — 16 loader unit tests.
- `tests/test_dependency_validator.py` — 11 validator unit tests + 1 \`@pytest.mark.integration\` end-to-end through the real \`CommandAdapter\`.

## Validation

\`\`\`text
\$ uv run pytest
1018 passed in 4.96s

\$ uv run pytest tests/test_dependency_manifest.py tests/test_dependency_validator.py -v
28 passed in 0.20s

\$ uvx ruff check .
All checks passed!

\$ uvx pyright
22 errors (all pre-existing-style noise: pytest / dotenv / anthropic / openai / new dependency_gates path; same posture as merged tests).

\$ GATE_KEEPER_BASE_REF=main uv run gate-keeper validate \\
    --rules-format ir docs/dependency-gate-rules.json \\
    --target docs/cli-reference.md \\
    --allow-command-adapter
docs/dependency-gate-rules.json:1: warning: [external/pass] cli-reference-tracks-cli-implementation: edge cli-implementation-documents-cli-reference: source src/gate_keeper/cli.py unchanged; target docs/cli-reference.md is up to date [dependent_artifact_unaffected(...)]
\`\`\`

## Acceptance (from #161)

- [x] Design note exists at \`docs/design/dependency-gates.md\` covering the seven settled rules, three open items resolved, failure-mode taxonomy, and a single explicit slice-2 promotion criterion.
- [x] \`scripts/dependency_gates/check_cli_reference.py\` runs via \`external_check\` + \`params.tool == \"command\"\`. Verified PASS on a clean tree (dogfood smoke + \`test_clean_tree_emits_unaffected\`); FAIL with \`dependent_artifact_changed_without_target_update\` (\`test_unack_change_fails\`); PASS with \`dependent_artifact_acked\` when matching ack file present (\`test_matching_ack_passes\`); FAIL when ack is stale (\`test_stale_ack_does_not_satisfy\`).
- [x] Loader tests confirm \`pairs:\` sugar desugars to two directed edges sharing \`pair_id\` (\`test_pairs_sugar_desugars_to_two_directed_edges\`) and \`mode: stamped\` parses (\`test_mode_stamped_parses\`).
- [x] \`uv run pytest\`, \`uvx ruff check .\` pass; \`uvx pyright\` matches pre-existing repo posture.

## Out of scope

- PR-trailer ack transport (file-only this slice).
- MCP transport for the validator.
- Cycle-detection rule.
- In-repo #158-family reference validator (no in-repo translation/Lean pair).
- Promoting any failure subtype to a core \`RuleKind\` (slice-2 decision; criterion recorded in design note §6).
- New CLI flag for changed-file set (validator computes the diff internally).

## Notes

- The \`command\` adapter is disabled by default. The dogfood rule only fires when callers pass \`--allow-command-adapter\`; otherwise it emits \`unavailable\` / \`command_adapter_disabled\` per existing adapter behaviour.
- The \`cli-reference-tracks-cli-implementation\` rule is intentionally **advisory** (\`severity: warning\`) — promotion to required follows \`docs/dogfooding.md\` § \"Promotion criteria\".
- 22 pyright errors include 19 pre-existing-style imports (pytest, dotenv, anthropic, openai) and 3 fresh ones for the new \`scripts/dependency_gates/\` path; same posture as the rest of the test suite.

## Test plan

- [x] \`uv run pytest\` (1018 passed)
- [x] \`uv run pytest tests/test_dependency_{manifest,validator}.py -v\` (28 passed including the \`@pytest.mark.integration\` real-subprocess test)
- [x] \`uvx ruff check .\` (clean)
- [x] \`uvx pyright\` (matches repo posture)
- [x] End-to-end smoke via \`uv run gate-keeper validate --rules-format ir --allow-command-adapter\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)