### PR TITLE
feat(llm-rubric): span-based evidence offsets for supporting quotes (#179)

### DIFF
--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -241,13 +241,98 @@ strip-and-flag offending quotes. The user-visible signal "this verdict
 came from a model that ignored the substring contract" is more valuable
 than a verdict whose grounding has been silently degraded.
 
+### Span-based evidence offsets (#179)
+
+After the substring-grounding validator accepts the model's quotes, the
+backend additionally resolves each validated quote to a span pointing into
+the **original** artifact text. Spans surface as a parallel list under
+`evidence[0].data.supporting_evidence_spans` on every successful
+`llm_judgment` evidence record. The pre-existing
+`supporting_evidence_quotes` field is preserved verbatim — spans are
+**additive**, not a replacement.
+
+A span has the following shape:
+
+```json
+{
+  "quote": "<the model's raw quote string, verbatim>",
+  "artifact_index": 0,
+  "start_offset": 142,
+  "end_offset": 181,
+  "start_line": 8,
+  "start_column": 3,
+  "end_line": 8,
+  "end_column": 42,
+  "match_normalisation": "exact" | "smart_quotes" | "whitespace"
+}
+```
+
+- **Character offsets** (`start_offset`, `end_offset`) — Python `str`
+  indices into the artifact text the model was shown (the same string the
+  fabrication validator runs against; see "Parser-side substring
+  grounding"). Half-open: `artifact_text[start_offset:end_offset]` slices
+  the matched substring out of the **original** artifact, even when the
+  match required normalisation. Byte offsets are not emitted; the artifact
+  is held as a Python `str` and recovering bytes would require nailing an
+  encoding for no extra evidence.
+- **1-indexed line / column** (`start_line`, `start_column`, `end_line`,
+  `end_column`) — for human-friendly rendering. Lines and columns are
+  1-indexed; columns count Unicode code points within the line. End
+  position is one past the last matched character (matching the half-open
+  convention of `end_offset`).
+- **`artifact_index: 0`** — reserved for the multi-artifact follow-up
+  (#182). Single-artifact callers can ignore it; including it now keeps
+  the wire format forward-compatible.
+- **`match_normalisation`** — records which tolerance the resolver had
+  to apply. `"exact"` means the quote was found verbatim; `"smart_quotes"`
+  means the curly-quote / dash folding (see `_QUOTE_FOLDING`) was needed;
+  `"whitespace"` means whitespace-run collapsing was needed (typically a
+  line-wrapped quote in the artifact rendered as one line by the model).
+  The resolver records the **weakest** normalisation that succeeded — an
+  exact match always wins over a smart-quote match, and a smart-quote
+  match always wins over a whitespace-collapse match.
+- **`quote`** — the model's raw quote string, preserved verbatim so a
+  consumer can correlate `supporting_evidence_spans[i]` with
+  `supporting_evidence_quotes[i]` even when the in-artifact text differs
+  (e.g. a smart-quote-folded match where the original artifact carries
+  curly punctuation).
+
+#### Duplicate quote handling
+
+If a quote occurs multiple times in the artifact, the span points to the
+**first match**. This is the simplest deterministic default and the one
+humans usually want when asking "where did the model find this quote?".
+A future iteration may add an "ambiguity flag" or all-matches list, but
+the first-match contract is stable for the current evidence shape.
+
+#### Fabricated quotes do not get spans
+
+Quote fabrication still produces an `llm_quote_fabrication` diagnostic
+(see "Parser-side substring grounding" above) — by definition, a
+fabricated quote has no in-artifact location. The fabrication evidence
+record carries the standard quote / telemetry fields and **does not**
+include a `supporting_evidence_spans` field. Consumers that branch on
+`evidence[0].kind == "llm_judgment"` get spans; consumers that branch
+on `evidence[0].kind == "llm_quote_fabrication"` do not.
+
+#### Compatibility
+
+`supporting_evidence_quotes` remains the stable, authoritative
+compatibility surface. A consumer that ignores
+`supporting_evidence_spans` keeps working unchanged. A consumer that
+needs location-aware rendering reads the spans list. If the resolver
+fails to locate a validated quote (a guard against future drift between
+the validator and the resolver), that quote is silently omitted from the
+span list — the quote remains in `supporting_evidence_quotes`, so no
+information is lost; only the optional location annotation is missing.
+
 ### Successful diagnostic shape
 
 When a provider responds successfully, the diagnostic carries:
 
 - `status`: `pass` or `fail`.
 - `message`: the `primary_reason` from the structured judgment.
-- `evidence[0]`: `{ kind: "llm_judgment", data: { model, prompt_version, judgment, primary_reason, supporting_evidence_quotes, suggested_action, latency_ms, tokens_in, tokens_out, cost_estimate_usd } }`.
+- `evidence[0]`: `{ kind: "llm_judgment", data: { model, prompt_version, judgment, primary_reason, supporting_evidence_quotes, supporting_evidence_spans, suggested_action, latency_ms, tokens_in, tokens_out, cost_estimate_usd } }`.
 - `remediation`: set to `suggested_action` when `status=fail`; `null` on `pass`.
 
 ### Per-rule observability fields

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -815,6 +815,290 @@ def _find_fabricated_quotes(quotes: list[str], artifact_text: str) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Span resolution for validated quotes (#179)
+#
+# Once ``_find_fabricated_quotes`` confirms every quote is a normalised
+# substring of the artifact, ``_resolve_quote_spans`` locates the **first
+# match** of each quote inside the original (un-normalised) artifact text and
+# returns deterministic span metadata: character offsets and 1-indexed
+# line / column ranges, plus a ``match_normalisation`` tag identifying which
+# tolerance step was needed (``"exact"`` / ``"whitespace"`` /
+# ``"smart_quotes"``).
+#
+# Design choices:
+#
+# - **Character offsets, not byte offsets.** Python strings index by code
+#   point and the artifact_text we receive is already a ``str``; computing
+#   byte offsets would require nailing an encoding (UTF-8 by convention) and
+#   re-encoding for every match, with no extra information for the consumer.
+#   Line / column are computed alongside for human-friendly rendering.
+#
+# - **First match wins on duplicates.** If the same quote appears N times in
+#   the artifact, the span points to the first occurrence. This is the
+#   simplest deterministic default and the one humans usually want when
+#   asking "where did the model find this quote?". Documented in
+#   ``docs/llm-rubric.md``.
+#
+# - **Normalisation-aware fallback.** ``str.find`` is tried first against
+#   the raw text (``match_normalisation: "exact"``); if that misses, a
+#   smart-quote-folded copy is searched (``"smart_quotes"``); if that still
+#   misses, the artifact's whitespace is collapsed and a regex over the
+#   collapsed-whitespace artifact locates the run, with the offsets mapped
+#   back to the original text (``"whitespace"``). The fabrication validator
+#   in ``_find_fabricated_quotes`` already accepts this composite tolerance,
+#   so any quote that passed validation is guaranteed to resolve to a span.
+#
+# - **Single-artifact ``artifact_index: 0``.** Included so the field stays
+#   meaningful when multi-artifact attribution arrives in a follow-up
+#   (#182 / multi-target semantic context). Single-artifact callers can
+#   ignore it without confusion.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class QuoteSpan:
+    """Span metadata for one validated supporting quote (#179).
+
+    Fields
+    ------
+    quote:
+        The quote string as the model returned it. Preserved verbatim so a
+        consumer can correlate ``supporting_evidence_spans[i]`` with
+        ``supporting_evidence_quotes[i]`` even when the in-artifact text
+        differs (e.g. smart-quote folding).
+    artifact_index:
+        Index of the artifact this span points into. Always ``0`` in the
+        first slice (single-artifact); reserved so future multi-artifact
+        evidence attribution does not break the wire format.
+    start_offset, end_offset:
+        Character offsets (Python ``str`` indices) into the artifact text.
+        Half-open: ``artifact_text[start_offset:end_offset]`` is the
+        matched substring in the **original** artifact text — even when
+        ``match_normalisation`` is ``"whitespace"`` or ``"smart_quotes"``.
+    start_line, end_line:
+        1-indexed line numbers of the start and end positions. ``end_line``
+        is the line containing the last matched character (inclusive).
+    start_column, end_column:
+        1-indexed column numbers (Unicode code-points within the line).
+        ``end_column`` is one past the last matched character (so an empty
+        match would have ``start_column == end_column``); this matches the
+        half-open-interval convention used for ``end_offset``.
+    match_normalisation:
+        ``"exact"`` if the quote was found verbatim, ``"smart_quotes"`` if
+        smart-quote folding was needed, ``"whitespace"`` if collapsing
+        whitespace runs was needed. The tag records the **weakest**
+        normalisation the resolver had to apply: an exact match always
+        wins over a smart-quote match, and a smart-quote match always wins
+        over a whitespace-collapse match.
+    """
+
+    quote: str
+    artifact_index: int
+    start_offset: int
+    end_offset: int
+    start_line: int
+    start_column: int
+    end_line: int
+    end_column: int
+    match_normalisation: Literal["exact", "smart_quotes", "whitespace"]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "quote": self.quote,
+            "artifact_index": self.artifact_index,
+            "start_offset": self.start_offset,
+            "end_offset": self.end_offset,
+            "start_line": self.start_line,
+            "start_column": self.start_column,
+            "end_line": self.end_line,
+            "end_column": self.end_column,
+            "match_normalisation": self.match_normalisation,
+        }
+
+
+def _line_col_from_offset(text: str, offset: int) -> tuple[int, int]:
+    """Return the 1-indexed (line, column) for *offset* in *text*.
+
+    ``offset`` is clamped into ``[0, len(text)]`` so callers can pass
+    ``end_offset`` (which may equal ``len(text)`` for a trailing match) without
+    branching. Lines are 1-indexed; columns are 1-indexed within the line and
+    counted in Python ``str`` code points.
+    """
+    if offset < 0:
+        offset = 0
+    if offset > len(text):
+        offset = len(text)
+    # Number of newlines before *offset* gives the 0-indexed line; +1 makes it
+    # 1-indexed. Column = offset minus the position just after the last
+    # preceding newline (or 0 if none), then +1 for 1-indexing.
+    last_newline = text.rfind("\n", 0, offset)
+    line = text.count("\n", 0, offset) + 1
+    column = offset - (last_newline + 1) + 1
+    return line, column
+
+
+def _resolve_quote_span_in(artifact_text: str, quote: str) -> QuoteSpan | None:
+    """Return the first-match span for *quote* in *artifact_text*, or ``None``.
+
+    Tries three strategies in escalating tolerance order, recording the
+    weakest one that succeeded as ``match_normalisation``:
+
+    1. **Exact** substring search via ``str.find`` against the raw
+       artifact text.
+    2. **Smart-quote folded** search: fold both artifact and quote through
+       ``_QUOTE_FOLDING`` (preserving character count — every entry in the
+       table maps to a single ASCII character), then run ``str.find`` on
+       the folded artifact. Offsets in the folded form coincide with
+       offsets in the original because folding is character-for-character.
+    3. **Whitespace-collapsed** search: collapse each whitespace run in the
+       artifact to a single space, build an offset-mapping array from
+       collapsed-form indices back to original-form indices, then locate
+       the (smart-quote-folded, whitespace-collapsed) quote inside the
+       (smart-quote-folded, whitespace-collapsed) artifact via regex. The
+       returned offsets point into the **original** artifact text, so
+       ``artifact_text[start_offset:end_offset]`` always slices something
+       meaningful.
+
+    Returns ``None`` only if the quote does not match under any of the
+    three strategies. ``_find_fabricated_quotes`` already enforces the
+    composite tolerance so a quote that passed validation always resolves.
+    """
+    if not isinstance(quote, str) or not quote:
+        return None
+
+    # Strategy 1: exact match in the raw artifact.
+    idx = artifact_text.find(quote)
+    if idx >= 0:
+        start_line, start_column = _line_col_from_offset(artifact_text, idx)
+        end_line, end_column = _line_col_from_offset(artifact_text, idx + len(quote))
+        return QuoteSpan(
+            quote=quote,
+            artifact_index=0,
+            start_offset=idx,
+            end_offset=idx + len(quote),
+            start_line=start_line,
+            start_column=start_column,
+            end_line=end_line,
+            end_column=end_column,
+            match_normalisation="exact",
+        )
+
+    # Strategy 2: smart-quote folded match. The folding table maps each
+    # character to exactly one character, so str.find offsets in the folded
+    # artifact correspond byte-for-byte to offsets in the original.
+    folded_artifact = artifact_text.translate(_QUOTE_FOLDING)
+    folded_quote = quote.translate(_QUOTE_FOLDING)
+    if folded_artifact != artifact_text or folded_quote != quote:
+        idx = folded_artifact.find(folded_quote)
+        if idx >= 0:
+            start_line, start_column = _line_col_from_offset(artifact_text, idx)
+            end_line, end_column = _line_col_from_offset(artifact_text, idx + len(folded_quote))
+            return QuoteSpan(
+                quote=quote,
+                artifact_index=0,
+                start_offset=idx,
+                end_offset=idx + len(folded_quote),
+                start_line=start_line,
+                start_column=start_column,
+                end_line=end_line,
+                end_column=end_column,
+                match_normalisation="smart_quotes",
+            )
+
+    # Strategy 3: whitespace-collapsed match. We build a parallel index map
+    # so collapsed-form offsets translate back to original-form offsets.
+    # The mapping uses the smart-quote-folded artifact so quotes that need
+    # both normalisations also resolve.
+    collapsed_chars: list[str] = []
+    collapsed_to_original: list[int] = []
+    in_ws_run = False
+    ws_run_start = -1
+    for i, ch in enumerate(folded_artifact):
+        if ch.isspace():
+            if not in_ws_run:
+                in_ws_run = True
+                ws_run_start = i
+                collapsed_chars.append(" ")
+                collapsed_to_original.append(i)
+        else:
+            in_ws_run = False
+            ws_run_start = -1
+            collapsed_chars.append(ch)
+            collapsed_to_original.append(i)
+    del ws_run_start  # only used as a sentinel above
+    collapsed_artifact = "".join(collapsed_chars)
+    collapsed_quote = re.sub(r"\s+", " ", folded_quote).strip()
+    if not collapsed_quote:
+        return None
+
+    # Locate within the collapsed string. We use str.find on the stripped
+    # collapsed_artifact-equivalent: leading/trailing whitespace in the
+    # collapsed form does not change the quote's offset since str.find
+    # already skips past it; but we must be careful — the collapsed quote
+    # is stripped, while the collapsed_artifact retains leading whitespace.
+    # str.find naturally skips leading whitespace runs because they don't
+    # match the stripped quote, so this is correct.
+    cidx = collapsed_artifact.find(collapsed_quote)
+    if cidx < 0:
+        return None
+    cend = cidx + len(collapsed_quote)
+    start_offset = collapsed_to_original[cidx]
+    # End offset is one past the last matched character in the original.
+    # The last collapsed-form index is cend - 1 → maps to one original char.
+    # If that char is part of a whitespace run, the run in the original may
+    # be longer; advance to one past the run-original character.
+    if cend - 1 < len(collapsed_to_original):
+        last_original = collapsed_to_original[cend - 1]
+        # Determine whether the last collapsed character is a whitespace
+        # run representative; if so, end_offset is the original index of
+        # the next non-whitespace character (i.e. one past the whitespace
+        # run). For a non-whitespace last character, end_offset is one
+        # past last_original.
+        if folded_artifact[last_original].isspace():
+            end_offset = last_original + 1
+            while end_offset < len(folded_artifact) and folded_artifact[end_offset].isspace():
+                end_offset += 1
+        else:
+            end_offset = last_original + 1
+    else:  # pragma: no cover — defensive; cidx<len means cend-1<len.
+        end_offset = len(artifact_text)
+
+    start_line, start_column = _line_col_from_offset(artifact_text, start_offset)
+    end_line, end_column = _line_col_from_offset(artifact_text, end_offset)
+    return QuoteSpan(
+        quote=quote,
+        artifact_index=0,
+        start_offset=start_offset,
+        end_offset=end_offset,
+        start_line=start_line,
+        start_column=start_column,
+        end_line=end_line,
+        end_column=end_column,
+        match_normalisation="whitespace",
+    )
+
+
+def _resolve_quote_spans(quotes: list[str], artifact_text: str) -> list[QuoteSpan]:
+    """Return ``QuoteSpan`` for every quote in *quotes* (#179).
+
+    Precondition: every quote in *quotes* has already passed
+    ``_find_fabricated_quotes`` and is known to be a normalised substring of
+    *artifact_text*. Quotes that nevertheless fail to resolve (a guard
+    against future drift between the validator and the resolver) are
+    silently skipped — the caller still has ``supporting_evidence_quotes``
+    as the stable, span-free record. Skipping rather than raising preserves
+    the "spans are additive, quotes remain authoritative" invariant from
+    #179's compatibility design.
+    """
+    spans: list[QuoteSpan] = []
+    for quote in quotes:
+        span = _resolve_quote_span_in(artifact_text, quote)
+        if span is not None:
+            spans.append(span)
+    return spans
+
+
+# ---------------------------------------------------------------------------
 # Diagnostic constructors — #51 contract preserved byte-for-byte
 # ---------------------------------------------------------------------------
 
@@ -1086,6 +1370,12 @@ def check(rule: Rule, target: str | Path | TargetSpec) -> Diagnostic:
 
     status = Status.PASS if parsed.judgment == "pass" else Status.FAIL
     cost = _estimate_cost(model, telemetry["tokens_in"], telemetry["tokens_out"])
+    # #179 — once the fabrication validator has confirmed every quote is a
+    # normalised substring of the artifact, resolve each to a span pointing
+    # back into the original artifact text. Spans are additive: the
+    # ``supporting_evidence_quotes`` field remains the stable compatibility
+    # surface, ``supporting_evidence_spans`` is the new offset-bearing field.
+    spans = _resolve_quote_spans(parsed.supporting_evidence_quotes, artifact_text)
     evidence = Evidence(
         kind="llm_judgment",
         data={
@@ -1094,6 +1384,7 @@ def check(rule: Rule, target: str | Path | TargetSpec) -> Diagnostic:
             "judgment": parsed.judgment,
             "primary_reason": parsed.primary_reason,
             "supporting_evidence_quotes": parsed.supporting_evidence_quotes,
+            "supporting_evidence_spans": [span.to_dict() for span in spans],
             "suggested_action": parsed.suggested_action,
             "latency_ms": telemetry["latency_ms"],
             "tokens_in": telemetry["tokens_in"],

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -1286,6 +1286,360 @@ class TestQuoteFabricationDetection:
 
 
 # ---------------------------------------------------------------------------
+# Span resolution for validated quotes (#179)
+# ---------------------------------------------------------------------------
+
+
+class TestQuoteSpanResolution:
+    """#179 — span metadata for validated supporting quotes.
+
+    Once :func:`_find_fabricated_quotes` confirms a quote is a normalised
+    substring of the artifact, :func:`_resolve_quote_span_in` locates the
+    first match inside the original artifact text and returns deterministic
+    span metadata: character offsets and 1-indexed line/column ranges, plus
+    a ``match_normalisation`` tag identifying which tolerance was needed.
+
+    These unit tests exercise the resolver directly so a future refactor
+    that changes how spans are wired into ``check()`` can leave the span
+    semantics covered without depending on the provider-dispatch fixtures.
+    """
+
+    def test_exact_match_first_line(self):
+        artifact = "alpha beta gamma\ndelta epsilon"
+        span = llm_backend._resolve_quote_span_in(artifact, "alpha beta")
+        assert span is not None
+        assert span.match_normalisation == "exact"
+        assert span.artifact_index == 0
+        assert span.start_offset == 0
+        assert span.end_offset == 10
+        assert span.start_line == 1
+        assert span.start_column == 1
+        assert span.end_line == 1
+        # 1-indexed half-open: column one past the last matched character.
+        assert span.end_column == 11
+        # Slicing the original artifact by these offsets yields the quote.
+        assert artifact[span.start_offset : span.end_offset] == "alpha beta"
+
+    def test_exact_match_second_line_spanning_no_newline(self):
+        artifact = "first line\nsecond line\n"
+        span = llm_backend._resolve_quote_span_in(artifact, "second line")
+        assert span is not None
+        assert span.match_normalisation == "exact"
+        assert span.start_offset == artifact.index("second line")
+        assert span.start_line == 2
+        assert span.start_column == 1
+        assert span.end_line == 2
+        assert span.end_column == 12
+
+    def test_exact_match_spanning_newline(self):
+        # A multi-line quote: end_line is one greater than start_line.
+        artifact = "line one\nline two\nline three"
+        quote = "one\nline two"
+        span = llm_backend._resolve_quote_span_in(artifact, quote)
+        assert span is not None
+        assert span.match_normalisation == "exact"
+        assert span.start_line == 1
+        assert span.end_line == 2
+        # Slicing reproduces the multi-line quote.
+        assert artifact[span.start_offset : span.end_offset] == quote
+
+    def test_whitespace_normalised_match(self):
+        # Artifact line-wraps the phrase; quote arrives as one line. The
+        # resolver must locate the run in the original (line-wrapped) text
+        # and tag the span as whitespace-normalised.
+        artifact = "The PR description names\nthe user-visible change in the\nfirst sentence."
+        quote = "The PR description names the user-visible change in the first sentence."
+        span = llm_backend._resolve_quote_span_in(artifact, quote)
+        assert span is not None
+        assert span.match_normalisation == "whitespace"
+        # The span points back into the **original** artifact: slicing it
+        # yields the line-wrapped phrase, not the collapsed quote.
+        assert artifact[span.start_offset : span.end_offset].replace("\n", " ") == quote
+        assert span.start_line == 1
+        assert span.start_column == 1
+        assert span.end_line == 3
+        # 1-indexed half-open column at end of "first sentence."
+        assert span.end_column == len("first sentence.") + 1
+
+    def test_smart_quote_normalised_match(self):
+        # Artifact has curly apostrophe; quote arrives as ASCII.
+        artifact = "It’s the body that matters, not the subject line."
+        quote = "It's the body that matters, not the subject line."
+        span = llm_backend._resolve_quote_span_in(artifact, quote)
+        assert span is not None
+        assert span.match_normalisation == "smart_quotes"
+        # Slicing the original yields the curly-quote form (not the ASCII
+        # form the model returned). This is intentional — the span points
+        # into the original artifact text.
+        assert artifact[span.start_offset : span.end_offset] == artifact
+        assert span.start_line == 1
+
+    def test_duplicate_quote_first_match_wins(self):
+        artifact = "echo line.\nMiddle filler.\necho line."
+        span = llm_backend._resolve_quote_span_in(artifact, "echo line.")
+        assert span is not None
+        assert span.match_normalisation == "exact"
+        # First match — line 1, not line 3.
+        assert span.start_offset == 0
+        assert span.start_line == 1
+
+    def test_no_match_returns_none(self):
+        artifact = "Real artifact body here."
+        # Substring not present even after normalisation — model fabrication.
+        span = llm_backend._resolve_quote_span_in(artifact, "completely unrelated")
+        assert span is None
+
+    def test_empty_quote_returns_none(self):
+        # Defence in depth: the fabrication validator already rejects empty
+        # quotes, but the resolver must also be safe to call on them.
+        assert llm_backend._resolve_quote_span_in("any text", "") is None
+
+    def test_resolve_quote_spans_skips_unresolvable_silently(self):
+        # If a quote slips past the validator but cannot be located, it is
+        # silently dropped from the span list — supporting_evidence_quotes
+        # remains the authoritative compatibility surface.
+        artifact = "alpha beta"
+        spans = llm_backend._resolve_quote_spans(["alpha", "missing"], artifact)
+        assert [s.quote for s in spans] == ["alpha"]
+
+    def test_resolve_quote_spans_preserves_quote_string_verbatim(self):
+        # span.quote is the model's raw quote, not the in-artifact form,
+        # so a consumer can correlate spans[i] with quotes[i] across
+        # smart-quote folding.
+        artifact = "It’s here."
+        spans = llm_backend._resolve_quote_spans(["It's here."], artifact)
+        assert len(spans) == 1
+        assert spans[0].quote == "It's here."
+        assert spans[0].match_normalisation == "smart_quotes"
+
+    def test_to_dict_returns_documented_keys(self):
+        span = llm_backend._resolve_quote_span_in("alpha beta", "alpha")
+        assert span is not None
+        d = span.to_dict()
+        # Documented contract: every span dict carries these nine keys
+        # (and no others). Consumers may rely on this shape.
+        assert set(d.keys()) == {
+            "quote",
+            "artifact_index",
+            "start_offset",
+            "end_offset",
+            "start_line",
+            "start_column",
+            "end_line",
+            "end_column",
+            "match_normalisation",
+        }
+
+    def test_line_col_helper_clamps_offset(self):
+        # Defence in depth: callers may pass end_offset == len(text) for a
+        # trailing match; the helper must not raise.
+        line, col = llm_backend._line_col_from_offset("abc", 3)
+        assert line == 1
+        assert col == 4
+        # Negative clamps to (1, 1).
+        line, col = llm_backend._line_col_from_offset("abc", -1)
+        assert line == 1
+        assert col == 1
+
+
+class TestQuoteSpansInEvidence:
+    """#179 — supporting_evidence_spans surfaces alongside quotes in evidence.
+
+    The success path of :func:`check` must attach a ``supporting_evidence_spans``
+    list to every ``llm_judgment`` evidence entry. The pre-existing
+    ``supporting_evidence_quotes`` field must remain untouched (additive
+    extension, not replacement). Quote fabrication still produces
+    ``llm_quote_fabrication`` and does not attach spans.
+    """
+
+    _ENV = {
+        "GATE_KEEPER_LLM_PROVIDER": "openai",
+        "OPENAI_API_KEY": "sk-openai-test",
+    }
+
+    def test_pass_evidence_carries_spans(self, monkeypatch):
+        _patch_env(monkeypatch, self._ENV)
+        artifact = (
+            "The README documents both install and validate commands. "
+            "README.md has no '## Usage' heading and no example."
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(_VALID_PASS_JSON),
+        )
+        diag = llm_backend.check(_semantic_rule(), artifact)
+        assert diag.status is Status.PASS
+        assert diag.evidence[0].kind == "llm_judgment"
+        data = diag.evidence[0].data
+        # Compatibility: existing field is preserved verbatim.
+        assert data["supporting_evidence_quotes"] == [
+            "The README documents both install and validate commands."
+        ]
+        # New field: one span per quote, with the documented schema.
+        spans = data["supporting_evidence_spans"]
+        assert isinstance(spans, list)
+        assert len(spans) == 1
+        span = spans[0]
+        assert span["quote"] == "The README documents both install and validate commands."
+        assert span["artifact_index"] == 0
+        assert span["start_offset"] == 0
+        assert span["end_offset"] == len(span["quote"])
+        assert span["match_normalisation"] == "exact"
+        assert span["start_line"] == 1
+        assert span["start_column"] == 1
+
+    def test_fail_evidence_carries_spans(self, monkeypatch):
+        _patch_env(monkeypatch, self._ENV)
+        artifact = (
+            "The README documents both install and validate commands. "
+            "README.md has no '## Usage' heading and no example."
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(_VALID_FAIL_JSON),
+        )
+        diag = llm_backend.check(_semantic_rule(), artifact)
+        assert diag.status is Status.FAIL
+        spans = diag.evidence[0].data["supporting_evidence_spans"]
+        assert len(spans) == 1
+        # The fail-stub's quote is "README.md has no '## Usage' heading"
+        assert spans[0]["quote"] == "README.md has no '## Usage' heading"
+        assert spans[0]["match_normalisation"] == "exact"
+        assert artifact[spans[0]["start_offset"] : spans[0]["end_offset"]] == spans[0]["quote"]
+
+    def test_whitespace_normalised_quote_records_normalisation(self, monkeypatch):
+        _patch_env(monkeypatch, self._ENV)
+        # Artifact is line-wrapped; the model emits a single-line quote.
+        artifact = "The PR description names\nthe user-visible change in the\nfirst sentence."
+        payload = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "ok",
+                "supporting_evidence_quotes": [
+                    "The PR description names the user-visible change in the first sentence."
+                ],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(payload),
+        )
+        diag = llm_backend.check(_semantic_rule(), artifact)
+        assert diag.status is Status.PASS
+        spans = diag.evidence[0].data["supporting_evidence_spans"]
+        assert len(spans) == 1
+        assert spans[0]["match_normalisation"] == "whitespace"
+        assert spans[0]["start_line"] == 1
+        assert spans[0]["end_line"] == 3
+
+    def test_smart_quote_quote_records_normalisation(self, monkeypatch):
+        _patch_env(monkeypatch, self._ENV)
+        artifact = "It’s the body that matters, not the subject line."
+        payload = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "ok",
+                "supporting_evidence_quotes": ["It's the body that matters, not the subject line."],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(payload),
+        )
+        diag = llm_backend.check(_semantic_rule(), artifact)
+        assert diag.status is Status.PASS
+        spans = diag.evidence[0].data["supporting_evidence_spans"]
+        assert len(spans) == 1
+        assert spans[0]["match_normalisation"] == "smart_quotes"
+
+    def test_duplicate_quote_evidence_first_match(self, monkeypatch):
+        _patch_env(monkeypatch, self._ENV)
+        artifact = "echo line.\nMiddle filler.\necho line."
+        payload = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "ok",
+                "supporting_evidence_quotes": ["echo line."],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(payload),
+        )
+        diag = llm_backend.check(_semantic_rule(), artifact)
+        assert diag.status is Status.PASS
+        spans = diag.evidence[0].data["supporting_evidence_spans"]
+        # First-match policy: first occurrence at offset 0, line 1.
+        assert spans[0]["start_offset"] == 0
+        assert spans[0]["start_line"] == 1
+
+    def test_fabricated_quote_yields_no_spans(self, monkeypatch):
+        # Fabricated quotes route through llm_quote_fabrication, not
+        # llm_judgment. The fabrication evidence MUST NOT carry spans —
+        # there is no in-artifact location for a string the model invented.
+        _patch_env(monkeypatch, self._ENV)
+        artifact = "Real artifact body."
+        fabricated_payload = json.dumps(
+            {
+                "judgment": "fail",
+                "primary_reason": "x",
+                "supporting_evidence_quotes": ["Wholly fabricated phrase not in body."],
+                "suggested_action": "fix it",
+            }
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(fabricated_payload),
+        )
+        diag = llm_backend.check(_semantic_rule(), artifact)
+        assert diag.status is Status.UNSUPPORTED
+        assert diag.evidence[0].kind == "llm_quote_fabrication"
+        # Fabrication evidence keeps the existing fields and does not
+        # introduce a spans field — the quote is by definition unlocatable.
+        assert "supporting_evidence_spans" not in diag.evidence[0].data
+
+    def test_multiple_quotes_each_get_a_span(self, monkeypatch):
+        _patch_env(monkeypatch, self._ENV)
+        artifact = "alpha beta gamma\ndelta epsilon zeta\neta theta iota"
+        payload = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "ok",
+                "supporting_evidence_quotes": [
+                    "alpha beta",
+                    "delta epsilon",
+                    "iota",
+                ],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(
+            llm_backend,
+            "_call_openai",
+            lambda *_a, **_k: _stub_response(payload),
+        )
+        diag = llm_backend.check(_semantic_rule(), artifact)
+        assert diag.status is Status.PASS
+        spans = diag.evidence[0].data["supporting_evidence_spans"]
+        assert [s["quote"] for s in spans] == [
+            "alpha beta",
+            "delta epsilon",
+            "iota",
+        ]
+        # Each span resolves to the documented line in the artifact.
+        assert [s["start_line"] for s in spans] == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
 # _parse_response backward-compat shim (legacy tests, kept for regression)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #179.

## Summary

Once the substring-grounding validator (#172) accepts the model's
`supporting_evidence_quotes`, resolve each validated quote to a deterministic
span pointing into the original artifact text. Spans surface as a parallel
list under `evidence[0].data.supporting_evidence_spans` on every successful
`llm_judgment` record; the existing `supporting_evidence_quotes` field is
preserved verbatim — spans are **additive**, not a replacement.

## Span shape

```json
{
  "quote": "<the model's raw quote string, verbatim>",
  "artifact_index": 0,
  "start_offset": 142,
  "end_offset": 181,
  "start_line": 8,
  "start_column": 3,
  "end_line": 8,
  "end_column": 42,
  "match_normalisation": "exact" | "smart_quotes" | "whitespace"
}
```

## Design decisions (per #179 design questions)

- **Character offsets, not byte offsets.** Python `str` indices into the
  artifact text the model was shown (the same string the fabrication
  validator runs against). Half-open: `artifact_text[start:end]` slices
  the matched substring out of the original artifact, even when the match
  required normalisation. Byte offsets would require nailing an encoding
  for no extra evidence.
- **1-indexed line / column** alongside the offsets for human-friendly
  rendering.
- **First match wins on duplicates.** Cleanest deterministic default and
  the one humans usually want when asking "where did the model find this
  quote?". Documented explicitly in `docs/llm-rubric.md`.
- **`match_normalisation` records weakest tolerance.** `"exact"` /
  `"smart_quotes"` / `"whitespace"` — exact match wins over smart-quote
  match wins over whitespace-collapse match. The resolver always returns
  offsets into the original (un-normalised) artifact.
- **`artifact_index: 0`** included as a single-artifact placeholder
  reserved for the multi-artifact follow-up (#182). Forward-compatible
  with no cost to current callers.
- **Span extraction lives in `llm_rubric.py`.** Refactor to a shared
  evidence utility is deferred until a second backend needs span emission.
- **`supporting_evidence_quotes` remains the stable field.** Spans are
  additive; consumers that ignore them keep working.

## Fabricated quotes do not get spans

Quote fabrication still routes through `llm_quote_fabrication` — by
definition there is no in-artifact location for an invented string. The
fabrication evidence record carries its existing fields and does **not**
include a `supporting_evidence_spans` field.

## Compatibility / fallback

If the resolver fails to locate a validated quote (a guard against future
drift between validator and resolver), that quote is silently omitted from
the span list. The quote itself remains in `supporting_evidence_quotes`,
so no information is lost — only the optional location annotation.

## Validation

```sh
uv run pytest tests/test_llm_rubric_backend.py::TestQuoteSpanResolution \
              tests/test_llm_rubric_backend.py::TestQuoteSpansInEvidence -v
# 19 passed in 0.24s

uvx ruff check .                # All checks passed!
uvx ruff format --check .       # 65 files already formatted

uv run pytest                   # 1124 passed, 9 pre-existing failures
                                # (all "unconfigured" tests in this dev env;
                                # see git stash bisection in implementation
                                # notes — same 9 fail on origin/main without
                                # my changes)
```

Tests added (acceptance criteria, #179):
- Exact match (first line, second line, spanning newline)
- Whitespace-normalised match (line-wrapped artifact, single-line quote)
- Smart-quote-normalised match (curly apostrophe in artifact, ASCII in quote)
- Duplicate match returns first occurrence
- No-match returns `None` from the resolver
- `_resolve_quote_spans` skips unresolvable quotes silently
- Multiple quotes each resolve to their own span
- Fabricated quote evidence has no `supporting_evidence_spans` key
- `to_dict` returns the documented nine keys (no extras)
- `_line_col_from_offset` clamps out-of-range offsets

## Acceptance criteria — checklist

- [x] Every validated quote can be accompanied by a span pointing into the original artifact text.
- [x] Span metadata is deterministic and provider-independent.
- [x] Existing consumers of `supporting_evidence_quotes` remain compatible.
- [x] Duplicate quote handling is documented and tested.
- [x] Fabricated quotes still produce `llm_quote_fabrication`, not spans.
- [x] The design does not block future multi-artifact evidence attribution (`artifact_index` reserved).

## Test plan

- [x] CI green (ruff check + format, pytest, pyright)
- [x] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
