### PR TITLE
feat(llm-rubric): strip filename from prompt when --artifact-kind is declared (#191)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -452,6 +452,36 @@ gate-keeper validate docs/dogfooding-rules.md \
   --artifact-kind pr_description
 ```
 
+#### Path targets — file content is rendered, not the path (#191)
+
+When `--artifact-kind` is declared **and** `--target` resolves to a real
+file on disk, the `llm-rubric` backend renders the file *content* into
+the prompt's `Target reference` slot rather than the path string. This
+prevents the model from latching onto the filename as a substitute for
+the declared kind: at v4, gpt-4o-mini was observed returning
+`judgment=unsupported` with `primary_reason: "The rule is annotated
+'commit_message' but the artifact provided is a target-03-commit.txt."`
+on positive controls (rule's `target_kind` matched the declared
+`--artifact-kind`, so the deterministic precheck above correctly did NOT
+fire) — citing the filename instead of evaluating the body. With the
+content rendered, the model has no filename to parrot.
+
+```sh
+# Path target + matching --artifact-kind → the model sees the file body,
+# not the path. The substring fabrication validator (#172) checks
+# quotes against the same content, so content-grounded quotes resolve
+# to spans (#179) normally.
+gate-keeper validate docs/dogfooding-rules.md \
+  --target /tmp/scratch/target-03-commit.txt \
+  --artifact-kind commit_message
+```
+
+Omitting `--artifact-kind` preserves the legacy v4 byte-for-byte
+behaviour (the `Target reference` slot carries `str(target)` and the
+prompt-level fallback in #169 / #175 is responsible for declining
+mismatches). Inline-string targets (`--target "<commit message body>"`)
+and non-existent paths are forwarded unchanged regardless of the flag.
+
 ### Project-local `command` adapter (#149)
 
 The `command` external adapter lets a trusted local rule document delegate a

--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -218,14 +218,28 @@ The backend therefore enforces the substring contract in `check()` after
   punctuation pairs (curly single/double quotes, en/em dashes) is folded
   to their ASCII counterparts, so the model may copy with cosmetic
   differences. **Paraphrase or rewording is not tolerated.**
-- The check runs against `str(target)` — exactly the string the prompt
-  template renders into the `Target reference` block via `_build_prompt`.
-  This matches what the model actually sees: the provider helpers do
-  not give the model a file-read tool, so for path / PR-reference
-  targets the model only ever has access to the reference string. The
-  bench harness pre-resolves path targets to file contents before
-  calling `check`, so for bench callers the target string is already the
-  inline content.
+- The check runs against the **same string the prompt template rendered**
+  into the `Target reference` block via `_build_prompt`. The substitution
+  rules (issue #191) are:
+  - When the caller declares `--artifact-kind` **and** `target` resolves
+    to a real file on disk, the prompt renders the **file content**;
+    the substring check is therefore performed against that content.
+    This is the post-#191 path — gpt-4o-mini at v4 was observed
+    parroting filenames as artifact-kind evidence on path targets, so
+    the path / filename is intentionally withheld from the prompt.
+  - When `--artifact-kind` is **not** declared, the prompt renders
+    `str(target)` byte-for-byte (legacy v4 behaviour), and the
+    substring check accepts only quotes drawn from the path / inline
+    string the model actually saw.
+  - Inline-string targets and non-existent paths fall back to
+    `str(target)` regardless of `--artifact-kind` — there is no file
+    body to substitute.
+  The provider helpers do not give the model a file-read tool, so the
+  model only ever sees the rendered `Target reference` block. The bench
+  harness pre-resolves path targets to file contents before calling
+  `check`, so for bench callers the target string is already the inline
+  content; for the bench callers, `--artifact-kind` therefore changes
+  nothing at the substring-grounding layer.
 - On any violation the verdict is **rejected**: the diagnostic returns
   `status=unsupported` with `evidence[0]` of kind
   `llm_quote_fabrication`. The evidence preserves the model's claimed

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -53,6 +53,15 @@ _SUPPORTED_PROVIDERS = ("anthropic", "openai")
 #   message" example with a kind-neutral schema illustration, and (c) adds
 #   a checklist step requiring the model to identify which artifact kind
 #   the rule's predicate actually targets before deciding.
+#
+# The ``PROMPT_VERSION`` constant is **not** bumped for #191. The rendered
+# template body (schema, instructions, constraints, examples) is unchanged;
+# the only change is what string fills the ``Target reference`` slot — when
+# the caller declared an ``--artifact-kind`` and the target resolves to a
+# real file, the prompt now carries the file *content* rather than the
+# file *path* (and the substring grounding check follows the same
+# substitution). Reproducibility records keyed on ``prompt_version``
+# continue to mean the same thing.
 PROMPT_VERSION = "v4"
 
 # ---------------------------------------------------------------------------
@@ -458,8 +467,75 @@ def _build_rubric_input(rule: Rule, target: str | Path) -> dict[str, Any]:
     return payload
 
 
-def _build_prompt(rule: Rule, target: str | Path) -> tuple[str, str]:
-    """Render the system + user messages for *rule* against *target* (#169 / #175).
+def _resolve_artifact_input(
+    target: str | Path,
+    artifact_kind: TargetKind | None,
+) -> str:
+    """Return the string to render into the prompt's ``Target reference`` block (#191).
+
+    When *artifact_kind* is declared by the caller (``--artifact-kind`` on
+    the CLI surface) **and** *target* refers to a real file on disk, return
+    the file's text content so the model sees the artifact body itself
+    rather than the path string. The declared kind already tells the model
+    what kind of artifact this is — leaking the filename adds no signal and
+    actively misleads the model on file-path callers. (Issue #191:
+    gpt-4o-mini at v4 parroted ``target-03-commit.txt`` as the artifact
+    kind regardless of the declared ``--artifact-kind=commit_message``.)
+
+    When *artifact_kind* is ``None`` (caller omitted the flag), preserve
+    the legacy v4 behaviour byte-for-byte: return ``str(target)`` so the
+    prompt's ``Target reference`` block carries whatever the caller passed
+    in (path string for path targets, inline content for inline targets).
+    The legacy prompt-level fallback in #169/#175 is still responsible for
+    declining or evaluating in that path.
+
+    When *target* is a non-existent path (or any string that does not
+    resolve to a file), return ``str(target)`` regardless of
+    *artifact_kind*: there is no file body to substitute, and the model
+    will judge from the reference alone per the existing instruction
+    ("If you cannot read the target's content directly, judge from the
+    reference alone."). A read error (permission denied, decode failure,
+    …) also falls back to ``str(target)`` so the behaviour stays
+    fail-open at the prompt-builder level — the substring fabrication
+    validator in :func:`_resolve_artifact_text` mirrors the same
+    substitution so a successful content load is observable in evidence
+    even on this branch.
+
+    Note: the helper accepts both ``str`` and ``Path`` because
+    :func:`check` is called with whatever the validator forwards. The
+    ``str`` branch is the common one (``--target /path/to/file`` ⇒ str);
+    we coerce to ``Path`` locally before stat-ing.
+    """
+    if artifact_kind is None:
+        return str(target)
+    # Coerce to Path for the existence/read step. Construction itself
+    # cannot raise for any reasonable input; ``is_file`` may raise
+    # ``OSError`` on filesystems that reject the byte-string (matches
+    # the CLI's defensive handling in cli.py).
+    try:
+        path = target if isinstance(target, Path) else Path(str(target))
+        if path.is_file():
+            try:
+                return path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                # Fail-open at the prompt-builder level: legacy
+                # path-string behaviour is the safe fallback; the
+                # diagnostic remains observable via the regular
+                # provider response path.
+                return str(target)
+    except OSError:
+        # ``is_file`` itself rejected the path (e.g. ENAMETOOLONG when
+        # someone passes a long inline string as --target). Fall back.
+        pass
+    return str(target)
+
+
+def _build_prompt(
+    rule: Rule,
+    target: str | Path,
+    artifact_kind: TargetKind | None = None,
+) -> tuple[str, str]:
+    """Render the system + user messages for *rule* against *target* (#169 / #175 / #191).
 
     When ``rule.target_kind`` is :data:`TargetKind.UNSPECIFIED` three
     target-kind-related blocks render to the empty string:
@@ -479,11 +555,21 @@ def _build_prompt(rule: Rule, target: str | Path) -> tuple[str, str]:
     saw the canned ``unsupported`` example and emitted a stray
     ``unsupported`` verdict that the backend then degraded to
     ``provider_error / unsupported_without_target_kind``.
+
+    The optional *artifact_kind* parameter (#191) selects what fills the
+    ``Target reference`` slot. When the caller declares an
+    ``--artifact-kind`` and *target* resolves to a real file, the slot
+    receives the file content — not the path string — so gpt-4o-mini
+    cannot latch onto the filename as a substitute for the declared kind.
+    When ``artifact_kind is None`` the legacy ``str(target)`` rendering is
+    preserved byte-for-byte (the prompt-level v4 fallback continues to
+    apply). See :func:`_resolve_artifact_input` for the substitution
+    rules.
     """
     system = RUBRIC_SYSTEM_PROMPT
     user = RUBRIC_PROMPT_TEMPLATE.format(
         rule_text=rule.text,
-        target=str(target),
+        target=_resolve_artifact_input(target, artifact_kind),
         target_kind_block=_render_target_kind_block(rule.target_kind),
         unsupported_instruction=_render_unsupported_instruction(rule.target_kind),
         unsupported_example_block=_render_unsupported_example_block(rule.target_kind),
@@ -763,36 +849,48 @@ def _normalise_for_substring(text: str) -> str:
     return collapsed.strip()
 
 
-def _resolve_artifact_text(target: str | Path) -> str:
+def _resolve_artifact_text(
+    target: str | Path,
+    artifact_kind: TargetKind | None = None,
+) -> str:
     """Return the artifact text used for substring validation.
 
-    Returns ``str(target)`` — the same string the prompt template renders
-    into the ``Target reference`` block via ``_build_prompt``. This is
-    deliberate: the substring check must be performed against what the
-    **model actually saw**, not against any out-of-band file contents.
+    Returns the **same string the prompt template renders into the
+    ``Target reference`` block** via ``_build_prompt``. The substring
+    check must be performed against what the model actually saw, not
+    against any out-of-band file contents.
 
-    Concretely:
+    Concretely (#191 update):
+
+    - When *artifact_kind* is ``None`` (caller did not declare
+      ``--artifact-kind``): legacy behaviour. Returns ``str(target)`` —
+      the prompt also renders ``str(target)``, so quote substrings are
+      checked against the path / inline string the model actually saw.
+    - When *artifact_kind* is declared and *target* resolves to a real
+      file: the prompt now renders the file content (#191), so this
+      function returns the same content. Quotes must be substrings of
+      the file body, matching what the model saw.
+    - When *artifact_kind* is declared but *target* is inline / a
+      non-existent path: ``_resolve_artifact_input`` falls back to
+      ``str(target)`` and so does this function — they stay in lockstep.
+
+    Pre-existing properties preserved:
 
     - For inline-string targets (the dogfood case ``--target "<PR body>"``)
       the model receives the body inline; quotes must be substrings of it.
-    - For path / PR-reference targets (the ``validate --target <file>``
-      flow) the model receives only the reference string and is instructed
-      to "judge from the reference alone" when it cannot read the
-      content. The substring check accepts only quotes drawn from that
-      reference. Generic placeholder strings invented by the model still
-      fail containment and are flagged as ``llm_quote_fabrication`` — the
-      desired behaviour.
     - The bench harness pre-resolves path targets to file contents before
       invoking ``check`` (``bench.run_entry`` ⇒ ``Target.resolve``), so for
       bench callers the target string is already the inline content; no
       special-casing is required here.
 
-    Reading file contents off-band would diverge from what the model has
-    access to and would force every legitimate verdict on a path target
-    into a false ``llm_quote_fabrication`` rejection (Codex review on
-    PR #173).
+    Reading file contents off-band when *artifact_kind* is **not** set
+    would diverge from what the model sees and would force every
+    legitimate verdict on a path target into a false
+    ``llm_quote_fabrication`` rejection (Codex review on PR #173). The
+    #191 substitution is gated on *artifact_kind* precisely so the
+    no-flag legacy path stays untouched.
     """
-    return str(target)
+    return _resolve_artifact_input(target, artifact_kind)
 
 
 def _find_fabricated_quotes(quotes: list[str], artifact_text: str) -> list[str]:
@@ -1156,7 +1254,12 @@ def _unavailable_provider_error(
 # ---------------------------------------------------------------------------
 
 
-def check(rule: Rule, target: str | Path | TargetSpec) -> Diagnostic:
+def check(
+    rule: Rule,
+    target: str | Path | TargetSpec,
+    *,
+    artifact_kind: TargetKind | None = None,
+) -> Diagnostic:
     """Evaluate a semantic-rubric rule against *target*.
 
     When no provider is configured (or the env file is absent), returns
@@ -1180,6 +1283,29 @@ def check(rule: Rule, target: str | Path | TargetSpec) -> Diagnostic:
     happening — content assembly is deferred to a follow-up. Single-file
     ``TargetSpec`` values are unwrapped to the underlying path so callers
     can mix CLI surfaces freely.
+
+    Parameters
+    ----------
+    rule:
+        The semantic-rubric rule to evaluate.
+    target:
+        File path, PR reference, inline string, or single-file
+        :class:`TargetSpec`. When a multi-target spec is supplied the
+        call short-circuits to ``UNSUPPORTED`` with
+        ``multi_target_unsupported`` evidence (see above).
+    artifact_kind:
+        Optional caller-declared :class:`TargetKind` for *target* (#191).
+        When supplied **and** *target* refers to a real file on disk, the
+        prompt's ``Target reference`` block is filled with the file
+        content rather than the path string — gpt-4o-mini at v4 was
+        observed to parrot filenames as artifact-kind evidence
+        (e.g. ``target-03-commit.txt``) when the path was rendered into
+        the prompt, undermining the rule's declared ``target_kind``
+        annotation. Inline / non-existent targets and ``artifact_kind=None``
+        callers preserve the legacy v4 byte-for-byte behaviour. The
+        :func:`_resolve_artifact_text` substring grounding follows the
+        same substitution so quotes are validated against what the model
+        actually saw.
 
     On success the ``evidence[0].data`` dict contains:
 
@@ -1237,7 +1363,7 @@ def check(rule: Rule, target: str | Path | TargetSpec) -> Diagnostic:
 
     provider = env["GATE_KEEPER_LLM_PROVIDER"]
     model = _resolve_model(provider, env)
-    system, user = _build_prompt(rule, target)
+    system, user = _build_prompt(rule, target, artifact_kind)
 
     try:
         if provider == "anthropic":
@@ -1326,7 +1452,11 @@ def check(rule: Rule, target: str | Path | TargetSpec) -> Diagnostic:
     # #172 — parser-side enforcement of the v2 prompt's substring-grounding
     # contract. If any quote is not a substring of the artifact text, reject
     # the verdict and surface UNSUPPORTED with llm_quote_fabrication evidence.
-    artifact_text = _resolve_artifact_text(target)
+    # #191 — when ``artifact_kind`` is declared and the target is a real file,
+    # ``_resolve_artifact_text`` returns the file content (mirroring what
+    # ``_build_prompt`` injected). Quotes are validated against what the
+    # model actually saw.
+    artifact_text = _resolve_artifact_text(target, artifact_kind)
     fabricated = _find_fabricated_quotes(parsed.supporting_evidence_quotes, artifact_text)
     if fabricated:
         cost = _estimate_cost(model, telemetry["tokens_in"], telemetry["tokens_out"])
@@ -1419,7 +1549,13 @@ def check(rule: Rule, target: str | Path | TargetSpec) -> Diagnostic:
 # ---------------------------------------------------------------------------
 
 
-def run_n(rule: Rule, target: str | Path, n: int) -> Diagnostic:
+def run_n(
+    rule: Rule,
+    target: str | Path,
+    n: int,
+    *,
+    artifact_kind: TargetKind | None = None,
+) -> Diagnostic:
     """Evaluate *rule* against *target* ``n`` times and aggregate the result.
 
     Reproducibility metric (#68): runs ``check`` ``n`` times, then aggregates the
@@ -1440,16 +1576,19 @@ def run_n(rule: Rule, target: str | Path, n: int) -> Diagnostic:
     - If *any* run returns a non-pass/fail diagnostic (``UNAVAILABLE`` /
       ``ERROR``), aggregation is abandoned and that diagnostic is returned
       unchanged - fail-closed for unconfigured / error states.
+    - The optional *artifact_kind* keyword is forwarded verbatim to each
+      ``check`` call (#191) so reproducibility runs see the same prompt
+      substitution as a single-shot call.
     """
     if n < 1:
         raise ValueError(f"reproducibility n must be >= 1, got {n}")
 
     if n == 1:
-        return check(rule, target)
+        return check(rule, target, artifact_kind=artifact_kind)
 
     diagnostics: list[Diagnostic] = []
     for _ in range(n):
-        diag = check(rule, target)
+        diag = check(rule, target, artifact_kind=artifact_kind)
         # Fail-closed on non-deterministic outcomes: if any run is unavailable
         # or errored, don't synthesise a misleading reproducibility score.
         if diag.status not in (Status.PASS, Status.FAIL):

--- a/src/gate_keeper/validator.py
+++ b/src/gate_keeper/validator.py
@@ -85,11 +85,46 @@ def _resolve_backend_name(rule: Rule, backend_name: str) -> str:
     return backend_name
 
 
+def _invoke_check(
+    check_fn: Callable,
+    rule: Rule,
+    target: str | Path | TargetSpec,
+    artifact_kind: TargetKind | None,
+) -> Diagnostic:
+    """Invoke *check_fn* with optional ``artifact_kind`` keyword (#191).
+
+    The registry's published callable signature is ``(rule, target) ->
+    Diagnostic``; the real ``llm_rubric.check`` adds an optional
+    ``artifact_kind=`` keyword. Test doubles register simple two-argument
+    callables that do not declare the keyword. To keep both shapes
+    callable through the same code path:
+
+    - When *artifact_kind* is ``None``: call ``check_fn(rule, target)``
+      verbatim — every registered check accepts this form.
+    - When *artifact_kind* is supplied: call ``check_fn(rule, target,
+      artifact_kind=artifact_kind)`` first; on ``TypeError`` (the stub
+      doesn't accept the keyword), retry without it. Tests that exercise
+      the deterministic precheck only need the call count, so dropping
+      the keyword for stubs is harmless. Tests that want to assert on
+      the keyword can register a stub that accepts ``**kwargs``.
+    """
+    if artifact_kind is None:
+        return check_fn(rule, target)
+    try:
+        return check_fn(rule, target, artifact_kind=artifact_kind)
+    except TypeError:
+        # Registered stub does not accept the keyword. Fall back to the
+        # legacy signature so non-LLM stubs (which never read
+        # artifact_kind anyway) keep working.
+        return check_fn(rule, target)
+
+
 def _run_n(
     check_fn: Callable,
     rule: Rule,
     target: str | Path | TargetSpec,
     n: int,
+    artifact_kind: TargetKind | None = None,
 ) -> Diagnostic:
     """Run *check_fn* ``n`` times and aggregate via majority vote.
 
@@ -100,10 +135,16 @@ def _run_n(
     Ties break toward fail (fail-closed). Returns early on the first
     non-pass/fail diagnostic (UNAVAILABLE / ERROR) without synthesising a
     reproducibility score (fail-closed for unconfigured states).
+
+    *artifact_kind* (#191) is forwarded as a keyword argument to *check_fn*
+    when non-``None``. Test stubs that only accept ``(rule, target)``
+    continue to work because the keyword is omitted in that case; the
+    real ``llm_rubric.check`` accepts ``artifact_kind=`` and uses it to
+    decide whether to substitute file content into the prompt.
     """
     diags: list[Diagnostic] = []
     for _ in range(n):
-        d = check_fn(rule, target)
+        d = _invoke_check(check_fn, rule, target, artifact_kind)
         if d.status not in (Status.PASS, Status.FAIL):
             return d
         diags.append(d)
@@ -292,10 +333,16 @@ def validate(
                 # #68: apply multi-run reproducibility for llm-rubric rules via
                 # the registry check_fn so stubs/overrides work in tests.
                 # Non-LLM backends silently ignore N>1.
+                #
+                # #191: forward ``artifact_kind`` via ``_invoke_check`` only
+                # for the llm-rubric route — non-LLM backends (filesystem,
+                # github, external) take ``(rule, target)`` and would not
+                # benefit from the keyword.
+                rule_artifact_kind = artifact_kind if resolved_name == "llm-rubric" else None
                 if reproducibility > 1 and resolved_name == "llm-rubric":
-                    diag = _run_n(check_fn, rule, target, reproducibility)
+                    diag = _run_n(check_fn, rule, target, reproducibility, rule_artifact_kind)
                 else:
-                    diag = check_fn(rule, target)
+                    diag = _invoke_check(check_fn, rule, target, rule_artifact_kind)
             except Exception as exc:  # noqa: BLE001
                 diag = _error_diagnostic(rule, exc, _backend_for(resolved_name))
         diagnostics.append(diag)

--- a/src/gate_keeper/validator.py
+++ b/src/gate_keeper/validator.py
@@ -26,6 +26,7 @@ Diagnostics are emitted in the same order as ``ruleset.rules``.
 from __future__ import annotations
 
 import dataclasses
+import inspect
 from pathlib import Path
 from typing import Callable
 
@@ -85,6 +86,34 @@ def _resolve_backend_name(rule: Rule, backend_name: str) -> str:
     return backend_name
 
 
+def _accepts_artifact_kind(check_fn: Callable) -> bool:
+    """Return ``True`` if *check_fn* declares an ``artifact_kind`` parameter
+    (or accepts arbitrary ``**kwargs``).
+
+    Determined by signature introspection rather than a try/except on
+    ``TypeError`` so that genuine ``TypeError``s raised inside the backend
+    body (e.g. by ``llm_rubric.check``) are not misinterpreted as a
+    signature mismatch and silently retried with the keyword dropped
+    (codex P1 review on #193). Falls back to ``False`` for builtins and
+    other callables whose signature cannot be inspected — those are
+    invoked through the legacy two-argument form, which is the safe
+    default for test stubs.
+    """
+    try:
+        sig = inspect.signature(check_fn)
+    except (TypeError, ValueError):
+        return False
+    for param in sig.parameters.values():
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+        if param.name == "artifact_kind" and param.kind in (
+            inspect.Parameter.KEYWORD_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            return True
+    return False
+
+
 def _invoke_check(
     check_fn: Callable,
     rule: Rule,
@@ -97,26 +126,30 @@ def _invoke_check(
     Diagnostic``; the real ``llm_rubric.check`` adds an optional
     ``artifact_kind=`` keyword. Test doubles register simple two-argument
     callables that do not declare the keyword. To keep both shapes
-    callable through the same code path:
+    callable through the same code path we introspect *check_fn*'s
+    signature once and decide whether to forward the keyword:
 
     - When *artifact_kind* is ``None``: call ``check_fn(rule, target)``
       verbatim — every registered check accepts this form.
-    - When *artifact_kind* is supplied: call ``check_fn(rule, target,
-      artifact_kind=artifact_kind)`` first; on ``TypeError`` (the stub
-      doesn't accept the keyword), retry without it. Tests that exercise
-      the deterministic precheck only need the call count, so dropping
+    - When *artifact_kind* is supplied and *check_fn* declares an
+      ``artifact_kind`` parameter (or accepts ``**kwargs``): forward
+      the keyword.
+    - Otherwise: call the legacy two-argument form. Tests that exercise
+      the deterministic precheck only need the call count, so omitting
       the keyword for stubs is harmless. Tests that want to assert on
-      the keyword can register a stub that accepts ``**kwargs``.
+      the keyword register a stub that declares ``artifact_kind`` (or
+      ``**kwargs``).
+
+    Using signature introspection — rather than catching ``TypeError``
+    from the call — keeps real runtime ``TypeError``s raised inside
+    backend bodies (e.g. ``llm_rubric.check``) from being silently
+    swallowed and retried without the keyword (codex P1 review on
+    #193). Such errors now propagate to the caller, which converts them
+    to ``Status.ERROR`` diagnostics in the normal exception path.
     """
-    if artifact_kind is None:
+    if artifact_kind is None or not _accepts_artifact_kind(check_fn):
         return check_fn(rule, target)
-    try:
-        return check_fn(rule, target, artifact_kind=artifact_kind)
-    except TypeError:
-        # Registered stub does not accept the keyword. Fall back to the
-        # legacy signature so non-LLM stubs (which never read
-        # artifact_kind anyway) keep working.
-        return check_fn(rule, target)
+    return check_fn(rule, target, artifact_kind=artifact_kind)
 
 
 def _run_n(

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -2147,6 +2147,209 @@ class TestUnsupportedDispatch:
         assert diag.evidence[0].data["failure_mode"] == "unsupported_without_target_kind"
 
 
+class TestArtifactKindStripsFilenameFromPrompt:
+    """#191 — when ``--artifact-kind`` is declared and ``--target`` is a real file
+    path, the prompt's ``Target reference`` block must carry the file
+    *content*, not the file *path*.
+
+    Background: gpt-4o-mini at v4 was observed parroting filenames as
+    artifact-kind evidence on positive controls (rule.target_kind matches
+    --artifact-kind, deterministic precheck does NOT fire, the LLM is
+    invoked). The model returned ``judgment=unsupported`` with
+    ``primary_reason: "The rule is annotated 'commit_message' but the
+    artifact provided is a target-03-commit.txt."`` — i.e. it cited the
+    filename instead of honouring the declared kind.
+
+    The fix strips filename context from the prompt when ``--artifact-kind``
+    is declared by reading the file content and rendering it into the
+    ``Target reference`` slot. The substring fabrication validator
+    (``_resolve_artifact_text``) follows the same substitution so quote
+    grounding stays consistent with what the model actually saw.
+    """
+
+    @staticmethod
+    def _commit_rule():
+        from gate_keeper.models import TargetKind
+
+        return _semantic_rule_with_target_kind(TargetKind.COMMIT_MESSAGE)
+
+    def test_path_target_with_artifact_kind_renders_file_content(self, tmp_path):
+        """The prompt's ``Target reference`` slot must contain the file
+        content — not the path string — when ``artifact_kind`` is
+        declared and ``target`` is an existing file path."""
+        from gate_keeper.models import TargetKind
+
+        commit_path = tmp_path / "target-03-commit.txt"
+        commit_body = "fix(parser): handle CRLF in evidence blocks\n\nrelated to #foo"
+        commit_path.write_text(commit_body, encoding="utf-8")
+
+        _system, user = llm_backend._build_prompt(
+            self._commit_rule(),
+            commit_path,
+            artifact_kind=TargetKind.COMMIT_MESSAGE,
+        )
+
+        # The file content must appear inline.
+        assert commit_body in user
+        # The path / filename must NOT appear in the rendered prompt — the
+        # whole point of #191 is to deny the model a filename to parrot.
+        assert str(commit_path) not in user
+        assert commit_path.name not in user
+
+    def test_path_target_with_artifact_kind_string_path_also_strips(self, tmp_path):
+        """The substitution applies to both ``Path`` and string-path
+        targets — the CLI surface forwards ``--target`` as a string."""
+        from gate_keeper.models import TargetKind
+
+        commit_path = tmp_path / "target-03-commit.txt"
+        commit_body = "feat(cli): emit --help on stderr\n\nbecause stdout is reserved for results"
+        commit_path.write_text(commit_body, encoding="utf-8")
+
+        _system, user = llm_backend._build_prompt(
+            self._commit_rule(),
+            str(commit_path),
+            artifact_kind=TargetKind.COMMIT_MESSAGE,
+        )
+
+        assert commit_body in user
+        assert str(commit_path) not in user
+        assert commit_path.name not in user
+
+    def test_path_target_without_artifact_kind_preserves_legacy_path_render(self, tmp_path):
+        """When ``artifact_kind`` is omitted, legacy v4 behaviour is
+        preserved byte-for-byte: the path string is rendered into the
+        ``Target reference`` slot, not the file content. This guards
+        against accidentally widening the file-content substitution to
+        unannotated callers.
+        """
+        commit_path = tmp_path / "target-03-commit.txt"
+        commit_body = "fix(parser): pre-191 default behaviour\n\nbody intentionally unique"
+        commit_path.write_text(commit_body, encoding="utf-8")
+
+        _system, user = llm_backend._build_prompt(self._commit_rule(), commit_path)
+
+        # Legacy: the path is rendered, the body is not.
+        assert str(commit_path) in user
+        assert commit_body not in user
+
+    def test_inline_target_with_artifact_kind_stays_inline(self):
+        """Inline string targets (no on-disk file) are passed through
+        unchanged regardless of ``artifact_kind`` — there is no path to
+        strip and no file to read."""
+        from gate_keeper.models import TargetKind
+
+        inline = "fix(parser): handle CRLF in evidence blocks\n\nrelated to #foo"
+        _system, user = llm_backend._build_prompt(
+            self._commit_rule(),
+            inline,
+            artifact_kind=TargetKind.COMMIT_MESSAGE,
+        )
+        assert inline in user
+
+    def test_nonexistent_path_with_artifact_kind_falls_back_to_string(self, tmp_path):
+        """A non-existent path with ``artifact_kind`` set must not raise;
+        the helper falls back to ``str(target)`` so the model still gets
+        a reference (and the existing instruction "judge from the
+        reference alone" applies)."""
+        from gate_keeper.models import TargetKind
+
+        missing = tmp_path / "does-not-exist.txt"
+        _system, user = llm_backend._build_prompt(
+            self._commit_rule(),
+            missing,
+            artifact_kind=TargetKind.COMMIT_MESSAGE,
+        )
+        assert str(missing) in user
+
+    def test_resolve_artifact_text_mirrors_prompt_substitution(self, tmp_path):
+        """The substring fabrication validator must see the same
+        artifact text the prompt rendered, otherwise legitimate
+        content-grounded quotes would be falsely flagged
+        ``llm_quote_fabrication``.
+        """
+        from gate_keeper.models import TargetKind
+
+        path = tmp_path / "target-03-commit.txt"
+        body = "fix(parser): handle CRLF in evidence blocks"
+        path.write_text(body, encoding="utf-8")
+
+        # With artifact_kind declared, the validator returns file content.
+        assert llm_backend._resolve_artifact_text(path, TargetKind.COMMIT_MESSAGE) == body
+        # Without artifact_kind, the validator returns str(target) (legacy).
+        assert llm_backend._resolve_artifact_text(path, None) == str(path)
+        assert llm_backend._resolve_artifact_text(path) == str(path)
+
+    def test_path_target_with_artifact_kind_judges_content_via_check(self, monkeypatch, tmp_path):
+        """End-to-end: ``check`` with a path + ``artifact_kind`` produces
+        an ``llm_judgment`` whose grounding quotes are content
+        substrings (not path / filename substrings).
+
+        The provider helper is monkeypatched so the test is deterministic
+        — the substring-grounding validator (#172) is what proves the
+        ``Target reference`` slot rendered file content rather than a
+        path string: a quote that is a substring of the file body but
+        not of the path string would otherwise be flagged
+        ``llm_quote_fabrication``.
+        """
+        from gate_keeper.models import TargetKind
+
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "openai",
+            "OPENAI_API_KEY": "sk-test",
+        }
+        _patch_env(monkeypatch, env)
+
+        commit_path = tmp_path / "target-03-commit.txt"
+        commit_body = (
+            "fix(parser): handle CRLF in evidence blocks\n\n"
+            "Without this guard, blocks copied from Windows editors silently "
+            "fail substring grounding because the artifact text carries \\r\\n "
+            "while the LLM emits \\n quotes."
+        )
+        commit_path.write_text(commit_body, encoding="utf-8")
+
+        # The model returns a quote that is a substring of the body — but
+        # NOT a substring of the path / filename. Without #191 this would
+        # be flagged as fabricated; with #191 the validator sees the
+        # body and the quote is grounded.
+        body_quote = "blocks copied from Windows editors silently fail substring grounding"
+        response = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "Body explains the failure mode and the fix concretely.",
+                "supporting_evidence_quotes": [body_quote],
+                "suggested_action": None,
+            }
+        )
+
+        captured: dict[str, object] = {}
+
+        def _capture_call(api_key, system, user, model):
+            captured["user"] = user
+            return _stub_response(response)
+
+        monkeypatch.setattr(llm_backend, "_call_openai", _capture_call)
+
+        rule = self._commit_rule()
+        diag = llm_backend.check(
+            rule,
+            commit_path,
+            artifact_kind=TargetKind.COMMIT_MESSAGE,
+        )
+
+        # Sanity: the prompt the helper saw included the body and not the path.
+        assert isinstance(captured["user"], str)
+        rendered_prompt: str = captured["user"]  # type: ignore[assignment]
+        assert body_quote in rendered_prompt
+        assert str(commit_path) not in rendered_prompt
+        assert commit_path.name not in rendered_prompt
+
+        # End result: PASS with content-grounded evidence (no fabrication).
+        assert diag.status is Status.PASS
+        assert diag.evidence[0].kind == "llm_judgment"
+        assert diag.evidence[0].data["supporting_evidence_quotes"] == [body_quote]
+
+
 # ---------------------------------------------------------------------------
 # Reproducibility metric (#68): run_n
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When `validate ... --target <FILE_PATH> --artifact-kind <KIND>` is invoked on a **positive control** (rule's `target_kind` matches `--artifact-kind`, so the deterministic precheck from #178 correctly does NOT fire), the LLM is invoked. At v4, gpt-4o-mini was observed returning `judgment=unsupported` citing the **filename** instead of honouring the declared kind — e.g. `"The rule is annotated 'commit_message' but the artifact provided is a target-03-commit.txt."`

This PR strips filename / path context from the prompt when the caller has already declared the artifact kind. The `Target reference` slot now carries the file content rather than the path string. The substring fabrication validator (#172) and span resolver (#179) follow the same substitution so quote grounding stays consistent. Legacy callers (no `--artifact-kind`) preserve the byte-for-byte v4 prompt; inline targets and non-existent paths fall back to `str(target)`.

## Why

Direction (1) from #191's body: there is no reason to leak the filename when the kind is already declared by the caller. Once stripped, the model has no filename to parrot, and the declared kind in the rendered `## Artifact kind` block is the only kind signal in the prompt.

## What changed

- `src/gate_keeper/backends/llm_rubric.py`
  - `check(rule, target, *, artifact_kind=None)` accepts the new optional keyword.
  - New helper `_resolve_artifact_input(target, artifact_kind)` returns the file content when the kind is declared and the target resolves to a real file; `str(target)` otherwise.
  - `_build_prompt` and `_resolve_artifact_text` call through this helper so the prompt and the substring validator stay in lockstep.
  - `run_n` threads `artifact_kind` through every reproducibility call.
  - `PROMPT_VERSION` stays at `v4` — template body is unchanged; only what fills the `Target reference` slot differs, gated on `artifact_kind`.
- `src/gate_keeper/validator.py`
  - New `_invoke_check` shim forwards `artifact_kind` only on the `llm-rubric` route, with a `TypeError` fallback so test stubs registered with the legacy `(rule, target)` signature keep working unmodified.
  - `_run_n` accepts and threads `artifact_kind` through every retry.
- `tests/test_llm_rubric_backend.py` — new `TestArtifactKindStripsFilenameFromPrompt` class with 7 tests:
  - Path target + matching declared kind ⇒ prompt carries the file content; neither the path nor the filename appears (regression pin).
  - String-path target with declared kind ⇒ same substitution.
  - Path target with no declared kind ⇒ legacy path rendering preserved.
  - Inline target ⇒ unchanged regardless of declared kind.
  - Non-existent path ⇒ fail-open to `str(target)`.
  - `_resolve_artifact_text` mirrors the prompt substitution.
  - End-to-end `check()` with monkeypatched provider: a quote that is a substring of the file body but NOT of the path resolves to PASS with `llm_judgment` evidence (would have been flagged `llm_quote_fabrication` without the fix).
- `docs/cli-reference.md` — new "Path targets — file content is rendered, not the path (#191)" subsection under the deterministic-precheck heading.
- `docs/llm-rubric.md` — substring-grounding section now documents the three substitution rules (declared kind + file path ⇒ content; no flag ⇒ legacy `str(target)`; inline / non-existent ⇒ fall back).

## Validation

- `uv run pytest tests/test_llm_rubric_backend.py::TestArtifactKindStripsFilenameFromPrompt` → **7 passed**.
- `uv run pytest tests/test_validator.py::TestArtifactKindPrecheck tests/test_cli_validate.py::TestArtifactKindFlag` → **12 passed** (the deterministic-precheck suite from #178 is unaffected — the new behaviour is additive on the prompt-builder branch the precheck does NOT take).
- `uvx ruff check . && uvx ruff format --check .` → clean.
- `uv run pyright` → 0 errors.
- Pre-existing dotenv-leak failures (~10 tests in `TestLlmRubricBackendStub` etc. that assume the host has no API key) are unchanged on this branch — verified by stashing the diff and re-running. Not a regression introduced by this PR.

End-to-end equivalence between bench (inline) and CLI (file path) on the positive control will be observable in the next umbrella-loop tick:6 bench (the orchestrator's every-3rd-tick bench cadence per the issue body's note).

## Test plan

- [x] CI green on this PR.
- [x] Path target + matching declared kind renders file content (regression pinned).
- [x] Path target without declared kind preserves legacy v4 prompt byte-for-byte.
- [x] Substring grounding validator follows the same substitution (no false `llm_quote_fabrication` rejections on legitimate content quotes).
- [x] `target_kind_mismatch` evidence emission for genuine kind mismatches unaffected (#178 tests still pass).

Closes #191. Refs umbrella #164, prior iterations #169 / #175 / #178.