### PR TITLE
fix(cli): forward glob-shaped --target as literal on non-filesystem rules (#165)

### DIFF
--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -602,20 +602,26 @@ def _cmd_validate(args: argparse.Namespace) -> int:
                 # through ``resolve_targets`` even when the rules in this
                 # ruleset have no filesystem backend.  When the expansion
                 # produced zero filesystem matches AND no rule routes to
-                # the filesystem backend, the only sensible interpretation
-                # is "literal text"; fall through to the raw string so the
-                # llm-rubric / github / external backend receives the
-                # author-supplied content instead of an empty TargetSpec.
+                # the filesystem backend AND the user did not force a
+                # filesystem backend via ``--backend filesystem``, the
+                # only sensible interpretation is "literal text"; fall
+                # through to the raw string so the llm-rubric / github /
+                # external backend receives the author-supplied content
+                # instead of an empty TargetSpec.
                 #
-                # The check is intentionally narrow: a filesystem rule with
-                # an empty glob still produces ``UNAVAILABLE`` (the legacy
-                # fail-closed behaviour exercised by
-                # ``test_empty_glob_fails_closed``), and a non-filesystem
+                # The check is intentionally narrow: a filesystem rule
+                # with an empty glob still produces ``UNAVAILABLE`` (the
+                # legacy fail-closed behaviour exercised by
+                # ``test_empty_glob_fails_closed``), a non-filesystem
                 # rule with a glob that actually matched files still
                 # surfaces as ``multi_target_unsupported`` (the user
                 # explicitly asked for multiple files; #74's job to lift
-                # that restriction).
-                if not resolved.paths and not _ruleset_has_filesystem_rule(ruleset):
+                # that restriction), and an explicit
+                # ``--backend filesystem`` override still expects
+                # filesystem-style target resolution regardless of the
+                # ruleset's backend hints.
+                forced_filesystem = backend == "filesystem"
+                if not resolved.paths and not _ruleset_has_filesystem_rule(ruleset) and not forced_filesystem:
                     target = sole
                 else:
                     target = resolved

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from gate_keeper import __version__
 from gate_keeper.diagnostics import EXIT_OK, EXIT_USAGE
-from gate_keeper.models import RuleSet
+from gate_keeper.models import Backend, RuleSet
 
 # Backend choices exposed by the registry (always includes auto).
 _BACKEND_CHOICES = ["auto", "filesystem", "github", "llm-rubric", "external"]
@@ -454,6 +454,20 @@ def _load_ir_ruleset(path: Path) -> RuleSet | int:
         return EXIT_USAGE
 
 
+def _ruleset_has_filesystem_rule(ruleset: RuleSet) -> bool:
+    """Return True when at least one rule in *ruleset* routes to the filesystem backend.
+
+    Used by ``_cmd_validate`` to decide whether a single ``--target`` value
+    that contains glob metacharacters but expanded to zero filesystem matches
+    should be reinterpreted as literal text (issue #165).  Filesystem rules
+    have a meaningful interpretation of an empty glob — the legacy
+    fail-closed UNAVAILABLE outcome — so we must not silently rewrite the
+    target for them; only when **no** rule needs a filesystem path is a
+    glob-shaped literal unambiguously prose to forward to the backend.
+    """
+    return any(rule.backend_hint is Backend.FILESYSTEM for rule in ruleset.rules)
+
+
 def _cmd_validate(args: argparse.Namespace) -> int:
     from gate_keeper import validator
     from gate_keeper.backends import is_registered
@@ -577,10 +591,34 @@ def _cmd_validate(args: argparse.Namespace) -> int:
                 target = sole
             else:
                 try:
-                    target = resolve_targets(raw_targets)
+                    resolved = resolve_targets(raw_targets)
                 except TargetExpansionError as exc:
                     print(f"error: --target: {exc}", file=sys.stderr)
                     return EXIT_USAGE
+                # Issue #165: a literal ``--target`` containing glob
+                # metacharacters (``*``/``?``/``[``) — common in markdown
+                # PR-body text such as ``**bold** with [link](x)`` or a
+                # GitHub-style checkbox ``- [x] item`` — is mis-routed
+                # through ``resolve_targets`` even when the rules in this
+                # ruleset have no filesystem backend.  When the expansion
+                # produced zero filesystem matches AND no rule routes to
+                # the filesystem backend, the only sensible interpretation
+                # is "literal text"; fall through to the raw string so the
+                # llm-rubric / github / external backend receives the
+                # author-supplied content instead of an empty TargetSpec.
+                #
+                # The check is intentionally narrow: a filesystem rule with
+                # an empty glob still produces ``UNAVAILABLE`` (the legacy
+                # fail-closed behaviour exercised by
+                # ``test_empty_glob_fails_closed``), and a non-filesystem
+                # rule with a glob that actually matched files still
+                # surfaces as ``multi_target_unsupported`` (the user
+                # explicitly asked for multiple files; #74's job to lift
+                # that restriction).
+                if not resolved.paths and not _ruleset_has_filesystem_rule(ruleset):
+                    target = sole
+                else:
+                    target = resolved
         else:
             target = sole
     else:

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -1524,11 +1524,17 @@ class TestGlobMetacharLiteralFallthrough:
         assert rc == EXIT_FAIL
 
     def test_filesystem_rule_with_empty_glob_still_fails_closed(self, tmp_path, capsys):
-        # Negative regression: when the ruleset *does* contain a filesystem
-        # rule, the legacy "empty glob → UNAVAILABLE" contract must survive.
-        # Without this guard the #165 fall-through would silently rewrite
-        # ``--target docs/*.zzz`` to a literal string and mask a real
-        # missing-file diagnostic.
+        # Negative regression on the new fall-through *decision boundary*:
+        # the guard at ``_cmd_validate`` must not rewrite a glob-shaped
+        # ``--target`` when the ruleset routes to filesystem.  The legacy
+        # ``test_empty_glob_fails_closed`` covers the same shape but only
+        # asserts the diagnostic ``status`` — this case fails when the
+        # #165 fall-through fires too eagerly, so we additionally pin the
+        # ``backend == "filesystem"`` and ``multi_target_summary`` shape
+        # (the explicit signal that the filesystem multi-target branch
+        # ran, not the literal-text fall-through).  Without this pin a
+        # future change that silently swapped the branches could keep the
+        # status="unavailable" surface intact while breaking the contract.
         rules = tmp_path / "rules.md"
         rules.write_text(
             "# Rules\n\n## Required Files\n\n- `README.md` must exist.\n",
@@ -1551,3 +1557,74 @@ class TestGlobMetacharLiteralFallthrough:
         data = json.loads(captured.out)
         diag = data["diagnostics"][0]
         assert diag["status"] == "unavailable"
+        # The diagnostic must come from the filesystem backend (proves
+        # the empty-glob branch ran; literal-text fall-through would
+        # have routed elsewhere).
+        assert diag["backend"] == "filesystem", (
+            f"expected filesystem backend (legacy empty-glob branch), got {diag['backend']}"
+        )
+        # ``multi_target_summary`` with ``file_count == 0`` is the
+        # specific evidence shape emitted by the multi-target filesystem
+        # path on empty resolution.  Asserting both kind and zero count
+        # distinguishes this from a successful match or a rewrite to
+        # literal text.
+        summary = next(
+            (ev for ev in diag["evidence"] if ev["kind"] == "multi_target_summary"),
+            None,
+        )
+        assert summary is not None, (
+            f"expected multi_target_summary evidence (empty filesystem glob), "
+            f"got {[ev['kind'] for ev in diag['evidence']]}"
+        )
+        assert summary["data"]["file_count"] == 0
+
+    def test_backend_filesystem_override_with_nonfilesystem_ruleset_still_resolves_targets(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        # New decision-boundary regression: the ruleset has no filesystem
+        # rule, but the user explicitly forces ``--backend filesystem``.
+        # The #165 fall-through must NOT fire here — the user's explicit
+        # backend choice means filesystem-style target resolution
+        # applies, so an empty glob still surfaces
+        # ``multi_target_summary`` with ``file_count == 0`` rather than
+        # silently being rewritten to literal text and routed to the
+        # rubric backend.  This guards the gap raised by Copilot's
+        # review on PR #171.
+        from gate_keeper.backends import llm_rubric
+
+        monkeypatch.setattr(llm_rubric, "_load_env_file", lambda *a, **kw: {})
+
+        # A semantic-only ruleset (rubric kind) with no filesystem rule.
+        rc = main(
+            [
+                "validate",
+                str(DOGFOODING_RULES_DOC),
+                "--target",
+                str(tmp_path / "no_match_*.zzz"),
+                "--backend",
+                "filesystem",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == EXIT_FAIL
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        # Every diagnostic must come from the filesystem backend with a
+        # zero-count multi_target_summary — proof the ``--backend
+        # filesystem`` override drove target resolution down the
+        # filesystem branch instead of taking the #165 literal
+        # fall-through.
+        for diag in data["diagnostics"]:
+            assert diag["backend"] == "filesystem", (
+                f"--backend filesystem override should keep filesystem backend; got {diag['backend']}"
+            )
+            summary = next(
+                (ev for ev in diag["evidence"] if ev["kind"] == "multi_target_summary"),
+                None,
+            )
+            assert summary is not None, (
+                f"--backend filesystem override must keep multi-target filesystem "
+                f"resolution; got evidence {[ev['kind'] for ev in diag['evidence']]}"
+            )
+            assert summary["data"]["file_count"] == 0

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -1413,3 +1413,141 @@ class TestLongLiteralTargetDoesNotCrash:
         assert "Traceback" not in captured.err
         assert "ENAMETOOLONG" not in captured.err
         assert "File name too long" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Glob-metachar literal text on non-filesystem rules (issue #165)
+# ---------------------------------------------------------------------------
+
+
+class TestGlobMetacharLiteralFallthrough:
+    """Issue #165: a single ``--target`` value that contains glob metachars
+    (``*``/``?``/``[``) but expands to zero filesystem matches must be
+    forwarded as literal text when the ruleset has no filesystem rules.
+
+    Before this fix, ``resolve_targets`` produced ``TargetSpec(is_multi=True,
+    paths=[])`` and the llm-rubric backend rejected it with
+    ``multi_target_unsupported`` — the literal author-supplied prose never
+    reached the model. This dropped 5/5 PR-body samples in tick 1 of the
+    dogfood loop (umbrella #164) because every realistic markdown body
+    contains ``**bold**``, ``[link](x)`` brackets, or ``- [x] item``
+    checkbox syntax.
+    """
+
+    def test_markdown_body_with_metachars_reaches_backend_as_literal(self, capsys, monkeypatch):
+        # Mask the developer dotenv via the established stub pattern so the
+        # llm-rubric backend takes its provider-unconfigured path. See
+        # tests/test_dogfooding_rules.py for the rationale on why patching
+        # ``_load_env_file`` (rather than ``DOTENV_PATH``) is required.
+        from gate_keeper.backends import llm_rubric
+
+        monkeypatch.setattr(llm_rubric, "_load_env_file", lambda *a, **kw: {})
+
+        # Realistic PR body fragment containing every glob metachar that
+        # tick 1 sampled: ``*`` (italics/bold), ``[`` (link), ``?`` (URL
+        # query). No filesystem path on disk would ever match it.
+        body = "**bold** with [link](x?diff=split) and *italics*"
+        assert any(c in body for c in "*?[")
+
+        rc = main(
+            [
+                "validate",
+                str(DOGFOODING_RULES_DOC),
+                "--target",
+                body,
+                "--backend",
+                "llm-rubric",
+                "--format",
+                "json",
+            ]
+        )
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["diagnostics"], "expected at least one diagnostic"
+
+        # Contract: the backend must see the literal text.  With the
+        # provider stubbed unconfigured every diagnostic is UNAVAILABLE
+        # with ``provider_unconfigured`` evidence — proving the rubric
+        # entered ``check`` rather than fast-failing on the multi-target
+        # rejection branch.  Crucially, no diagnostic carries
+        # ``multi_target_unsupported`` evidence (the bug signature).
+        for diag in data["diagnostics"]:
+            assert diag["status"] == "unavailable", (
+                f"expected unavailable, got {diag['status']}: {diag['evidence']}"
+            )
+            ev_kinds = {ev["kind"] for ev in diag["evidence"]}
+            assert "provider_unconfigured" in ev_kinds, (
+                f"backend did not reach configuration check: {ev_kinds}"
+            )
+            assert "multi_target_unsupported" not in ev_kinds, (
+                "literal --target was mis-routed through multi-target glob resolver"
+            )
+
+        # Exit code is fail-closed (FAIL) for unavailable diagnostics.
+        assert rc == EXIT_FAIL
+
+    def test_github_checkbox_syntax_reaches_backend_as_literal(self, capsys, monkeypatch):
+        # Tick 2 (PR #167 body) hit this case: a markdown task list of the
+        # form ``- [x] item`` contains the ``[`` glob metachar and no
+        # filesystem matches exist for the bracket-prefixed token.
+        from gate_keeper.backends import llm_rubric
+
+        monkeypatch.setattr(llm_rubric, "_load_env_file", lambda *a, **kw: {})
+
+        body = "- [x] item one\n- [ ] item two\n- [x] item three"
+        assert "[" in body
+
+        rc = main(
+            [
+                "validate",
+                str(DOGFOODING_RULES_DOC),
+                "--target",
+                body,
+                "--backend",
+                "llm-rubric",
+                "--format",
+                "json",
+            ]
+        )
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["diagnostics"]
+
+        for diag in data["diagnostics"]:
+            assert diag["status"] == "unavailable"
+            ev_kinds = {ev["kind"] for ev in diag["evidence"]}
+            assert "provider_unconfigured" in ev_kinds
+            assert "multi_target_unsupported" not in ev_kinds
+
+        assert rc == EXIT_FAIL
+
+    def test_filesystem_rule_with_empty_glob_still_fails_closed(self, tmp_path, capsys):
+        # Negative regression: when the ruleset *does* contain a filesystem
+        # rule, the legacy "empty glob → UNAVAILABLE" contract must survive.
+        # Without this guard the #165 fall-through would silently rewrite
+        # ``--target docs/*.zzz`` to a literal string and mask a real
+        # missing-file diagnostic.
+        rules = tmp_path / "rules.md"
+        rules.write_text(
+            "# Rules\n\n## Required Files\n\n- `README.md` must exist.\n",
+            encoding="utf-8",
+        )
+        rc = main(
+            [
+                "validate",
+                str(rules),
+                "--target",
+                str(tmp_path / "no_match_*.zzz"),
+                "--backend",
+                "filesystem",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == EXIT_FAIL
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        diag = data["diagnostics"][0]
+        assert diag["status"] == "unavailable"


### PR DESCRIPTION
## Summary

Fixes #165 (under umbrella #164 — semantic-rubric dogfood loop).

Before this change, a single `--target` value containing glob metachars (`*`/`?`/`[`) was always routed through `resolve_targets()`, even when the rule kind was non-filesystem. Markdown PR-body text — `**bold**`, `[link](x)`, GitHub-style `- [x]` checkbox — produces `TargetSpec(is_multi=True, paths=[])`, which the llm-rubric backend rejects with `multi_target_unsupported`. The literal text never reached the model. Tick 1 of the dogfood loop hit this on 5/5 PR bodies; tick 2 hit it on PR #167.

After this change, when the glob expansion yields **zero** filesystem matches **and** no rule in the loaded ruleset routes to the filesystem backend, the CLI forwards the raw string as a literal target. The rubric (or github/external) backend then receives the author-supplied prose unchanged.

### Design choice: (a) implicit fall-through, not (b) `--target-mode`

The issue body offered two shapes: (a) implicit disambiguation when the rule kind is non-filesystem AND glob expansion is empty; (b) an explicit `--target-mode {literal,path,auto}` flag.

Picked (a) because:

- The guard is unambiguous — fall-through only fires when **both** conditions hold (non-filesystem ruleset AND zero matches), so no existing semantics change. `test_empty_glob_fails_closed` still produces UNAVAILABLE for filesystem rules, and a non-filesystem rule whose glob actually matched files still surfaces `multi_target_unsupported` (#74's job to lift).
- Zero new CLI surface; no migration burden on existing dogfood scripts.
- The information needed (`Rule.backend_hint`) is already on the loaded ruleset at the point of `--target` resolution.

### Files changed

- `src/gate_keeper/cli.py` — added `_ruleset_has_filesystem_rule(ruleset)` helper; in the single-target glob-metachar branch of `_cmd_validate`, after `resolve_targets` returns an empty `TargetSpec`, fall through to the raw string when no rule has `Backend.FILESYSTEM`. Imports updated to bring in `Backend`.
- `tests/test_cli_validate.py` — new `TestGlobMetacharLiteralFallthrough` class with three regression tests.

### What the new tests assert

Each new test uses the established `monkeypatch.setattr(llm_rubric, "_load_env_file", lambda *a, **kw: {})` stub from `tests/test_dogfooding_rules.py` so they are immune to the developer's local LLM provider configuration.

- `test_markdown_body_with_metachars_reaches_backend_as_literal` — body `**bold** with [link](x?diff=split) and *italics*` (every metachar that tick 1 sampled) routes to the rubric backend; diagnostics carry `provider_unconfigured` rather than `multi_target_unsupported`.
- `test_github_checkbox_syntax_reaches_backend_as_literal` — `- [x] item` body (the tick-2 PR #167 case) routes to the rubric backend.
- `test_filesystem_rule_with_empty_glob_still_fails_closed` — negative regression: a filesystem rule with `--target docs/*.zzz` still produces UNAVAILABLE (the legacy `test_empty_glob_fails_closed` contract is not weakened).

## Validation

```sh
uvx ruff check src/gate_keeper/cli.py tests/test_cli_validate.py   # All checks passed!
uvx pyright src/gate_keeper/cli.py                                  # 0 errors, 0 warnings
uv run pytest tests/test_cli_validate.py::TestGlobMetacharLiteralFallthrough -v
# 3 passed
uv run pytest tests/                                                 # 1032 passed
# 12 pre-existing failures unrelated to this change — they are the
# real-LLM-provider-configured noise documented on PR #167 (the
# llm_rubric stub paths see real fail/pass diagnostics instead of
# unavailable).
```

Manual repro from the issue body now produces real `llm_judgment` evidence:

```sh
$ uv run gate-keeper validate docs/dogfooding-rules.md --target "**bold** with [link](x) and *italics*" --format json
# diagnostics: 3, status=fail, evidence=[llm_judgment]   (was: unsupported / multi_target_unsupported)
```

## Test plan

- [x] New regression tests pass (3/3)
- [x] All pre-existing CLI-validate tests pass (48 unaffected)
- [x] `ruff check` and `pyright` clean
- [x] Filesystem multi-target / glob / empty-glob behaviours unchanged