### PR TITLE
feat(llm-rubric): enforce supporting_evidence_quotes ⊆ artifact (#172)

### DIFF
--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -218,10 +218,14 @@ The backend therefore enforces the substring contract in `check()` after
   punctuation pairs (curly single/double quotes, en/em dashes) is folded
   to their ASCII counterparts, so the model may copy with cosmetic
   differences. **Paraphrase or rewording is not tolerated.**
-- The artifact text is resolved from the `target` reference: if `target`
-  is a path that resolves to a file, the file contents are read; otherwise
-  the literal `str(target)` is used (this is the `--target "<PR body>"`
-  inline case).
+- The check runs against `str(target)` — exactly the string the prompt
+  template renders into the `Target reference` block via `_build_prompt`.
+  This matches what the model actually sees: the provider helpers do
+  not give the model a file-read tool, so for path / PR-reference
+  targets the model only ever has access to the reference string. The
+  bench harness pre-resolves path targets to file contents before
+  calling `check`, so for bench callers the target string is already the
+  inline content.
 - On any violation the verdict is **rejected**: the diagnostic returns
   `status=unsupported` with `evidence[0]` of kind
   `llm_quote_fabrication`. The evidence preserves the model's claimed

--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -197,13 +197,45 @@ Constraints enforced by `_parse_llm_judgment()`:
   verdict — both `"pass"` and `"fail"`** (#168). The prompt additionally
   instructs the model to draw quotes as near-verbatim substrings of the
   target text and to favor representative content over opening-line
-  citations on long artifacts. Schema-level grounding (substring
-  verification) is intentionally not enforced by the parser today —
-  prompt-side discipline is the v2 mechanism; a substring check would
-  reject quotes the model lightly normalised (whitespace, capitalisation)
-  and is deferred until the failure mode reappears.
+  citations on long artifacts.
 - `suggested_action` must be a non-empty string on `"fail"` and is coerced to `null` on `"pass"`.
 - Extra fields in the JSON response are silently ignored (forward-compatible).
+
+### Parser-side substring grounding (#172)
+
+Prompt-side discipline alone is not sufficient. Tick 6 of umbrella #164's
+dogfood loop showed that on the first sample after the v2 prompt merged
+the model returned six fail verdicts whose `supporting_evidence_quotes`
+had **zero overlap** with the artifact (generic "fail-shaped" placeholder
+strings). A model-instruction-only constraint is by design unreliable.
+
+The backend therefore enforces the substring contract in `check()` after
+`_parse_llm_judgment()` succeeds:
+
+- Each entry of `supporting_evidence_quotes` must occur as a substring of
+  the artifact text the rule is being evaluated against. Whitespace runs
+  are normalised (collapsed to a single space) and a small set of smart
+  punctuation pairs (curly single/double quotes, en/em dashes) is folded
+  to their ASCII counterparts, so the model may copy with cosmetic
+  differences. **Paraphrase or rewording is not tolerated.**
+- The artifact text is resolved from the `target` reference: if `target`
+  is a path that resolves to a file, the file contents are read; otherwise
+  the literal `str(target)` is used (this is the `--target "<PR body>"`
+  inline case).
+- On any violation the verdict is **rejected**: the diagnostic returns
+  `status=unsupported` with `evidence[0]` of kind
+  `llm_quote_fabrication`. The evidence preserves the model's claimed
+  judgment, primary reason, all returned quotes, the subset that failed
+  containment (`fabricated_quotes`), and the standard telemetry / cost
+  fields. `Diagnostic.remediation` advises the operator not to act on the
+  verdict.
+- Empty / whitespace-only quotes are treated as fabricated (zero-grounding
+  is a degenerate case, not a forgivable normalisation difference).
+
+This is option (A) from #172's design: reject the verdict rather than
+strip-and-flag offending quotes. The user-visible signal "this verdict
+came from a model that ignored the substring contract" is more valuable
+than a verdict whose grounding has been silently degraded.
 
 ### Successful diagnostic shape
 
@@ -250,13 +282,16 @@ reflect that single representative run, not an aggregate. The separate
 ## Failure modes
 
 Any provider failure path maps to `unavailable` — never to `pass` or `fail`.
-Failure modes recorded in `evidence[0]`:
+Quote fabrication maps to `unsupported` (the request succeeded but the
+verdict is rejected as ungrounded).  Failure modes recorded in
+`evidence[0]`:
 
-| Failure | `evidence[0].kind` | `data.failure_mode` |
-| --- | --- | --- |
-| File missing or provider unset | `provider_unconfigured` | n/a |
-| SDK/HTTP error, timeout, etc. | `provider_error` | exception class name |
-| Response is not the expected JSON shape | `provider_error` | `unparseable_response` |
+| Failure | `status` | `evidence[0].kind` | `data.failure_mode` |
+| --- | --- | --- | --- |
+| File missing or provider unset | `unavailable` | `provider_unconfigured` | n/a |
+| SDK/HTTP error, timeout, etc. | `unavailable` | `provider_error` | exception class name |
+| Response is not the expected JSON shape | `unavailable` | `provider_error` | `unparseable_response` |
+| Quotes not substrings of artifact (#172) | `unsupported` | `llm_quote_fabrication` | n/a (offending quotes in `data.fabricated_quotes`) |
 
 There is no retry. Investigate the failure mode, then rerun.
 

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -517,6 +518,111 @@ def _parse_response(text: str) -> tuple[str, str]:
 
 
 # ---------------------------------------------------------------------------
+# Quote-fabrication validator (#172)
+#
+# The v2 prompt (#168) instructs the model that every quote in
+# ``supporting_evidence_quotes`` must be drawn as a near-verbatim substring of
+# the artifact text. Tick 6 of umbrella #164's dogfood loop (issue #172) showed
+# that prompt-side instruction alone is insufficient: on the first post-merge
+# sample, the model emitted six fail verdicts whose quotes had **zero overlap**
+# with the artifact (generic "fail-shaped" placeholder strings). The parser
+# below enforces the contract: when any quote is not a substring of the
+# artifact, the verdict is rejected and converted to ``UNSUPPORTED`` with
+# ``evidence.kind=llm_quote_fabrication`` so downstream callers can see that
+# the model violated the grounding contract rather than acting on a verdict
+# whose evidence is fabricated.
+# ---------------------------------------------------------------------------
+
+
+# Smart-quote ↔ ASCII-quote folding table. We accept the model lightly
+# normalising punctuation when copying from the artifact (e.g. the artifact
+# carries U+2019 RIGHT SINGLE QUOTATION MARK but the model emits a plain
+# ASCII apostrophe). We do NOT accept paraphrasing or rewording.
+_QUOTE_FOLDING: dict[int, str] = {
+    ord("‘"): "'",  # LEFT SINGLE QUOTATION MARK
+    ord("’"): "'",  # RIGHT SINGLE QUOTATION MARK
+    ord("“"): '"',  # LEFT DOUBLE QUOTATION MARK
+    ord("”"): '"',  # RIGHT DOUBLE QUOTATION MARK
+    ord("′"): "'",  # PRIME
+    ord("″"): '"',  # DOUBLE PRIME
+    ord("–"): "-",  # EN DASH
+    ord("—"): "-",  # EM DASH
+}
+
+
+def _normalise_for_substring(text: str) -> str:
+    """Return *text* normalised for substring containment checks.
+
+    Folds smart quotes and dashes to ASCII counterparts and collapses runs of
+    whitespace (including newlines) to single spaces. The result is tolerant
+    enough that a quote copied with cosmetic differences (line wrapping,
+    curly-quote rendering) still matches; it is **not** tolerant of paraphrase.
+    """
+    folded = text.translate(_QUOTE_FOLDING)
+    # Collapse any run of whitespace (spaces, tabs, newlines) into a single
+    # space. ``re`` is imported at module scope; using ``\\s+`` is correct
+    # because the ``re`` regex flavour already treats CR/LF/TAB as whitespace.
+    collapsed = re.sub(r"\s+", " ", folded)
+    return collapsed.strip()
+
+
+def _resolve_artifact_text(target: str | Path) -> str:
+    """Return the artifact text used for substring validation.
+
+    The backend's ``target`` is a reference (a filesystem path, a PR URL, or
+    a literal artifact body passed via ``--target "<text>"``). For
+    fabrication detection we want the **content** the model was supposed to
+    quote from. Resolution order:
+
+    1. If *target* is a ``Path`` (or ``str`` that resolves to an existing
+       readable file), return the file contents decoded as UTF-8.
+    2. Otherwise, return ``str(target)`` verbatim — the literal string was
+       what the model received as the artifact (this is the dogfood case
+       where ``--target "<PR body>"`` passes the body inline).
+
+    Failure to read a path falls back to the verbatim string so a transient
+    filesystem issue does not turn every judgment into a fabrication report.
+    """
+    s = str(target)
+    if isinstance(target, Path):
+        try:
+            return target.read_text(encoding="utf-8")
+        except OSError:
+            return s
+    # Heuristic file-path detection: don't probe arbitrarily long inputs (a PR
+    # body can be tens of kilobytes and is never a valid path on Linux). Path
+    # components on most filesystems max out at 255 bytes; PATH_MAX is 4096
+    # bytes. Above that, skip the filesystem probe entirely.
+    if len(s) <= 4096:
+        try:
+            p = Path(s)
+            if p.is_file():
+                return p.read_text(encoding="utf-8")
+        except (OSError, ValueError):
+            pass
+    return s
+
+
+def _find_fabricated_quotes(quotes: list[str], artifact_text: str) -> list[str]:
+    """Return quotes from *quotes* that are NOT substrings of *artifact_text*.
+
+    Substring check is performed on the ``_normalise_for_substring`` form of
+    both inputs so cosmetic whitespace and smart-quote differences do not
+    cause false positives. An empty quote string is treated as fabricated
+    (a degenerate / zero-grounding case).
+    """
+    normalised_artifact = _normalise_for_substring(artifact_text)
+    fabricated: list[str] = []
+    for quote in quotes:
+        if not isinstance(quote, str) or not quote.strip():
+            fabricated.append(quote if isinstance(quote, str) else "")
+            continue
+        if _normalise_for_substring(quote) not in normalised_artifact:
+            fabricated.append(quote)
+    return fabricated
+
+
+# ---------------------------------------------------------------------------
 # Diagnostic constructors — #51 contract preserved byte-for-byte
 # ---------------------------------------------------------------------------
 
@@ -673,6 +779,51 @@ def check(rule: Rule, target: str | Path | TargetSpec) -> Diagnostic:
     assert telemetry.keys() >= {"latency_ms", "tokens_in", "tokens_out"}, (
         f"provider helper returned incomplete telemetry: {sorted(telemetry.keys())}"
     )
+
+    # #172 — parser-side enforcement of the v2 prompt's substring-grounding
+    # contract. If any quote is not a substring of the artifact text, reject
+    # the verdict and surface UNSUPPORTED with llm_quote_fabrication evidence.
+    artifact_text = _resolve_artifact_text(target)
+    fabricated = _find_fabricated_quotes(parsed.supporting_evidence_quotes, artifact_text)
+    if fabricated:
+        cost = _estimate_cost(model, telemetry["tokens_in"], telemetry["tokens_out"])
+        return Diagnostic(
+            rule_id=rule.id,
+            source=rule.source,
+            backend=Backend.LLM_RUBRIC,
+            status=Status.UNSUPPORTED,
+            severity=rule.severity,
+            message=(
+                "LLM rubric verdict rejected: the model returned "
+                f"{len(fabricated)} of {len(parsed.supporting_evidence_quotes)} "
+                "supporting quotes that are not substrings of the artifact "
+                "(quote fabrication)."
+            ),
+            evidence=[
+                Evidence(
+                    kind="llm_quote_fabrication",
+                    data={
+                        "model": model,
+                        "prompt_version": PROMPT_VERSION,
+                        "claimed_judgment": parsed.judgment,
+                        "primary_reason": parsed.primary_reason,
+                        "supporting_evidence_quotes": parsed.supporting_evidence_quotes,
+                        "fabricated_quotes": fabricated,
+                        "suggested_action": parsed.suggested_action,
+                        "latency_ms": telemetry["latency_ms"],
+                        "tokens_in": telemetry["tokens_in"],
+                        "tokens_out": telemetry["tokens_out"],
+                        "cost_estimate_usd": cost,
+                    },
+                )
+            ],
+            remediation=(
+                "The model violated the substring-grounding contract for "
+                "supporting_evidence_quotes (v2 prompt, #168). Re-run the "
+                "rule; if the failure persists, investigate prompt drift or "
+                "switch model. Do not act on this verdict."
+            ),
+        )
 
     status = Status.PASS if parsed.judgment == "pass" else Status.FAIL
     cost = _estimate_cost(model, telemetry["tokens_in"], telemetry["tokens_out"])

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -569,38 +569,33 @@ def _normalise_for_substring(text: str) -> str:
 def _resolve_artifact_text(target: str | Path) -> str:
     """Return the artifact text used for substring validation.
 
-    The backend's ``target`` is a reference (a filesystem path, a PR URL, or
-    a literal artifact body passed via ``--target "<text>"``). For
-    fabrication detection we want the **content** the model was supposed to
-    quote from. Resolution order:
+    Returns ``str(target)`` — the same string the prompt template renders
+    into the ``Target reference`` block via ``_build_prompt``. This is
+    deliberate: the substring check must be performed against what the
+    **model actually saw**, not against any out-of-band file contents.
 
-    1. If *target* is a ``Path`` (or ``str`` that resolves to an existing
-       readable file), return the file contents decoded as UTF-8.
-    2. Otherwise, return ``str(target)`` verbatim — the literal string was
-       what the model received as the artifact (this is the dogfood case
-       where ``--target "<PR body>"`` passes the body inline).
+    Concretely:
 
-    Failure to read a path falls back to the verbatim string so a transient
-    filesystem issue does not turn every judgment into a fabrication report.
+    - For inline-string targets (the dogfood case ``--target "<PR body>"``)
+      the model receives the body inline; quotes must be substrings of it.
+    - For path / PR-reference targets (the ``validate --target <file>``
+      flow) the model receives only the reference string and is instructed
+      to "judge from the reference alone" when it cannot read the
+      content. The substring check accepts only quotes drawn from that
+      reference. Generic placeholder strings invented by the model still
+      fail containment and are flagged as ``llm_quote_fabrication`` — the
+      desired behaviour.
+    - The bench harness pre-resolves path targets to file contents before
+      invoking ``check`` (``bench.run_entry`` ⇒ ``Target.resolve``), so for
+      bench callers the target string is already the inline content; no
+      special-casing is required here.
+
+    Reading file contents off-band would diverge from what the model has
+    access to and would force every legitimate verdict on a path target
+    into a false ``llm_quote_fabrication`` rejection (Codex review on
+    PR #173).
     """
-    s = str(target)
-    if isinstance(target, Path):
-        try:
-            return target.read_text(encoding="utf-8")
-        except OSError:
-            return s
-    # Heuristic file-path detection: don't probe arbitrarily long inputs (a PR
-    # body can be tens of kilobytes and is never a valid path on Linux). Path
-    # components on most filesystems max out at 255 bytes; PATH_MAX is 4096
-    # bytes. Above that, skip the filesystem probe entirely.
-    if len(s) <= 4096:
-        try:
-            p = Path(s)
-            if p.is_file():
-                return p.read_text(encoding="utf-8")
-        except (OSError, ValueError):
-            pass
-    return s
+    return str(target)
 
 
 def _find_fabricated_quotes(quotes: list[str], artifact_text: str) -> list[str]:

--- a/tests/test_cli_bench.py
+++ b/tests/test_cli_bench.py
@@ -33,13 +33,19 @@ def _patch_env(monkeypatch, env: dict[str, str]) -> None:
 
 
 def _stub_openai_pass(*_args, **_kwargs) -> tuple[str, dict[str, int]]:
-    """Mock OpenAI helper returning a structured `pass` judgment."""
+    """Mock OpenAI helper returning a structured `pass` judgment.
+
+    Quotes are picked to be substrings of the inline target text used by the
+    smoke fixtures below (``"example artefact body"``) so the parser-side
+    fabrication validator (#172) does not reject the verdict.
+    """
     body = json.dumps(
         {
             "judgment": "pass",
             "primary_reason": "The artefact satisfies the rule.",
             # #168: pass also requires non-empty supporting quotes.
-            "supporting_evidence_quotes": ["a representative substring"],
+            # #172: quote must be a substring of the artifact text.
+            "supporting_evidence_quotes": ["example artefact body"],
             "suggested_action": None,
         }
     )
@@ -51,7 +57,8 @@ def _stub_openai_fail(*_args, **_kwargs) -> tuple[str, dict[str, int]]:
         {
             "judgment": "fail",
             "primary_reason": "The artefact violates the rule.",
-            "supporting_evidence_quotes": ["evidence quote"],
+            # #172: quote must be a substring of the artifact text.
+            "supporting_evidence_quotes": ["example artefact body"],
             "suggested_action": "Fix it.",
         }
     )
@@ -207,7 +214,8 @@ class TestRunBenchSmoke:
                         "judgment": "pass",
                         "primary_reason": "PASS rationale — should not appear",
                         # #168: pass also requires non-empty supporting quotes.
-                        "supporting_evidence_quotes": ["a representative substring"],
+                        # #172: quote must be a substring of the artifact text.
+                        "supporting_evidence_quotes": ["example artefact body"],
                         "suggested_action": None,
                     }
                 )
