### PR TITLE
feat(validator): deterministic target_kind mismatch precheck (#178)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -183,6 +183,7 @@ gate-keeper validate [--rules-format {markdown,ir}]
                      [--format {text,json}] [--verbose]
                      [--reproducibility N]
                      [--allow-command-adapter]
+                     [--artifact-kind {pr_description,commit_message,issue_body,documentation,code_change}]
                      --target <TARGET> [--target <TARGET> ...]
                      (<rules> | --include GLOB [--include GLOB ...])
 ```
@@ -203,6 +204,7 @@ Provide either a single positional `rules` document **or** one or more
 | `--verbose, -v` | flag | off | Expand structured LLM-rubric rationale (judgment, reason, evidence quotes, suggested action, model) as indented lines below each diagnostic. Has no effect for non-LLM backends. |
 | `--reproducibility N` | option | `1` | Run each LLM-rubric rule N times and record an agreement-rate `reproducibility_score` evidence entry. **No-op for non-LLM backends** (filesystem, GitHub, external ignore this flag). |
 | `--allow-command-adapter` | flag | off | Enable the project-local `command` external adapter for this run only. **Security: pass this only for rule documents you fully trust** — the adapter executes whatever `params.argv` the rule document defines. Without this flag, every `external_check` rule whose `params.tool == "command"` returns `unavailable` / `command_adapter_disabled` and no subprocess runs. See [Project-local `command` adapter (#149)](#project-local-command-adapter-149) below. |
+| `--artifact-kind {pr_description,commit_message,issue_body,documentation,code_change}` | option | — | Declare the kind of artifact passed via `--target` (#178). When set, every rule routed to the `llm-rubric` backend whose `target_kind` annotation differs from this value short-circuits to `unsupported` with `evidence.kind=target_kind_mismatch` (carrying `dispatch=deterministic_precheck` and `llm_called=false`) **before any provider call**. Rules with `target_kind=unspecified` ignore this flag (the prompt-level fallback still applies). Omit the flag to preserve the prior compatibility behaviour. See [Deterministic target_kind mismatch (#178)](#deterministic-target_kind-mismatch-178) below. |
 | `-h, --help` | flag | — | Show help and exit. |
 
 ### When to use `--rules-format ir`
@@ -392,6 +394,63 @@ of the resolved paths.
 
 See [docs/design/multi-target.md](design/multi-target.md) for the design
 background; this section documents the first implemented slice.
+
+### Deterministic target_kind mismatch (#178)
+
+The `--artifact-kind` flag declares the kind of artifact passed via
+`--target` so the validator can decide deterministically — before any
+LLM call — whether each rule's annotated `target_kind` applies. When a
+rule routed to the `llm-rubric` backend carries an explicit
+`target_kind` annotation that differs from `--artifact-kind`, the rule
+short-circuits to `unsupported` with a `target_kind_mismatch` evidence
+record:
+
+```json
+{
+  "kind": "target_kind_mismatch",
+  "data": {
+    "rule_target_kind": "pr_description",
+    "artifact_kind": "commit_message",
+    "dispatch": "deterministic_precheck",
+    "llm_called": false
+  }
+}
+```
+
+The `dispatch=deterministic_precheck` and `llm_called=false` markers
+distinguish this short-circuit from a model-returned `unsupported`
+verdict (which carries the same evidence kind plus provider telemetry).
+
+Vocabulary matches `TargetKind`: `pr_description`, `commit_message`,
+`issue_body`, `documentation`, `code_change`. `unspecified` is rejected
+by argparse — users who want the legacy prompt-level behaviour omit the
+flag entirely. Rules whose `target_kind` is `unspecified` are
+unaffected: they preserve the prompt-level fallback (the `llm-rubric`
+prompt still names the rule's annotated kind in the model's
+instructions for defence-in-depth, see `docs/llm-rubric.md`). Rules
+routed to non-LLM backends (filesystem, github, external) ignore this
+flag.
+
+Sample invocations:
+
+```sh
+# PR-description rule + PR body → reach the model normally.
+gate-keeper validate docs/dogfooding-rules.md \
+  --target "$(gh pr view 178 --json body --jq .body)" \
+  --artifact-kind pr_description
+
+# Commit-message rule + commit message → reach the model normally.
+gate-keeper validate docs/dogfooding-rules.md \
+  --target "$(git log -1 --format=%B)" \
+  --artifact-kind commit_message
+
+# Mismatch: PR-description rule + commit message → short-circuit, no
+# model call. The rule's diagnostic carries
+# evidence.kind = target_kind_mismatch.
+gate-keeper validate docs/dogfooding-rules.md \
+  --target "$(git log -1 --format=%B)" \
+  --artifact-kind pr_description
+```
 
 ### Project-local `command` adapter (#149)
 

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -29,6 +29,33 @@ A single rule may be promoted from advisory to required when **all** hold:
 Promotion is per-rule, not per-ruleset. Demotion is always allowed and does
 not require ceremony beyond an issue noting the trigger.
 
+## Artifact kind for self-gating runs (#178)
+
+When the dogfood loop validates a PR body or a commit message, it must
+pass `--artifact-kind` so rules whose `target_kind` annotation does not
+match the artifact short-circuit deterministically (`Status.UNSUPPORTED`
+with `evidence.kind=target_kind_mismatch`, `llm_called=false`) instead
+of routing through the LLM. Use `pr_description` for PR bodies and
+`commit_message` for commit messages:
+
+```sh
+# Validating a PR description.
+uv run gate-keeper validate docs/dogfooding-rules.md \
+  --target "$(gh pr view <N> --json body --jq .body)" \
+  --artifact-kind pr_description
+
+# Validating a commit message.
+uv run gate-keeper validate docs/dogfooding-rules.md \
+  --target "$(git log -1 --format=%B)" \
+  --artifact-kind commit_message
+```
+
+Rules whose `target_kind` is `unspecified` ignore the flag — only
+annotated rules participate in the deterministic dispatch. See
+[`cli-reference.md` — Deterministic target_kind mismatch
+(#178)](cli-reference.md#deterministic-target_kind-mismatch-178) for
+the evidence shape and full vocabulary.
+
 ## Issue hygiene
 
 Every false positive, false negative, or unclear failure observed during

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -8,10 +8,16 @@ from pathlib import Path
 
 from gate_keeper import __version__
 from gate_keeper.diagnostics import EXIT_OK, EXIT_USAGE
-from gate_keeper.models import Backend, RuleSet
+from gate_keeper.models import Backend, RuleSet, TargetKind
 
 # Backend choices exposed by the registry (always includes auto).
 _BACKEND_CHOICES = ["auto", "filesystem", "github", "llm-rubric", "external"]
+
+# ``--artifact-kind`` accepts every TargetKind value except ``unspecified``
+# (#178). Passing ``unspecified`` would be equivalent to omitting the flag,
+# so we reject it explicitly to make the CLI behaviour unambiguous — a user
+# who genuinely wants the legacy prompt-only behaviour omits the flag.
+_ARTIFACT_KIND_CHOICES = sorted(member.value for member in TargetKind if member is not TargetKind.UNSPECIFIED)
 
 
 class _IncludeError(Exception):
@@ -270,6 +276,20 @@ def build_parser() -> argparse.ArgumentParser:
             "enable the project-local 'command' external adapter for this run. "
             "WARNING: this lets the rule document execute arbitrary local commands "
             "(via params.argv). Pass this ONLY for rule documents you fully trust."
+        ),
+    )
+    validate_parser.add_argument(
+        "--artifact-kind",
+        dest="artifact_kind",
+        default=None,
+        choices=_ARTIFACT_KIND_CHOICES,
+        help=(
+            "declare the kind of artifact passed via --target (#178). "
+            "When set, llm-rubric rules whose `target_kind` annotation differs "
+            "from this value short-circuit to UNSUPPORTED with "
+            "`evidence.kind=target_kind_mismatch` BEFORE the model is called. "
+            "Rules with `target_kind=unspecified` ignore this flag. Omit the "
+            "flag to preserve the prompt-level behaviour."
         ),
     )
 
@@ -641,9 +661,25 @@ def _cmd_validate(args: argparse.Namespace) -> int:
 
     previous_enabled = command_adapter.is_enabled()
     command_adapter.set_enabled(bool(args.allow_command_adapter))
+    # Resolve --artifact-kind into a TargetKind enum value once, here, so the
+    # validator API stays typed (it accepts ``TargetKind | None``). argparse
+    # has already validated the raw value against ``_ARTIFACT_KIND_CHOICES``,
+    # so ``TargetKind(...)`` cannot raise — but if a future refactor widens
+    # the choices we'd want the error to surface cleanly rather than crash.
+    artifact_kind: TargetKind | None
+    if getattr(args, "artifact_kind", None) is None:
+        artifact_kind = None
+    else:
+        artifact_kind = TargetKind(args.artifact_kind)
     try:
         # Run validation.
-        report = validator.validate(ruleset, target, backend=backend, reproducibility=args.reproducibility)
+        report = validator.validate(
+            ruleset,
+            target,
+            backend=backend,
+            reproducibility=args.reproducibility,
+            artifact_kind=artifact_kind,
+        )
     finally:
         command_adapter.set_enabled(previous_enabled)
 

--- a/src/gate_keeper/validator.py
+++ b/src/gate_keeper/validator.py
@@ -38,6 +38,7 @@ from gate_keeper.models import (
     Rule,
     RuleSet,
     Status,
+    TargetKind,
 )
 from gate_keeper.targets import TargetSpec
 
@@ -132,11 +133,55 @@ def _run_n(
     )
 
 
+def _target_kind_mismatch_diagnostic(
+    rule: Rule,
+    artifact_kind: TargetKind,
+) -> Diagnostic:
+    """Synthesise an ``Status.UNSUPPORTED`` diagnostic for the deterministic
+    target-kind-mismatch precheck (#178).
+
+    The evidence carries ``dispatch=deterministic_precheck`` and
+    ``llm_called=false`` so callers can distinguish the deterministic
+    short-circuit from a model-returned ``unsupported`` (which surfaces as
+    ``target_kind_mismatch`` evidence with provider telemetry).
+    """
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=Backend.LLM_RUBRIC,
+        status=Status.UNSUPPORTED,
+        severity=rule.severity,
+        message=(
+            f"Rule annotated `target_kind: {rule.target_kind.value}` does not "
+            f"apply to artifact of kind `{artifact_kind.value}`; skipping "
+            "without invoking the LLM."
+        ),
+        evidence=[
+            Evidence(
+                kind="target_kind_mismatch",
+                data={
+                    "rule_target_kind": rule.target_kind.value,
+                    "artifact_kind": artifact_kind.value,
+                    "dispatch": "deterministic_precheck",
+                    "llm_called": False,
+                },
+            )
+        ],
+        remediation=(
+            "The rule's premise does not apply to this artifact kind. "
+            "Either evaluate the rule against an artifact whose kind "
+            f"matches its `target_kind` ({rule.target_kind.value}), or "
+            "remove / change the `target_kind` annotation on the rule."
+        ),
+    )
+
+
 def validate(
     ruleset: RuleSet,
     target: str | Path | TargetSpec,
     backend: str = "auto",
     reproducibility: int = 1,
+    artifact_kind: TargetKind | None = None,
 ) -> DiagnosticReport:
     """Validate *ruleset* against *target* using *backend*.
 
@@ -166,6 +211,20 @@ def validate(
         preserves the original behaviour. Values ``> 1`` apply only to rules
         dispatched to the ``llm-rubric`` backend; non-LLM backends ignore this
         parameter. Must be ``>= 1``.
+    artifact_kind:
+        Optional caller-declared :class:`TargetKind` for *target* (#178).
+        When supplied, every rule routed to the ``llm-rubric`` backend with
+        an explicit ``rule.target_kind`` annotation is checked
+        deterministically: if the rule's ``target_kind`` is set
+        (i.e. not :data:`TargetKind.UNSPECIFIED`) and differs from
+        *artifact_kind*, the rule is short-circuited to
+        :data:`Status.UNSUPPORTED` with ``evidence.kind=target_kind_mismatch``
+        (carrying ``dispatch=deterministic_precheck`` and
+        ``llm_called=false``) **without invoking the provider**. Rules whose
+        ``target_kind`` is ``unspecified`` are unaffected. Rules dispatched
+        to other backends (filesystem, github, external) ignore this
+        parameter. Default ``None`` preserves prior behaviour, including
+        the prompt-level fallback inside the llm-rubric backend.
 
     Returns
     -------
@@ -188,6 +247,22 @@ def validate(
     diagnostics: list[Diagnostic] = []
     for rule in ruleset.rules:
         resolved_name = _resolve_backend_name(rule, backend)
+
+        # #178 — deterministic target-kind-mismatch precheck. Applied only
+        # to rules routed to the llm-rubric backend that carry an explicit
+        # ``target_kind`` annotation (UNSPECIFIED rules preserve the
+        # prompt-level fallback). The check is performed here, before
+        # dispatch, so no provider call is made on mismatch — the test
+        # suite asserts this by counting calls into the stubbed provider.
+        if (
+            artifact_kind is not None
+            and resolved_name == "llm-rubric"
+            and rule.target_kind is not TargetKind.UNSPECIFIED
+            and rule.target_kind is not artifact_kind
+        ):
+            diagnostics.append(_target_kind_mismatch_diagnostic(rule, artifact_kind))
+            continue
+
         check_fn = _registry.get(resolved_name)
         if check_fn is None:
             # Defensive: name resolved from backend_hint is not registered.

--- a/tests/fixtures/ir/rule-llm-rubric-pr-description.json
+++ b/tests/fixtures/ir/rule-llm-rubric-pr-description.json
@@ -1,0 +1,19 @@
+{
+  "rules": [
+    {
+      "id": "pr-body-explains-motivation",
+      "title": "PR body explains motivation",
+      "source": {
+        "path": "docs/example-rules.md",
+        "line": 1
+      },
+      "text": "The pull-request body must explain why the change is needed.",
+      "kind": "semantic_rubric",
+      "severity": "warning",
+      "backend_hint": "llm-rubric",
+      "confidence": "medium",
+      "params": {},
+      "target_kind": "pr_description"
+    }
+  ]
+}

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -1632,3 +1632,144 @@ class TestGlobMetacharLiteralFallthrough:
                 f"resolution; got evidence {[ev['kind'] for ev in diag['evidence']]}"
             )
             assert summary["data"]["file_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# --artifact-kind (issue #178) — deterministic target_kind mismatch precheck
+# ---------------------------------------------------------------------------
+
+
+IR_LLM_PR_DESC_RULES = IR_FIXTURES / "rule-llm-rubric-pr-description.json"
+
+
+class TestArtifactKindFlag:
+    """End-to-end CLI tests for ``--artifact-kind``.
+
+    Uses a precompiled IR rule (``target_kind: pr_description``, llm-rubric
+    backend) so the test does not depend on the Markdown classifier or on
+    the model API. The deterministic short-circuit lives in the validator
+    layer; we assert the backend was never reached by inspecting the
+    rendered evidence shape (``dispatch=deterministic_precheck``,
+    ``llm_called=false``).
+    """
+
+    def test_mismatch_short_circuits_to_unsupported(self, capsys):
+        rc = main(
+            [
+                "validate",
+                "--rules-format",
+                "ir",
+                str(IR_LLM_PR_DESC_RULES),
+                "--target",
+                "fix(parser): handle CRLF\n\nbody",
+                "--artifact-kind",
+                "commit_message",
+                "--format",
+                "json",
+            ]
+        )
+        # UNSUPPORTED rules are advisory by default — exit code reflects
+        # the diagnostic policy. The behaviour we care about is the
+        # diagnostic shape, not the exit code, so assert on the JSON.
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert len(data["diagnostics"]) == 1
+        diag = data["diagnostics"][0]
+        assert diag["status"] == "unsupported"
+        assert diag["backend"] == "llm-rubric"
+        ev = diag["evidence"][0]
+        assert ev["kind"] == "target_kind_mismatch"
+        assert ev["data"]["rule_target_kind"] == "pr_description"
+        assert ev["data"]["artifact_kind"] == "commit_message"
+        assert ev["data"]["dispatch"] == "deterministic_precheck"
+        assert ev["data"]["llm_called"] is False
+        # Sanity: rc is a usage-clean exit (no argparse error).
+        assert rc != EXIT_USAGE
+
+    def test_match_does_not_short_circuit(self, capsys, monkeypatch):
+        """A matching --artifact-kind must let the rule reach the backend."""
+        from gate_keeper.backends import llm_rubric
+
+        # Force the backend to its unconfigured fallback (no model call).
+        monkeypatch.setattr(llm_rubric, "_load_env_file", lambda *a, **kw: {})
+        rc = main(
+            [
+                "validate",
+                "--rules-format",
+                "ir",
+                str(IR_LLM_PR_DESC_RULES),
+                "--target",
+                "PR body that explains the change",
+                "--artifact-kind",
+                "pr_description",
+                "--format",
+                "json",
+            ]
+        )
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        diag = data["diagnostics"][0]
+        # When kinds match, the rule reaches the backend. With no provider
+        # configured, the backend returns UNAVAILABLE — proving the
+        # precheck did NOT fire (which would have produced UNSUPPORTED).
+        assert diag["status"] == "unavailable"
+        assert diag["evidence"][0]["kind"] == "provider_unconfigured"
+        assert rc != EXIT_USAGE
+
+    def test_omitted_artifact_kind_preserves_compat(self, capsys, monkeypatch):
+        """No --artifact-kind → no precheck; reach the backend as before."""
+        from gate_keeper.backends import llm_rubric
+
+        monkeypatch.setattr(llm_rubric, "_load_env_file", lambda *a, **kw: {})
+        rc = main(
+            [
+                "validate",
+                "--rules-format",
+                "ir",
+                str(IR_LLM_PR_DESC_RULES),
+                "--target",
+                "any artifact text",
+                "--format",
+                "json",
+            ]
+        )
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        diag = data["diagnostics"][0]
+        assert diag["status"] == "unavailable"
+        assert diag["evidence"][0]["kind"] == "provider_unconfigured"
+        assert rc != EXIT_USAGE
+
+    def test_invalid_artifact_kind_exits_2(self, capsys):
+        """An unknown kind must be rejected by argparse (exit 2)."""
+        with pytest.raises(SystemExit) as excinfo:
+            main(
+                [
+                    "validate",
+                    "--rules-format",
+                    "ir",
+                    str(IR_LLM_PR_DESC_RULES),
+                    "--target",
+                    "x",
+                    "--artifact-kind",
+                    "not_a_kind",
+                ]
+            )
+        assert excinfo.value.code == EXIT_USAGE
+
+    def test_unspecified_rejected_by_argparse(self, capsys):
+        """``--artifact-kind unspecified`` is rejected — users omit the flag instead."""
+        with pytest.raises(SystemExit) as excinfo:
+            main(
+                [
+                    "validate",
+                    "--rules-format",
+                    "ir",
+                    str(IR_LLM_PR_DESC_RULES),
+                    "--target",
+                    "x",
+                    "--artifact-kind",
+                    "unspecified",
+                ]
+            )
+        assert excinfo.value.code == EXIT_USAGE

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -787,7 +787,7 @@ class TestRulesFormatIR:
 
         captured_rulesets: list[RuleSet] = []
 
-        def fake_validate(ruleset, target, *, backend, reproducibility):
+        def fake_validate(ruleset, target, *, backend, reproducibility, artifact_kind=None):
             captured_rulesets.append(ruleset)
             return DiagnosticReport(diagnostics=[])
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -276,3 +276,220 @@ class TestTargetSpecArgument:
         diag = report.diagnostics[0]
         assert diag.status is Status.UNSUPPORTED
         assert any(e.kind == "multi_target_unsupported" for e in diag.evidence)
+
+
+# ---------------------------------------------------------------------------
+# Deterministic target_kind mismatch precheck (#178)
+# ---------------------------------------------------------------------------
+
+
+def _semantic_rule(
+    target_kind=None,
+) -> Rule:
+    """Build a SEMANTIC_RUBRIC rule with an optional ``target_kind``."""
+    from gate_keeper.models import TargetKind
+
+    if target_kind is None:
+        target_kind = TargetKind.UNSPECIFIED
+    return Rule(
+        id="semantic-rule",
+        title="Semantic rule",
+        source=SourceLocation(path="rules.md", line=1),
+        text="rule text",
+        kind=RuleKind.SEMANTIC_RUBRIC,
+        severity=Severity.ERROR,
+        backend_hint=Backend.LLM_RUBRIC,
+        confidence=Confidence.HIGH,
+        params={},
+        target_kind=target_kind,
+    )
+
+
+class _CallCountingCheck:
+    """Test double for the registered ``llm-rubric`` check.
+
+    Counts invocations and returns a configurable diagnostic. The deterministic
+    precheck path must short-circuit *before* this stub is called, so an
+    invocation count of ``0`` is the assertion that the LLM was never invoked.
+    """
+
+    def __init__(self, status: Status = Status.PASS) -> None:
+        self.calls: list[tuple[Rule, object]] = []
+        self.status = status
+
+    def __call__(self, rule, target):
+        self.calls.append((rule, target))
+        return Diagnostic(
+            rule_id=rule.id,
+            source=rule.source,
+            backend=Backend.LLM_RUBRIC,
+            status=self.status,
+            severity=rule.severity,
+            message="stub: provider response",
+            evidence=[],
+        )
+
+
+class TestArtifactKindPrecheck:
+    """#178 — deterministic short-circuit before invoking llm-rubric.
+
+    These tests prove the dispatch is provider-independent by stubbing the
+    registry entry with a call counter and asserting the LLM is not invoked
+    on mismatch.
+    """
+
+    def test_pr_description_rule_with_commit_message_artifact_short_circuits(self, tmp_path, monkeypatch):
+        """rule.target_kind=pr_description + artifact_kind=commit_message →
+        UNSUPPORTED with target_kind_mismatch and no LLM call."""
+        from gate_keeper.models import TargetKind
+
+        stub = _CallCountingCheck()
+        monkeypatch.setitem(registry._REGISTRY, "llm-rubric", stub)
+        rule = _semantic_rule(TargetKind.PR_DESCRIPTION)
+        report = validate(
+            _make_ruleset(rule),
+            "any commit message text",
+            backend="auto",
+            artifact_kind=TargetKind.COMMIT_MESSAGE,
+        )
+        diag = report.diagnostics[0]
+        assert stub.calls == []  # Provider was NOT invoked.
+        assert diag.status is Status.UNSUPPORTED
+        assert diag.backend is Backend.LLM_RUBRIC
+        assert len(diag.evidence) == 1
+        ev = diag.evidence[0]
+        assert ev.kind == "target_kind_mismatch"
+        assert ev.data["rule_target_kind"] == "pr_description"
+        assert ev.data["artifact_kind"] == "commit_message"
+        assert ev.data["dispatch"] == "deterministic_precheck"
+        assert ev.data["llm_called"] is False
+
+    def test_matching_kinds_proceed_to_llm(self, tmp_path, monkeypatch):
+        """rule.target_kind=commit_message + artifact_kind=commit_message →
+        backend is invoked normally."""
+        from gate_keeper.models import TargetKind
+
+        stub = _CallCountingCheck(status=Status.PASS)
+        monkeypatch.setitem(registry._REGISTRY, "llm-rubric", stub)
+        rule = _semantic_rule(TargetKind.COMMIT_MESSAGE)
+        report = validate(
+            _make_ruleset(rule),
+            "subject\n\nbody",
+            backend="auto",
+            artifact_kind=TargetKind.COMMIT_MESSAGE,
+        )
+        diag = report.diagnostics[0]
+        assert len(stub.calls) == 1  # Provider WAS invoked.
+        assert diag.status is Status.PASS
+
+    def test_unspecified_rule_ignores_artifact_kind(self, tmp_path, monkeypatch):
+        """rule.target_kind=unspecified → artifact_kind has no effect."""
+        from gate_keeper.models import TargetKind
+
+        stub = _CallCountingCheck(status=Status.FAIL)
+        monkeypatch.setitem(registry._REGISTRY, "llm-rubric", stub)
+        rule = _semantic_rule(TargetKind.UNSPECIFIED)
+        report = validate(
+            _make_ruleset(rule),
+            "any artifact",
+            backend="auto",
+            artifact_kind=TargetKind.PR_DESCRIPTION,
+        )
+        # Even though artifact_kind != rule.target_kind formally, an
+        # UNSPECIFIED rule must preserve the prompt-level fallback path —
+        # the backend is invoked.
+        assert len(stub.calls) == 1
+        assert report.diagnostics[0].status is Status.FAIL
+
+    def test_omitted_artifact_kind_preserves_compat(self, tmp_path, monkeypatch):
+        """artifact_kind=None → no precheck, backend is invoked normally."""
+        from gate_keeper.models import TargetKind
+
+        stub = _CallCountingCheck(status=Status.PASS)
+        monkeypatch.setitem(registry._REGISTRY, "llm-rubric", stub)
+        rule = _semantic_rule(TargetKind.PR_DESCRIPTION)
+        # Note: a *mismatch* would only be visible to a provider; with
+        # artifact_kind=None the validator forwards the rule unchanged so
+        # the prompt-level v4 fallback is responsible for declining.
+        report = validate(
+            _make_ruleset(rule),
+            "commit message text",
+            backend="auto",
+            artifact_kind=None,
+        )
+        assert len(stub.calls) == 1
+        assert report.diagnostics[0].status is Status.PASS
+
+    def test_precheck_provider_independent(self, tmp_path, monkeypatch):
+        """Mismatch path produces the same diagnostic regardless of which
+        provider would have been called — proven by registering a stub that
+        raises on invocation."""
+        from gate_keeper.models import TargetKind
+
+        def _raises(rule, target):
+            raise AssertionError("Provider must NOT be invoked on deterministic mismatch")
+
+        monkeypatch.setitem(registry._REGISTRY, "llm-rubric", _raises)
+        rule = _semantic_rule(TargetKind.PR_DESCRIPTION)
+        report = validate(
+            _make_ruleset(rule),
+            "any commit message",
+            backend="auto",
+            artifact_kind=TargetKind.COMMIT_MESSAGE,
+        )
+        diag = report.diagnostics[0]
+        assert diag.status is Status.UNSUPPORTED
+        assert diag.evidence[0].kind == "target_kind_mismatch"
+        assert diag.evidence[0].data["llm_called"] is False
+
+    def test_precheck_skipped_for_non_llm_rules(self, tmp_path, monkeypatch):
+        """Non-LLM rules (filesystem, github, external) are unaffected by
+        artifact_kind — they receive the target as before."""
+        from gate_keeper.models import TargetKind
+
+        # Fixture file so the filesystem backend has something to evaluate.
+        fixture = tmp_path / "README.md"
+        fixture.write_text("# README\n")
+        rule = Rule(
+            id="fs-rule",
+            title="fs",
+            source=SourceLocation(path="rules.md", line=1),
+            text="README must exist",
+            kind=RuleKind.FILE_EXISTS,
+            severity=Severity.ERROR,
+            backend_hint=Backend.FILESYSTEM,
+            confidence=Confidence.HIGH,
+            params={"path": "README.md"},
+            # Annotations on a filesystem rule are non-binding for routing.
+            target_kind=TargetKind.PR_DESCRIPTION,
+        )
+        report = validate(
+            _make_ruleset(rule),
+            tmp_path,
+            backend="auto",
+            artifact_kind=TargetKind.COMMIT_MESSAGE,
+        )
+        # Filesystem rule is unaffected: it routed to filesystem and PASSed.
+        diag = report.diagnostics[0]
+        assert diag.backend is Backend.FILESYSTEM
+        assert diag.status is Status.PASS
+
+    def test_precheck_diagnostic_round_trips(self, tmp_path, monkeypatch):
+        """Synthesised diagnostic round-trips through Diagnostic.to_dict /
+        from_dict so JSON renderers stay byte-faithful."""
+        from gate_keeper.models import TargetKind
+
+        stub = _CallCountingCheck()
+        monkeypatch.setitem(registry._REGISTRY, "llm-rubric", stub)
+        rule = _semantic_rule(TargetKind.PR_DESCRIPTION)
+        report = validate(
+            _make_ruleset(rule),
+            "anything",
+            backend="auto",
+            artifact_kind=TargetKind.COMMIT_MESSAGE,
+        )
+        diag = report.diagnostics[0]
+        rebuilt = Diagnostic.from_dict(diag.to_dict())
+        assert rebuilt.status is Status.UNSUPPORTED
+        assert rebuilt.evidence[0].data["dispatch"] == "deterministic_precheck"
+        assert rebuilt.evidence[0].data["llm_called"] is False


### PR DESCRIPTION
## Summary

- Add `--artifact-kind {pr_description,commit_message,issue_body,documentation,code_change}` to `gate-keeper validate`.
- In the validator, before dispatch to `llm-rubric`, short-circuit any rule whose `target_kind` annotation differs from the declared `artifact_kind` to `Status.UNSUPPORTED` with `evidence.kind=target_kind_mismatch`, `dispatch=deterministic_precheck`, `llm_called=false`. **No provider call is made on mismatch.**
- `target_kind=unspecified` rules ignore the flag (the prompt-level v4 fallback from #169 / #175 still applies). Non-LLM backends are untouched. Omitting the flag preserves prior compatibility behaviour.

## Why

The dogfood loop (umbrella #164) knows whether it is validating a PR body or a commit message. v3/v4 prompt iterations (#169, #175) tried to teach the model to recognise `target_kind` mismatches, but observed dogfood evidence shows gpt-4o-mini still misroutes both directions — including under v4. Applicability of a rule to an artifact is metadata, not semantic reasoning, so this turns the dispatch into a deterministic gate.

## What changed

- `src/gate_keeper/validator.py` — `validate(..., artifact_kind: TargetKind | None = None)`. Added per-rule precheck loop before backend dispatch, plus a `_target_kind_mismatch_diagnostic` helper. Existing behaviour preserved when `artifact_kind is None`.
- `src/gate_keeper/cli.py` — `--artifact-kind` argparse option (vocabulary = `TargetKind` minus `unspecified`; choices enforced at parse time).
- `docs/cli-reference.md` — synopsis, options table row, and a new "Deterministic target_kind mismatch (#178)" subsection covering evidence shape, vocabulary, and sample invocations.
- `docs/dogfooding.md` — guidance to pass `pr_description` / `commit_message` for self-gating runs.
- `tests/test_validator.py` — 7 new tests in `TestArtifactKindPrecheck` (mismatch, match, unspecified rule, omitted flag, provider-independence via raise-on-call stub, non-LLM rule unaffected, diagnostic round-trip).
- `tests/test_cli_validate.py` — 5 new tests in `TestArtifactKindFlag` covering CLI wiring (mismatch JSON shape, match path, omitted flag, invalid value, `unspecified` rejected by argparse).
- `tests/fixtures/ir/rule-llm-rubric-pr-description.json` — IR fixture for an annotated llm-rubric rule (used by the CLI tests).

## Validation

- `uv run pytest tests/test_validator.py::TestArtifactKindPrecheck tests/test_cli_validate.py::TestArtifactKindFlag` → **12 passed**.
- `uv run pyright src/gate_keeper/cli.py src/gate_keeper/validator.py tests/test_validator.py tests/test_cli_validate.py` → **0 errors**.
- `uvx ruff check . && uvx ruff format --check .` → clean.
- Manual end-to-end: mismatch run produces `target_kind_mismatch` evidence with `llm_called=false` and no provider call; match run reaches the model normally.

## Test plan

- [x] CI green on this PR.
- [x] `--artifact-kind pr_description` against a commit-message target on a PR-description rule short-circuits without a provider call (verified locally).
- [x] Matching kinds reach the model (or `provider_unconfigured`) — verified by tests.
- [x] `target_kind=unspecified` rules unaffected — verified by tests.
- [x] Omitting the flag preserves prior behaviour — verified by tests.

Closes #178. Refs umbrella #164, prior iterations #169 / #175.
