### PR TITLE
fix(cli): handle ENAMETOOLONG in --target disambiguation (#166)

### DIFF
--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -544,13 +544,28 @@ def _cmd_validate(args: argparse.Namespace) -> int:
         # Order matters: a literal directory or an existing literal file
         # always wins over glob detection so a real filename like
         # ``a[b].txt`` does not get mis-expanded as a pattern.
-        if sole_path.is_dir():
+        #
+        # The ``is_dir`` / ``is_file`` calls can raise ``OSError`` when the
+        # token cannot be a real path on the host filesystem — most commonly
+        # ``ENAMETOOLONG`` (errno 36) when a ``/``-segment exceeds NAME_MAX
+        # (255 bytes on Linux), and ``EINVAL`` on some kernels for embedded
+        # NULs.  Such inputs cannot possibly resolve to a path, so we treat
+        # them as literal text and fall through to the non-path branch
+        # rather than letting the traceback escape (issue #166).
+        try:
+            sole_is_dir = sole_path.is_dir()
+            sole_is_file = sole_path.is_file()
+        except OSError:
+            sole_is_dir = False
+            sole_is_file = False
+
+        if sole_is_dir:
             try:
                 target = resolve_targets(raw_targets)
             except TargetExpansionError as exc:
                 print(f"error: --target: {exc}", file=sys.stderr)
                 return EXIT_USAGE
-        elif sole_path.is_file():
+        elif sole_is_file:
             target = sole
         elif looks_like_glob(sole):
             # Token has glob metacharacters but the literal path doesn't

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -12,6 +12,7 @@ from gate_keeper.diagnostics import EXIT_FAIL, EXIT_OK, EXIT_USAGE
 
 REPO_ROOT = Path(__file__).parent.parent
 EXAMPLE_DOC = REPO_ROOT / "docs" / "example-rules.md"
+DOGFOODING_RULES_DOC = REPO_ROOT / "docs" / "dogfooding-rules.md"
 LOCAL_FIXTURES = Path(__file__).parent / "fixtures" / "local"
 PASS_DIR = LOCAL_FIXTURES / "pass"
 FAIL_DIR = LOCAL_FIXTURES / "fail"
@@ -1322,3 +1323,93 @@ class TestMultiTarget:
         diag = data["diagnostics"][0]
         assert diag["status"] == "unsupported"
         assert any(e["kind"] == "multi_target_unsupported" for e in diag["evidence"])
+
+
+# ---------------------------------------------------------------------------
+# ENAMETOOLONG defence in --target disambiguation (issue #166)
+# ---------------------------------------------------------------------------
+
+
+class TestLongLiteralTargetDoesNotCrash:
+    """Issue #166: a literal ``--target`` value with a ``/``-segment longer
+    than NAME_MAX (255 bytes on Linux) used to propagate an uncaught
+    ``OSError(ENAMETOOLONG)`` from ``Path(sole).is_dir()`` inside the
+    path-vs-literal disambiguation block. The CLI must instead treat the
+    token as literal text and emit a clean Diagnostic.
+    """
+
+    def test_long_literal_target_emits_clean_diagnostic(self, capsys, monkeypatch):
+        # Force the llm-rubric backend to its unconfigured-provider path so
+        # the test exercises the CLI surface without depending on a real
+        # provider key. ``_load_env_file`` is the only knob that reliably
+        # masks any developer dotenv (see test_dogfooding_rules.py for the
+        # rationale on why patching DOTENV_PATH is insufficient).
+        from gate_keeper.backends import llm_rubric
+
+        monkeypatch.setattr(llm_rubric, "_load_env_file", lambda *a, **kw: {})
+
+        # 600-byte literal blob with two ``/``-segments, each well above
+        # NAME_MAX (255 bytes). No glob metachars so the disambiguation
+        # block reaches the ``Path(sole).is_dir()`` call.
+        long_literal = ("a" * 300) + "/" + ("b" * 300)
+        assert "/" in long_literal
+        assert max(len(seg) for seg in long_literal.split("/")) > 255
+        assert not any(c in long_literal for c in "*?[")
+
+        rc = main(
+            [
+                "validate",
+                str(DOGFOODING_RULES_DOC),
+                "--target",
+                long_literal,
+                "--backend",
+                "llm-rubric",
+                "--format",
+                "json",
+            ]
+        )
+
+        captured = capsys.readouterr()
+        # Must produce well-formed JSON (no Python traceback on stderr).
+        data = json.loads(captured.out)
+        assert "diagnostics" in data
+        assert isinstance(data["diagnostics"], list)
+        assert data["diagnostics"], "expected at least one diagnostic"
+
+        # Each rule routes to llm-rubric; with the provider stubbed
+        # unconfigured, every diagnostic is UNAVAILABLE with
+        # ``provider_unconfigured`` evidence — the contract documented in
+        # docs/llm-rubric.md.
+        for diag in data["diagnostics"]:
+            assert diag["status"] == "unavailable"
+            kinds = {ev["kind"] for ev in diag["evidence"]}
+            assert "provider_unconfigured" in kinds, f"expected provider_unconfigured evidence, got {kinds}"
+
+        # Exit code is fail-closed (FAIL) for unavailable diagnostics.
+        assert rc == EXIT_FAIL
+
+    def test_long_literal_target_no_traceback_on_stderr(self, capsys, monkeypatch):
+        # Companion check: the previous bug surfaced as a Python traceback
+        # on stderr. Pin the no-traceback contract explicitly.
+        from gate_keeper.backends import llm_rubric
+
+        monkeypatch.setattr(llm_rubric, "_load_env_file", lambda *a, **kw: {})
+
+        long_literal = "x" * 400  # single segment > NAME_MAX, no slash
+        main(
+            [
+                "validate",
+                str(DOGFOODING_RULES_DOC),
+                "--target",
+                long_literal,
+                "--backend",
+                "llm-rubric",
+                "--format",
+                "json",
+            ]
+        )
+
+        captured = capsys.readouterr()
+        assert "Traceback" not in captured.err
+        assert "ENAMETOOLONG" not in captured.err
+        assert "File name too long" not in captured.err


### PR DESCRIPTION
## Summary

- Wrap the `Path(sole).is_dir()` / `Path(sole).is_file()` calls in the single-target `--target` disambiguation block (`src/gate_keeper/cli.py`) in `try/except OSError`. On `OSError` (`ENAMETOOLONG`, `EINVAL`, etc.) treat the token as literal text and fall through to the non-path branch.
- Adds two regression tests under `TestLongLiteralTargetDoesNotCrash` that run `validate` against `docs/dogfooding-rules.md` with a long literal `--target` and assert clean JSON output, no traceback on stderr, and `provider_unconfigured` evidence (`_load_env_file` monkeypatched to mask developer local provider state).

## Context

Discovered by the umbrella #164 dogfood orchestrator loop, tick 1: 4 of 10 `validate` runs crashed with an uncaught `OSError(ENAMETOOLONG)` from `pathlib` because PR commit-message and body text passed via `--target` exceeded NAME_MAX (255 bytes on Linux) in a `/`-segment. The CLI's path-vs-literal heuristic didn't defend against "this couldn't possibly be a real path" `OSError` variants.

The fix is mechanical and well-contained: it does not touch the rubric prompt, the IR, or the multi-target resolver.

## Test plan

- [x] `uv run pytest tests/test_cli_validate.py::TestLongLiteralTargetDoesNotCrash` — both new tests pass with the fix; both fail without it (verified via `git stash`).
- [x] `uv run pytest tests/test_cli_validate.py` — 48 pass, 1 pre-existing failure on `main` unrelated to this change (`test_llm_rubric_backend_accepted_but_unavailable` — fails when a real LLM provider is configured locally).
- [x] `uvx ruff check .` and `uvx ruff format --check` clean.
- [x] `uv run pyright src/gate_keeper/cli.py tests/test_cli_validate.py` — 0 errors.

Closes #166
Refs umbrella #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)