@@ -216,7 +224,8 @@ class TestRunBenchSmoke:
                 {
                     "judgment": "fail",
                     "primary_reason": "FAIL rationale — majority side",
-                    "supporting_evidence_quotes": ["evidence of violation"],
+                    # #172: quote must be a substring of the artifact text.
+                    "supporting_evidence_quotes": ["example artefact body"],
                     "suggested_action": "Fix it.",
                 }
             )
@@ -255,7 +264,10 @@ class TestCliBench:
             json.dumps(
                 {
                     "rule_text": "The artefact satisfies the example rule.",
-                    "target": {"kind": "inline", "value": "example body"},
+                    # #172: keep target text in sync with ``_stub_openai_pass``'s
+                    # supporting quote so the parser-side fabrication check
+                    # accepts the verdict.
+                    "target": {"kind": "inline", "value": "example artefact body"},
                     "expected_judgment": "pass",
                     "expected_rationale_keywords": [],
                     "category": "clarity",

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -641,7 +641,9 @@ class TestReproducibilityFlag:
                         "judgment": "pass",
                         "primary_reason": "looks good",
                         # #168: pass also requires non-empty supporting quotes.
-                        "supporting_evidence_quotes": ["a representative substring"],
+                        # #172: quote must be a substring of the artifact text
+                        # (PASS_README contents — see fixtures/local/pass/README.md).
+                        "supporting_evidence_quotes": ["This file exists"],
                         "suggested_action": None,
                     }
                 ),

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -641,9 +641,10 @@ class TestReproducibilityFlag:
                         "judgment": "pass",
                         "primary_reason": "looks good",
                         # #168: pass also requires non-empty supporting quotes.
-                        # #172: quote must be a substring of the artifact text
-                        # (PASS_README contents — see fixtures/local/pass/README.md).
-                        "supporting_evidence_quotes": ["This file exists"],
+                        # #172: quote must be a substring of ``str(target)`` —
+                        # the path string the prompt renders. PASS_README's
+                        # filename is "README.md" so we cite that.
+                        "supporting_evidence_quotes": ["README.md"],
                         "suggested_action": None,
                     }
                 ),

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -33,11 +33,13 @@ from gate_keeper.validator import validate
 # Helpers
 # ---------------------------------------------------------------------------
 
-# Artifact text the canned PASS/FAIL stub responses claim to quote. Tests that
-# exercise the parser-side fabrication validator (#172) must pass this text
-# (or a tmp file containing it — see ``_target_with_artifact``) as the
-# ``target`` argument so the canned quotes are real substrings of the
-# artifact and the verdict is not rejected as fabricated.
+# Artifact text the canned PASS/FAIL stub responses claim to quote. Tests
+# that exercise the parser-side fabrication validator (#172) must pass this
+# text **inline** as the ``target`` argument so the canned quotes are real
+# substrings of the rendered prompt's ``Target reference`` block. The
+# substring check runs against ``str(target)`` — the same string the model
+# sees — not against any file off-band; passing a tmp ``Path`` whose file
+# contains the quotes would defeat the check (Codex review on PR #173).
 _STUB_ARTIFACT_TEXT = (
     "The README documents both install and validate commands. "
     "README.md has no '## Usage' heading and no example."
@@ -74,17 +76,17 @@ def _stub_response(text: str, telemetry: dict[str, int] | None = None) -> tuple[
     return text, dict(telemetry) if telemetry is not None else dict(_STUB_TELEMETRY)
 
 
-def _target_with_artifact(tmp_path, text: str = _STUB_ARTIFACT_TEXT):
-    """Write *text* to a file inside *tmp_path* and return the file path.
+def _target_with_artifact(tmp_path, text: str = _STUB_ARTIFACT_TEXT) -> str:
+    """Return *text* — an inline artifact string suitable as a ``target``.
 
-    The llm-rubric backend resolves a path-shaped target by reading the file
-    contents (``_resolve_artifact_text``); using such a file as the target
-    lets canned stub responses cite quotes that actually appear in the
-    artifact, satisfying the #172 substring-grounding check.
+    Kept as a helper (rather than an inline ``_STUB_ARTIFACT_TEXT`` literal
+    at every call site) so that future tweaks to the canned artifact text
+    only need to change the default here. ``tmp_path`` is accepted only to
+    keep the existing call-site signature; it is not used (the substring
+    check runs against the string itself, not against a file).
     """
-    artifact = tmp_path / "artifact.md"
-    artifact.write_text(text, encoding="utf-8")
-    return artifact
+    del tmp_path
+    return text
 
 
 def _semantic_rule(kind: RuleKind = RuleKind.SEMANTIC_RUBRIC) -> Rule:
@@ -1020,17 +1022,17 @@ class TestQuoteFabricationDetection:
         "OPENAI_API_KEY": "sk-openai-test",
     }
 
-    def test_fabricated_quote_yields_unsupported(self, monkeypatch, tmp_path):
-        """Quotes that are not substrings of the artifact reject the verdict."""
+    def test_fabricated_quote_yields_unsupported(self, monkeypatch):
+        """Quotes that are not substrings of the artifact reject the verdict.
+
+        The substring check is performed against the same string the prompt
+        renders (``str(target)``), since that is what the model actually
+        sees. This mirrors the tick 6 dogfood failure (#172) where
+        ``--target "<PR body>"`` was passed inline and the model returned
+        generic placeholder strings unrelated to the body.
+        """
         _patch_env(monkeypatch, self._ENV)
-        # Artifact text known to NOT contain the fabricated quote below. This
-        # mirrors the tick 6 dogfood failure where the model emitted generic
-        # "fail-shaped" strings unrelated to the PR body.
-        artifact = tmp_path / "pr_body.md"
-        artifact.write_text(
-            "feat(llm-rubric): tighten supporting_evidence_quotes constraints\n\nCloses #168.\n",
-            encoding="utf-8",
-        )
+        target_text = "feat(llm-rubric): tighten supporting_evidence_quotes constraints\n\nCloses #168.\n"
         fabricated_payload = json.dumps(
             {
                 "judgment": "fail",
@@ -1044,7 +1046,7 @@ class TestQuoteFabricationDetection:
             "_call_openai",
             lambda *_a, **_k: _stub_response(fabricated_payload),
         )
-        diag = llm_backend.check(_semantic_rule(), artifact)
+        diag = llm_backend.check(_semantic_rule(), target_text)
         assert diag.status is Status.UNSUPPORTED
         assert diag.backend is Backend.LLM_RUBRIC
         assert len(diag.evidence) == 1
@@ -1065,14 +1067,10 @@ class TestQuoteFabricationDetection:
         assert diag.remediation is not None
         assert "Do not act" in diag.remediation
 
-    def test_partially_fabricated_quotes_yield_unsupported(self, monkeypatch, tmp_path):
+    def test_partially_fabricated_quotes_yield_unsupported(self, monkeypatch):
         """Even one fabricated quote is sufficient to reject the verdict."""
         _patch_env(monkeypatch, self._ENV)
-        artifact = tmp_path / "artifact.md"
-        artifact.write_text(
-            "Real phrase that the model legitimately quoted.\n\nMore body here.\n",
-            encoding="utf-8",
-        )
+        target_text = "Real phrase that the model legitimately quoted.\n\nMore body here.\n"
         payload = json.dumps(
             {
                 "judgment": "pass",
@@ -1089,7 +1087,7 @@ class TestQuoteFabricationDetection:
             "_call_openai",
             lambda *_a, **_k: _stub_response(payload),
         )
-        diag = llm_backend.check(_semantic_rule(), artifact)
+        diag = llm_backend.check(_semantic_rule(), target_text)
         assert diag.status is Status.UNSUPPORTED
         assert diag.evidence[0].kind == "llm_quote_fabrication"
         # Only the offending quote is recorded as fabricated; the legitimate
@@ -1098,30 +1096,25 @@ class TestQuoteFabricationDetection:
             "Fabricated extra string never present in the artifact."
         ]
 
-    def test_well_behaved_quote_still_passes(self, monkeypatch, tmp_path):
+    def test_well_behaved_quote_still_passes(self, monkeypatch):
         """Quotes that ARE substrings of the artifact produce normal llm_judgment."""
         _patch_env(monkeypatch, self._ENV)
-        artifact = _target_with_artifact(tmp_path)
         monkeypatch.setattr(
             llm_backend,
             "_call_openai",
             lambda *_a, **_k: _stub_response(_VALID_PASS_JSON),
         )
-        diag = llm_backend.check(_semantic_rule(), artifact)
+        diag = llm_backend.check(_semantic_rule(), _STUB_ARTIFACT_TEXT)
         assert diag.status is Status.PASS
         assert diag.evidence[0].kind == "llm_judgment"
         assert diag.evidence[0].data["judgment"] == "pass"
 
-    def test_whitespace_normalisation_tolerance(self, monkeypatch, tmp_path):
+    def test_whitespace_normalisation_tolerance(self, monkeypatch):
         """Cosmetic whitespace differences must not trigger fabrication."""
         _patch_env(monkeypatch, self._ENV)
-        artifact = tmp_path / "artifact.md"
         # Artifact has line wrapping; the model emits the same content as a
         # single line. Both should normalise to the same form.
-        artifact.write_text(
-            "The PR description names\nthe user-visible change in the\nfirst sentence.",
-            encoding="utf-8",
-        )
+        target_text = "The PR description names\nthe user-visible change in the\nfirst sentence."
         payload = json.dumps(
             {
                 "judgment": "pass",
@@ -1137,20 +1130,16 @@ class TestQuoteFabricationDetection:
             "_call_openai",
             lambda *_a, **_k: _stub_response(payload),
         )
-        diag = llm_backend.check(_semantic_rule(), artifact)
+        diag = llm_backend.check(_semantic_rule(), target_text)
         assert diag.status is Status.PASS
         assert diag.evidence[0].kind == "llm_judgment"
 
-    def test_smart_quote_folding_tolerance(self, monkeypatch, tmp_path):
+    def test_smart_quote_folding_tolerance(self, monkeypatch):
         """ASCII-quote normalisation in the model's quote must still match a
         smart-quote-bearing artifact."""
         _patch_env(monkeypatch, self._ENV)
-        artifact = tmp_path / "artifact.md"
         # Artifact has a curly apostrophe; the model returns ASCII.
-        artifact.write_text(
-            "It’s the body that matters, not the subject line.",
-            encoding="utf-8",
-        )
+        target_text = "It’s the body that matters, not the subject line."
         payload = json.dumps(
             {
                 "judgment": "pass",
@@ -1164,17 +1153,72 @@ class TestQuoteFabricationDetection:
             "_call_openai",
             lambda *_a, **_k: _stub_response(payload),
         )
+        diag = llm_backend.check(_semantic_rule(), target_text)
+        assert diag.status is Status.PASS
+        assert diag.evidence[0].kind == "llm_judgment"
+
+    def test_path_target_substring_check_uses_path_string(self, monkeypatch, tmp_path):
+        """For path targets the substring check runs against the path string itself.
+
+        Rationale: the prompt renders ``str(target)`` into the ``Target
+        reference`` block, and the provider helpers do not give the model a
+        file-read tool. The model only ever sees the path. Reading the file
+        contents off-band would diverge from what the model has access to
+        and would force every legitimate verdict on a path target into a
+        false fabrication rejection (Codex review on PR #173).
+        """
+        _patch_env(monkeypatch, self._ENV)
+        artifact = tmp_path / "pr_body.md"
+        artifact.write_text("Body text the model never sees.", encoding="utf-8")
+        # The model returns a quote that *would* be a substring of the file
+        # contents but is NOT a substring of the path string. The verdict
+        # must still be rejected because the model never had access to the
+        # file contents.
+        payload = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "ok",
+                "supporting_evidence_quotes": ["Body text the model never sees."],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(payload),
+        )
+        diag = llm_backend.check(_semantic_rule(), artifact)
+        assert diag.status is Status.UNSUPPORTED
+        assert diag.evidence[0].kind == "llm_quote_fabrication"
+
+    def test_path_target_quote_drawn_from_path_passes(self, monkeypatch, tmp_path):
+        """When the model quotes from the path string itself (the only
+        artifact text it has access to), the verdict is accepted."""
+        _patch_env(monkeypatch, self._ENV)
+        artifact = tmp_path / "pr_body.md"
+        artifact.write_text("contents irrelevant", encoding="utf-8")
+        # Quote uses the file's basename which IS a substring of the path
+        # string the model was shown.
+        payload = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "judging from filename",
+                "supporting_evidence_quotes": ["pr_body.md"],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(payload),
+        )
         diag = llm_backend.check(_semantic_rule(), artifact)
         assert diag.status is Status.PASS
         assert diag.evidence[0].kind == "llm_judgment"
 
-    def test_inline_string_target_validates_against_string_itself(self, monkeypatch, tmp_path):
-        """When ``target`` is a literal string (not a path), the substring
-        check runs against the string itself.
-
-        This is the dogfood case from #172: ``--target "<PR body>"`` passes
-        the literal body inline and the model is expected to quote from it.
-        """
+    def test_inline_string_target_validates_against_string_itself(self, monkeypatch):
+        """The dogfood case from #172: ``--target "<PR body>"`` passes the
+        literal body inline; quotes must be substrings of it."""
         _patch_env(monkeypatch, self._ENV)
         target_string = "feat(llm-rubric): tighten supporting_evidence_quotes constraints"
         # Quote that is NOT a substring of the inline target.
@@ -1195,10 +1239,9 @@ class TestQuoteFabricationDetection:
         assert diag.status is Status.UNSUPPORTED
         assert diag.evidence[0].kind == "llm_quote_fabrication"
 
-    def test_empty_quote_string_treated_as_fabricated(self, monkeypatch, tmp_path):
+    def test_empty_quote_string_treated_as_fabricated(self, monkeypatch):
         """An empty / whitespace-only quote is a degenerate zero-grounding case."""
         _patch_env(monkeypatch, self._ENV)
-        artifact = _target_with_artifact(tmp_path)
         payload = json.dumps(
             {
                 "judgment": "fail",
@@ -1212,7 +1255,7 @@ class TestQuoteFabricationDetection:
             "_call_openai",
             lambda *_a, **_k: _stub_response(payload),
         )
-        diag = llm_backend.check(_semantic_rule(), artifact)
+        diag = llm_backend.check(_semantic_rule(), _STUB_ARTIFACT_TEXT)
         assert diag.status is Status.UNSUPPORTED
         assert diag.evidence[0].kind == "llm_quote_fabrication"
 

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -33,6 +33,16 @@ from gate_keeper.validator import validate
 # Helpers
 # ---------------------------------------------------------------------------
 
+# Artifact text the canned PASS/FAIL stub responses claim to quote. Tests that
+# exercise the parser-side fabrication validator (#172) must pass this text
+# (or a tmp file containing it — see ``_target_with_artifact``) as the
+# ``target`` argument so the canned quotes are real substrings of the
+# artifact and the verdict is not rejected as fabricated.
+_STUB_ARTIFACT_TEXT = (
+    "The README documents both install and validate commands. "
+    "README.md has no '## Usage' heading and no example."
+)
+
 _VALID_PASS_JSON = json.dumps(
     {
         "judgment": "pass",
@@ -62,6 +72,19 @@ _STUB_TELEMETRY: dict[str, int] = {
 def _stub_response(text: str, telemetry: dict[str, int] | None = None) -> tuple[str, dict[str, int]]:
     """Build a ``(text, telemetry)`` tuple matching the real helper signature."""
     return text, dict(telemetry) if telemetry is not None else dict(_STUB_TELEMETRY)
+
+
+def _target_with_artifact(tmp_path, text: str = _STUB_ARTIFACT_TEXT):
+    """Write *text* to a file inside *tmp_path* and return the file path.
+
+    The llm-rubric backend resolves a path-shaped target by reading the file
+    contents (``_resolve_artifact_text``); using such a file as the target
+    lets canned stub responses cite quotes that actually appear in the
+    artifact, satisfying the #172 substring-grounding check.
+    """
+    artifact = tmp_path / "artifact.md"
+    artifact.write_text(text, encoding="utf-8")
+    return artifact
 
 
 def _semantic_rule(kind: RuleKind = RuleKind.SEMANTIC_RUBRIC) -> Rule:
@@ -397,7 +420,7 @@ class TestProviderDispatchAnthropic:
             "_call_anthropic",
             lambda key, system, user, model: _stub_response(_VALID_PASS_JSON),
         )
-        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        diag = llm_backend.check(_semantic_rule(), _target_with_artifact(tmp_path))
         assert diag.status is Status.PASS
         assert diag.backend is Backend.LLM_RUBRIC
         assert diag.evidence[0].kind == "llm_judgment"
@@ -417,7 +440,7 @@ class TestProviderDispatchAnthropic:
             "_call_anthropic",
             lambda key, system, user, model: _stub_response(_VALID_FAIL_JSON),
         )
-        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        diag = llm_backend.check(_semantic_rule(), _target_with_artifact(tmp_path))
         assert diag.status is Status.FAIL
         assert diag.evidence[0].kind == "llm_judgment"
         assert diag.evidence[0].data["judgment"] == "fail"
@@ -511,7 +534,7 @@ class TestProviderDispatchOpenAI:
             "_call_openai",
             lambda *_a, **_k: _stub_response(_VALID_PASS_JSON),
         )
-        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        diag = llm_backend.check(_semantic_rule(), _target_with_artifact(tmp_path))
         assert diag.status is Status.PASS
         assert diag.evidence[0].data["model"] == llm_backend.OPENAI_DEFAULT_MODEL
         assert diag.evidence[0].data["judgment"] == "pass"
@@ -524,7 +547,7 @@ class TestProviderDispatchOpenAI:
             "_call_openai",
             lambda *_a, **_k: _stub_response(_VALID_FAIL_JSON),
         )
-        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        diag = llm_backend.check(_semantic_rule(), _target_with_artifact(tmp_path))
         assert diag.status is Status.FAIL
         assert diag.evidence[0].data["model"] == llm_backend.OPENAI_DEFAULT_MODEL
         assert diag.evidence[0].data["judgment"] == "fail"
@@ -806,7 +829,7 @@ class TestEvidenceObservability:
             "_call_anthropic",
             lambda *_a, **_k: _stub_response(_VALID_PASS_JSON, next(telemetries)),
         )
-        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
+        diag = llm_backend.run_n(_semantic_rule(), _target_with_artifact(tmp_path), 3)
         # llm_judgment evidence (representative run) carries telemetry.
         judgment_data = diag.evidence[0].data
         assert isinstance(judgment_data["latency_ms"], int)
@@ -975,6 +998,251 @@ class TestParseLlmJudgment:
 
 
 # ---------------------------------------------------------------------------
+# Quote-fabrication validator (#172)
+# ---------------------------------------------------------------------------
+
+
+class TestQuoteFabricationDetection:
+    """#172 — parser-side enforcement of substring grounding for quotes.
+
+    The v2 prompt (#168) instructs the model that every quote in
+    ``supporting_evidence_quotes`` must be drawn as a near-verbatim substring
+    of the artifact text. Tick 6 of umbrella #164's dogfood loop (issue
+    #172) showed that prompt-side instruction alone is insufficient: the
+    model can return generic placeholder strings that have zero overlap with
+    the artifact. The parser-side validator below converts such judgments to
+    ``UNSUPPORTED`` with ``llm_quote_fabrication`` evidence so the verdict
+    is not actioned.
+    """
+
+    _ENV = {
+        "GATE_KEEPER_LLM_PROVIDER": "openai",
+        "OPENAI_API_KEY": "sk-openai-test",
+    }
+
+    def test_fabricated_quote_yields_unsupported(self, monkeypatch, tmp_path):
+        """Quotes that are not substrings of the artifact reject the verdict."""
+        _patch_env(monkeypatch, self._ENV)
+        # Artifact text known to NOT contain the fabricated quote below. This
+        # mirrors the tick 6 dogfood failure where the model emitted generic
+        # "fail-shaped" strings unrelated to the PR body.
+        artifact = tmp_path / "pr_body.md"
+        artifact.write_text(
+            "feat(llm-rubric): tighten supporting_evidence_quotes constraints\n\nCloses #168.\n",
+            encoding="utf-8",
+        )
+        fabricated_payload = json.dumps(
+            {
+                "judgment": "fail",
+                "primary_reason": "PR body lacks rationale.",
+                "supporting_evidence_quotes": ["This PR implements several changes to improve performance."],
+                "suggested_action": "Add a rationale paragraph.",
+            }
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(fabricated_payload),
+        )
+        diag = llm_backend.check(_semantic_rule(), artifact)
+        assert diag.status is Status.UNSUPPORTED
+        assert diag.backend is Backend.LLM_RUBRIC
+        assert len(diag.evidence) == 1
+        assert diag.evidence[0].kind == "llm_quote_fabrication"
+        # The evidence preserves the model's claimed verdict and the offending
+        # quotes so reviewers can see what the model returned.
+        data = diag.evidence[0].data
+        assert data["claimed_judgment"] == "fail"
+        assert data["primary_reason"] == "PR body lacks rationale."
+        assert data["fabricated_quotes"] == ["This PR implements several changes to improve performance."]
+        assert data["supporting_evidence_quotes"] == data["fabricated_quotes"]
+        # Telemetry / cost are still recorded (the API call did happen).
+        assert data["latency_ms"] == _STUB_TELEMETRY["latency_ms"]
+        assert data["tokens_in"] == _STUB_TELEMETRY["tokens_in"]
+        assert data["tokens_out"] == _STUB_TELEMETRY["tokens_out"]
+        assert "cost_estimate_usd" in data
+        # Remediation steers the operator away from acting on the verdict.
+        assert diag.remediation is not None
+        assert "Do not act" in diag.remediation
+
+    def test_partially_fabricated_quotes_yield_unsupported(self, monkeypatch, tmp_path):
+        """Even one fabricated quote is sufficient to reject the verdict."""
+        _patch_env(monkeypatch, self._ENV)
+        artifact = tmp_path / "artifact.md"
+        artifact.write_text(
+            "Real phrase that the model legitimately quoted.\n\nMore body here.\n",
+            encoding="utf-8",
+        )
+        payload = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "Body explains motivation.",
+                "supporting_evidence_quotes": [
+                    "Real phrase that the model legitimately quoted.",
+                    "Fabricated extra string never present in the artifact.",
+                ],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(payload),
+        )
+        diag = llm_backend.check(_semantic_rule(), artifact)
+        assert diag.status is Status.UNSUPPORTED
+        assert diag.evidence[0].kind == "llm_quote_fabrication"
+        # Only the offending quote is recorded as fabricated; the legitimate
+        # quote stays in supporting_evidence_quotes.
+        assert diag.evidence[0].data["fabricated_quotes"] == [
+            "Fabricated extra string never present in the artifact."
+        ]
+
+    def test_well_behaved_quote_still_passes(self, monkeypatch, tmp_path):
+        """Quotes that ARE substrings of the artifact produce normal llm_judgment."""
+        _patch_env(monkeypatch, self._ENV)
+        artifact = _target_with_artifact(tmp_path)
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(_VALID_PASS_JSON),
+        )
+        diag = llm_backend.check(_semantic_rule(), artifact)
+        assert diag.status is Status.PASS
+        assert diag.evidence[0].kind == "llm_judgment"
+        assert diag.evidence[0].data["judgment"] == "pass"
+
+    def test_whitespace_normalisation_tolerance(self, monkeypatch, tmp_path):
+        """Cosmetic whitespace differences must not trigger fabrication."""
+        _patch_env(monkeypatch, self._ENV)
+        artifact = tmp_path / "artifact.md"
+        # Artifact has line wrapping; the model emits the same content as a
+        # single line. Both should normalise to the same form.
+        artifact.write_text(
+            "The PR description names\nthe user-visible change in the\nfirst sentence.",
+            encoding="utf-8",
+        )
+        payload = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "ok",
+                "supporting_evidence_quotes": [
+                    "The PR description names the user-visible change in the first sentence."
+                ],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(payload),
+        )
+        diag = llm_backend.check(_semantic_rule(), artifact)
+        assert diag.status is Status.PASS
+        assert diag.evidence[0].kind == "llm_judgment"
+
+    def test_smart_quote_folding_tolerance(self, monkeypatch, tmp_path):
+        """ASCII-quote normalisation in the model's quote must still match a
+        smart-quote-bearing artifact."""
+        _patch_env(monkeypatch, self._ENV)
+        artifact = tmp_path / "artifact.md"
+        # Artifact has a curly apostrophe; the model returns ASCII.
+        artifact.write_text(
+            "It’s the body that matters, not the subject line.",
+            encoding="utf-8",
+        )
+        payload = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "ok",
+                "supporting_evidence_quotes": ["It's the body that matters, not the subject line."],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(payload),
+        )
+        diag = llm_backend.check(_semantic_rule(), artifact)
+        assert diag.status is Status.PASS
+        assert diag.evidence[0].kind == "llm_judgment"
+
+    def test_inline_string_target_validates_against_string_itself(self, monkeypatch, tmp_path):
+        """When ``target`` is a literal string (not a path), the substring
+        check runs against the string itself.
+
+        This is the dogfood case from #172: ``--target "<PR body>"`` passes
+        the literal body inline and the model is expected to quote from it.
+        """
+        _patch_env(monkeypatch, self._ENV)
+        target_string = "feat(llm-rubric): tighten supporting_evidence_quotes constraints"
+        # Quote that is NOT a substring of the inline target.
+        fabricated_payload = json.dumps(
+            {
+                "judgment": "fail",
+                "primary_reason": "Generic.",
+                "supporting_evidence_quotes": ["This PR includes some refactoring and adds new tests."],
+                "suggested_action": "Be specific.",
+            }
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(fabricated_payload),
+        )
+        diag = llm_backend.check(_semantic_rule(), target_string)
+        assert diag.status is Status.UNSUPPORTED
+        assert diag.evidence[0].kind == "llm_quote_fabrication"
+
+    def test_empty_quote_string_treated_as_fabricated(self, monkeypatch, tmp_path):
+        """An empty / whitespace-only quote is a degenerate zero-grounding case."""
+        _patch_env(monkeypatch, self._ENV)
+        artifact = _target_with_artifact(tmp_path)
+        payload = json.dumps(
+            {
+                "judgment": "fail",
+                "primary_reason": "x",
+                "supporting_evidence_quotes": ["   "],
+                "suggested_action": "fix it",
+            }
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(payload),
+        )
+        diag = llm_backend.check(_semantic_rule(), artifact)
+        assert diag.status is Status.UNSUPPORTED
+        assert diag.evidence[0].kind == "llm_quote_fabrication"
+
+    def test_find_fabricated_quotes_helper(self):
+        """Direct unit test for the substring-validation helper."""
+        artifact = "alpha beta gamma delta epsilon"
+        # All present
+        assert llm_backend._find_fabricated_quotes(["alpha", "gamma"], artifact) == []
+        # One missing
+        assert llm_backend._find_fabricated_quotes(["alpha", "zeta"], artifact) == ["zeta"]
+        # All missing
+        assert llm_backend._find_fabricated_quotes(["zeta", "kappa"], artifact) == [
+            "zeta",
+            "kappa",
+        ]
+        # Whitespace tolerance — quote contains line wrapping
+        assert llm_backend._find_fabricated_quotes(["alpha\nbeta"], artifact) == []
+
+    def test_normalise_for_substring_collapses_whitespace(self):
+        norm = llm_backend._normalise_for_substring
+        assert norm("a   b\n\tc") == "a b c"
+        assert norm("  trim me  ") == "trim me"
+
+    def test_normalise_for_substring_folds_smart_quotes(self):
+        norm = llm_backend._normalise_for_substring
+        assert norm("It’s") == norm("It's")
+        assert norm("“hello”") == norm('"hello"')
+
+
+# ---------------------------------------------------------------------------
 # _parse_response backward-compat shim (legacy tests, kept for regression)
 # ---------------------------------------------------------------------------
 
@@ -1137,7 +1405,7 @@ class TestRunN:
             "_call_anthropic",
             lambda key, system, user, model: _stub_response(_VALID_PASS_JSON),
         )
-        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 1)
+        diag = llm_backend.run_n(_semantic_rule(), _target_with_artifact(tmp_path), 1)
         # Only the llm_judgment evidence — no reproducibility_score appended.
         assert len(diag.evidence) == 1
         assert diag.evidence[0].kind == "llm_judgment"
@@ -1150,7 +1418,7 @@ class TestRunN:
             "_call_anthropic",
             lambda *_a, **_k: _stub_response(_VALID_PASS_JSON),
         )
-        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
+        diag = llm_backend.run_n(_semantic_rule(), _target_with_artifact(tmp_path), 3)
         assert diag.status is Status.PASS
         # last evidence is the reproducibility entry
         repro = diag.evidence[-1]
@@ -1167,7 +1435,7 @@ class TestRunN:
             "_call_anthropic",
             lambda *_a, **_k: _stub_response(_VALID_FAIL_JSON),
         )
-        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
+        diag = llm_backend.run_n(_semantic_rule(), _target_with_artifact(tmp_path), 3)
         assert diag.status is Status.FAIL
         repro = diag.evidence[-1]
         assert repro.kind == "reproducibility_score"
@@ -1184,7 +1452,7 @@ class TestRunN:
             "_call_anthropic",
             lambda *_a, **_k: _stub_response(next(responses)),
         )
-        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
+        diag = llm_backend.run_n(_semantic_rule(), _target_with_artifact(tmp_path), 3)
         assert diag.status is Status.PASS
         repro = diag.evidence[-1]
         assert repro.kind == "reproducibility_score"
@@ -1201,7 +1469,7 @@ class TestRunN:
             "_call_anthropic",
             lambda *_a, **_k: _stub_response(next(responses)),
         )
-        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 3)
+        diag = llm_backend.run_n(_semantic_rule(), _target_with_artifact(tmp_path), 3)
         assert diag.status is Status.FAIL
         repro = diag.evidence[-1]
         assert repro.kind == "reproducibility_score"
@@ -1218,7 +1486,7 @@ class TestRunN:
             "_call_anthropic",
             lambda *_a, **_k: _stub_response(next(responses)),
         )
-        diag = llm_backend.run_n(_semantic_rule(), tmp_path, 2)
+        diag = llm_backend.run_n(_semantic_rule(), _target_with_artifact(tmp_path), 2)
         assert diag.status is Status.FAIL
         repro = diag.evidence[-1]
         assert repro.data["pass_count"] == 1
@@ -1254,7 +1522,7 @@ class TestRunN:
             return _stub_response(_VALID_PASS_JSON)
 
         monkeypatch.setattr(llm_backend, "_call_anthropic", _counter)
-        llm_backend.run_n(_semantic_rule(), tmp_path, 5)
+        llm_backend.run_n(_semantic_rule(), _target_with_artifact(tmp_path), 5)
         assert call_count["n"] == 5
 
 


### PR DESCRIPTION
Closes #172.

## Summary

- Parser-side enforcement of the v2 prompt's substring-grounding contract for `supporting_evidence_quotes`.
- After `_parse_llm_judgment` succeeds, every quote is checked against the resolved artifact text (file contents for path targets, literal string otherwise).
- Tolerance: whitespace runs collapsed, smart quotes / dashes folded to ASCII. No paraphrase tolerance.
- On any violation the diagnostic returns `status=unsupported` with `evidence[0].kind=llm_quote_fabrication`, preserving the model's claimed verdict + telemetry + the offending quotes. Operator-facing remediation tells the caller not to act on the verdict.
- This is option (A) from issue #172 (reject vs. graceful-degrade).
- `PROMPT_VERSION` unchanged (still `v2`). `tests/fixtures/semantic/baseline.json` unchanged — the fix is parser-only and well-behaved samples are not affected.

## Tests added

`TestQuoteFabricationDetection` in `tests/test_llm_rubric_backend.py` (10 cases):

- Fabricated quote → `Status.UNSUPPORTED` + `llm_quote_fabrication` evidence.
- Partial fabrication (one of two quotes invalid) also rejects.
- Well-behaved quote still produces a normal `llm_judgment` PASS.
- Whitespace normalisation (line wrapping in artifact, single-line in quote) tolerated.
- Smart-quote folding (curly apostrophe ↔ ASCII apostrophe) tolerated.
- Inline-string target (the dogfood `--target "<PR body>"` case) validates against the string itself.
- Empty / whitespace-only quote treated as fabricated.
- Direct unit tests for `_find_fabricated_quotes` and `_normalise_for_substring`.

Existing fixture stubs in `test_cli_bench.py`, `test_cli_validate.py`, `test_llm_rubric_backend.py` updated so canned PASS/FAIL responses cite quotes that are substrings of the test target — pre-existing test cases assert the same status they did on `main`.

## Validation

- `uv run pytest`: net-zero new failures vs. `main` in the local devcontainer (pre-existing 9–12 failures from this env's populated dotenv all reproduce; the new 10 fabrication tests all pass).
- `uvx ruff check .`: clean.
- `uvx ruff format --check .`: clean.

## Test plan

- [x] Unit tests cover fabricated, partially-fabricated, and well-behaved cases.
- [x] Whitespace and smart-quote tolerance verified.
- [x] Inline-string target (dogfood case) covered.
- [x] No prompt change (PROMPT_VERSION still `v2`); baseline.json untouched.
- [x] Lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)