### PR TITLE
feat(bench): add cross-model llm-rubric matrix script (#177, slice 1)

### DIFF
--- a/scripts/llm_rubric_model_matrix.py
+++ b/scripts/llm_rubric_model_matrix.py
@@ -265,6 +265,10 @@ def main(argv: list[str] | None = None) -> int:
         parser.error(f"--entries-dir does not exist or is not a directory: {entries_dir}")
         return 2  # pragma: no cover — argparse exits
 
+    if args.reproducibility < 1:
+        parser.error(f"--reproducibility must be >= 1, got {args.reproducibility}")
+        return 2  # pragma: no cover — argparse exits
+
     report = run_matrix(entries_dir, models, reproducibility=args.reproducibility)
     rendered = render_json(report)
 

--- a/scripts/llm_rubric_model_matrix.py
+++ b/scripts/llm_rubric_model_matrix.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Cross-model benchmark matrix for the llm-rubric backend (#177, first slice).
+
+Runs the existing semantic fixture corpus across a small list of configured
+models and emits a JSON report. Intentionally bounded: the goal of this slice
+is to prove the matrix-loop architecture works without committing to surface-
+area decisions (CLI integration, YAML config, full metrics).
+
+Out of scope (deferred to follow-ups):
+
+- ``gate-keeper bench --model-matrix`` CLI surface.
+- YAML config (``docs/llm-model-matrix.yml``).
+- Per-category accuracy, fabrication rate, target-kind correctness, latency
+  summary stats, cost-estimation aggregates.
+- Multi-provider (Anthropic) plumbing — this slice supports the OpenAI
+  provider only, which is enough to validate the matrix shape across at
+  least two distinct models (e.g. ``gpt-4o-mini`` vs ``gpt-4o``).
+
+Usage::
+
+    uv run python scripts/llm_rubric_model_matrix.py \\
+        --models openai:gpt-4o-mini,openai:gpt-4o \\
+        --entries-dir tests/fixtures/semantic/entries \\
+        [--reproducibility 1] \\
+        [--out report.json]
+
+The script monkey-patches ``llm_rubric._load_env_file`` once per model so the
+existing ``bench.run_bench`` evaluator picks up the per-model override without
+needing a new model-injection seam in the backend. Tests use the same
+mechanism, so a hermetic test never touches the network.
+
+Refs: issue #177 / umbrella #164.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# Allow running as ``python scripts/llm_rubric_model_matrix.py`` without a prior
+# ``uv pip install -e .`` by inserting the in-tree ``src/`` onto ``sys.path``
+# when the package is not already importable.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from gate_keeper import bench as _bench  # noqa: E402
+from gate_keeper.backends import llm_rubric as _llm  # noqa: E402
+
+_SUPPORTED_PROVIDERS = ("openai",)
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """A single (provider, model) pair from the ``--models`` argument."""
+
+    provider: str
+    model: str
+
+    @property
+    def label(self) -> str:
+        return f"{self.provider}:{self.model}"
+
+
+def parse_models(spec: str) -> list[ModelSpec]:
+    """Parse a ``--models`` argument like ``openai:gpt-4o-mini,openai:gpt-4o``.
+
+    Order is preserved; duplicates are de-duplicated (first occurrence wins) so
+    the report rows stay aligned with the user-declared sequence.
+    """
+    out: list[ModelSpec] = []
+    seen: set[tuple[str, str]] = set()
+    for raw in spec.split(","):
+        token = raw.strip()
+        if not token:
+            continue
+        if ":" not in token:
+            raise ValueError(
+                f"--models entry {token!r} must be of the form 'provider:model' (e.g. 'openai:gpt-4o-mini')"
+            )
+        provider, model = token.split(":", 1)
+        provider = provider.strip()
+        model = model.strip()
+        if provider not in _SUPPORTED_PROVIDERS:
+            raise ValueError(
+                f"--models entry {token!r}: provider {provider!r} not supported in this slice; "
+                f"expected one of {list(_SUPPORTED_PROVIDERS)}"
+            )
+        if not model:
+            raise ValueError(f"--models entry {token!r}: model identifier is empty")
+        key = (provider, model)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(ModelSpec(provider=provider, model=model))
+    if not out:
+        raise ValueError("--models must contain at least one provider:model entry")
+    return out
+
+
+def _build_env_for_model(spec: ModelSpec, base_env: dict[str, str]) -> dict[str, str]:
+    """Return a per-model env dict for the llm_rubric loader.
+
+    Reuses the API key from *base_env* (the on-disk dotenv) and overrides the
+    provider + per-provider model identifier so ``_resolve_model`` returns
+    ``spec.model`` regardless of what the dotenv had for the default.
+    """
+    env = dict(base_env)
+    env["GATE_KEEPER_LLM_PROVIDER"] = spec.provider
+    if spec.provider == "openai":
+        env["GATE_KEEPER_OPENAI_MODEL"] = spec.model
+        # Surface a clearer message than KeyError if the dotenv lacks the key.
+        if "OPENAI_API_KEY" not in env:
+            raise RuntimeError(
+                "llm-rubric dotenv has no OPENAI_API_KEY; configure it before "
+                "running the model matrix (see docs/llm-rubric.md)."
+            )
+    else:  # pragma: no cover — guarded by parse_models
+        raise RuntimeError(f"unsupported provider: {spec.provider!r}")
+    return env
+
+
+def run_matrix(
+    entries_dir: Path,
+    models: list[ModelSpec],
+    *,
+    reproducibility: int = 1,
+) -> dict[str, Any]:
+    """Run the bench corpus once per model and assemble the JSON report.
+
+    Each model loop monkey-patches the module-level ``_load_env_file`` to a
+    closure returning the per-model env dict, then calls ``bench.run_bench``
+    (which internally drives the existing llm_rubric ``check`` path). The
+    original loader is restored after every iteration so a partial run does
+    not leak the override onto subsequent code paths.
+    """
+    base_env = _llm._load_env_file()
+    original_loader = _llm._load_env_file
+
+    per_model_rows: list[dict[str, Any]] = []
+    total_entries = 0
+    total_correct = 0
+    try:
+        for spec in models:
+            env = _build_env_for_model(spec, base_env)
+            _llm._load_env_file = lambda *_a, _env=env, **_k: dict(_env)  # type: ignore[assignment]
+            try:
+                bench_result = _bench.run_bench(entries_dir, reproducibility=reproducibility)
+            finally:
+                _llm._load_env_file = original_loader  # type: ignore[assignment]
+
+            entries_count = bench_result.summary.entries
+            correct = bench_result.summary.correct
+            accuracy = bench_result.summary.accuracy
+            total_entries += entries_count
+            total_correct += correct
+
+            per_rule_rows: list[dict[str, Any]] = []
+            for row in bench_result.per_rule:
+                per_rule_rows.append(
+                    {
+                        "id": row.id,
+                        "category": row.category,
+                        "expected": row.expected,
+                        "actual": row.actual,
+                        "status": row.status,
+                        "failure_mode": row.failure_mode,
+                        "latency_ms": row.latency_ms,
+                        "tokens_in": row.tokens_in,
+                        "tokens_out": row.tokens_out,
+                        "model": row.model,
+                    }
+                )
+
+            per_model_rows.append(
+                {
+                    "provider": spec.provider,
+                    "model": spec.model,
+                    "label": spec.label,
+                    "summary": {
+                        "entries": entries_count,
+                        "correct": correct,
+                        "accuracy": accuracy,
+                        "reproducibility_n": bench_result.summary.reproducibility_n,
+                        "tokens_in": bench_result.summary.tokens_in,
+                        "tokens_out": bench_result.summary.tokens_out,
+                        "latency_ms": bench_result.summary.latency_ms,
+                        "unavailable": bench_result.summary.unavailable,
+                        "errors": bench_result.summary.errors,
+                    },
+                    "per_rule": per_rule_rows,
+                }
+            )
+    finally:
+        _llm._load_env_file = original_loader  # type: ignore[assignment]
+
+    aggregate_accuracy = (total_correct / total_entries) if total_entries else 0.0
+    return {
+        "schema_version": 1,
+        "prompt_version": _llm.PROMPT_VERSION,
+        "reproducibility_n": reproducibility,
+        "entries_dir": str(entries_dir),
+        "models": per_model_rows,
+        "aggregate": {
+            "total": total_entries,
+            "correct": total_correct,
+            "accuracy": aggregate_accuracy,
+        },
+    }
+
+
+def render_json(report: dict[str, Any]) -> str:
+    """Render the matrix report as deterministic JSON."""
+    return json.dumps(report, sort_keys=True, indent=2)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="llm_rubric_model_matrix",
+        description=(
+            "Run the semantic fixture corpus across multiple llm-rubric models "
+            "and emit a JSON report. First-slice scope (issue #177): single "
+            "provider (OpenAI), minimal aggregate stats, no CLI integration."
+        ),
+    )
+    parser.add_argument(
+        "--models",
+        required=True,
+        help=("Comma-separated provider:model list, e.g. 'openai:gpt-4o-mini,openai:gpt-4o'."),
+    )
+    parser.add_argument(
+        "--entries-dir",
+        default=str(_REPO_ROOT / "tests" / "fixtures" / "semantic" / "entries"),
+        help=(
+            "Path to the semantic fixture entries directory. Defaults to the "
+            "repo's tests/fixtures/semantic/entries/."
+        ),
+    )
+    parser.add_argument(
+        "--reproducibility",
+        type=int,
+        default=1,
+        help="Number of provider calls per entry (majority vote). Defaults to 1.",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Optional path to write the JSON report. Defaults to stdout.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        models = parse_models(args.models)
+    except ValueError as exc:
+        parser.error(str(exc))
+        return 2  # pragma: no cover — argparse exits
+
+    entries_dir = Path(args.entries_dir)
+    if not entries_dir.is_dir():
+        parser.error(f"--entries-dir does not exist or is not a directory: {entries_dir}")
+        return 2  # pragma: no cover — argparse exits
+
+    report = run_matrix(entries_dir, models, reproducibility=args.reproducibility)
+    rendered = render_json(report)
+
+    if args.out:
+        Path(args.out).write_text(rendered + "\n", encoding="utf-8")
+    else:
+        sys.stdout.write(rendered + "\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_model_matrix_script.py
+++ b/tests/test_model_matrix_script.py
@@ -220,3 +220,25 @@ class TestMainCli:
         assert report["aggregate"]["correct"] == 1
         assert len(report["models"]) == 1
         assert report["models"][0]["label"] == "openai:gpt-4o-mini"
+
+    @pytest.mark.parametrize("bad", ["0", "-1"])
+    def test_main_rejects_non_positive_reproducibility(self, tmp_path, capsys, bad):
+        """--reproducibility <= 0 must exit cleanly via argparse, not propagate
+        a ValueError out of bench.run_bench as an uncaught traceback (#177
+        codex P2)."""
+        entries_dir = _single_entry_dir(tmp_path)
+
+        with pytest.raises(SystemExit) as excinfo:
+            matrix.main(
+                [
+                    "--models",
+                    "openai:gpt-4o-mini",
+                    "--entries-dir",
+                    str(entries_dir),
+                    "--reproducibility",
+                    bad,
+                ]
+            )
+        assert excinfo.value.code == 2
+        captured = capsys.readouterr()
+        assert "--reproducibility" in captured.err

--- a/tests/test_model_matrix_script.py
+++ b/tests/test_model_matrix_script.py
@@ -1,0 +1,222 @@
+"""Hermetic tests for ``scripts/llm_rubric_model_matrix.py`` (#177).
+
+The matrix script wraps the existing bench harness in a per-model loop. We
+exercise the wrapper end-to-end against a one-entry inline fixture corpus
+with the OpenAI provider stubbed out, mirroring the pattern in
+``tests/test_cli_bench.py`` and ``tests/test_llm_rubric_backend.py``.
+
+No real API key is required and no network call is made.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from gate_keeper.backends import llm_rubric as _llm
+
+# ---------------------------------------------------------------------------
+# Module loader (the script lives outside the importable package tree)
+# ---------------------------------------------------------------------------
+
+
+def _load_matrix_module():
+    """Import ``scripts/llm_rubric_model_matrix.py`` as a module by file path."""
+    repo_root = Path(__file__).resolve().parent.parent
+    script_path = repo_root / "scripts" / "llm_rubric_model_matrix.py"
+    spec = importlib.util.spec_from_file_location("llm_rubric_model_matrix", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["llm_rubric_model_matrix"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+matrix = _load_matrix_module()
+
+
+# ---------------------------------------------------------------------------
+# Stubs (mirror tests/test_cli_bench.py)
+# ---------------------------------------------------------------------------
+
+
+def _stub_openai_pass(*_args, **_kwargs) -> tuple[str, dict[str, int]]:
+    body = json.dumps(
+        {
+            "judgment": "pass",
+            "primary_reason": "The artefact satisfies the rule.",
+            "supporting_evidence_quotes": ["example artefact body"],
+            "suggested_action": None,
+        }
+    )
+    return body, {"latency_ms": 11, "tokens_in": 50, "tokens_out": 12}
+
+
+def _single_entry_dir(tmp_path: Path) -> Path:
+    entries = tmp_path / "entries"
+    entries.mkdir()
+    entry = {
+        "rule_text": "The artefact satisfies the example rule.",
+        "target": {"kind": "inline", "value": "example artefact body"},
+        "expected_judgment": "pass",
+        "expected_rationale_keywords": ["satisfies"],
+        "category": "clarity",
+        "intended_backend": "llm-rubric",
+    }
+    (entries / "smoke-01.json").write_text(json.dumps(entry))
+    return entries
+
+
+_BASE_ENV = {
+    "GATE_KEEPER_LLM_PROVIDER": "openai",
+    "OPENAI_API_KEY": "sk-test-stub-not-real",
+}
+
+
+# ---------------------------------------------------------------------------
+# parse_models
+# ---------------------------------------------------------------------------
+
+
+class TestParseModels:
+    def test_parses_two_entries_in_order(self):
+        specs = matrix.parse_models("openai:gpt-4o-mini,openai:gpt-4o")
+        assert [s.label for s in specs] == ["openai:gpt-4o-mini", "openai:gpt-4o"]
+
+    def test_dedupes_repeated_pairs(self):
+        specs = matrix.parse_models("openai:gpt-4o,openai:gpt-4o")
+        assert [s.label for s in specs] == ["openai:gpt-4o"]
+
+    def test_rejects_missing_colon(self):
+        with pytest.raises(ValueError, match="provider:model"):
+            matrix.parse_models("gpt-4o-mini")
+
+    def test_rejects_unsupported_provider(self):
+        with pytest.raises(ValueError, match="not supported"):
+            matrix.parse_models("anthropic:claude-haiku-4-5")
+
+    def test_rejects_empty_input(self):
+        with pytest.raises(ValueError, match="at least one"):
+            matrix.parse_models("")
+
+
+# ---------------------------------------------------------------------------
+# run_matrix
+# ---------------------------------------------------------------------------
+
+
+class TestRunMatrix:
+    def test_emits_expected_shape_two_models(self, monkeypatch, tmp_path):
+        # Hermetic: stub both the dotenv loader and the provider helper.
+        monkeypatch.setattr(_llm, "_load_env_file", lambda *a, **k: dict(_BASE_ENV))
+        monkeypatch.setattr(_llm, "_call_openai", _stub_openai_pass)
+
+        entries_dir = _single_entry_dir(tmp_path)
+        specs = matrix.parse_models("openai:gpt-4o-mini,openai:gpt-4o")
+
+        report = matrix.run_matrix(entries_dir, specs, reproducibility=1)
+
+        assert report["schema_version"] == 1
+        assert report["prompt_version"] == _llm.PROMPT_VERSION
+        assert report["reproducibility_n"] == 1
+        assert report["entries_dir"] == str(entries_dir)
+
+        models_section = report["models"]
+        assert len(models_section) == 2
+        assert [m["label"] for m in models_section] == [
+            "openai:gpt-4o-mini",
+            "openai:gpt-4o",
+        ]
+
+        for row, expected_model in zip(models_section, ["gpt-4o-mini", "gpt-4o"]):
+            assert row["provider"] == "openai"
+            assert row["model"] == expected_model
+            assert row["summary"]["entries"] == 1
+            assert row["summary"]["correct"] == 1
+            assert row["summary"]["accuracy"] == 1.0
+            assert row["summary"]["tokens_in"] == 50
+            assert row["summary"]["tokens_out"] == 12
+            assert len(row["per_rule"]) == 1
+            entry_row = row["per_rule"][0]
+            assert entry_row["id"] == "smoke-01"
+            assert entry_row["status"] == "PASS"
+            assert entry_row["expected"] == "pass"
+            assert entry_row["actual"] == "pass"
+            # The bench harness records the resolved model on each row; this
+            # is the seam the matrix script depends on.
+            assert entry_row["model"] == expected_model
+
+        aggregate = report["aggregate"]
+        assert aggregate["total"] == 2
+        assert aggregate["correct"] == 2
+        assert aggregate["accuracy"] == 1.0
+
+    def test_restores_loader_after_run(self, monkeypatch, tmp_path):
+        sentinel_env = dict(_BASE_ENV)
+
+        def _sentinel_loader(*_a, **_k):
+            return dict(sentinel_env)
+
+        monkeypatch.setattr(_llm, "_load_env_file", _sentinel_loader)
+        monkeypatch.setattr(_llm, "_call_openai", _stub_openai_pass)
+
+        entries_dir = _single_entry_dir(tmp_path)
+        specs = matrix.parse_models("openai:gpt-4o-mini")
+
+        matrix.run_matrix(entries_dir, specs, reproducibility=1)
+
+        # After the matrix run completes, the original loader must be back in
+        # place so subsequent code paths see the unmodified env.
+        assert _llm._load_env_file is _sentinel_loader
+
+    def test_raises_when_api_key_missing(self, monkeypatch, tmp_path):
+        # No OPENAI_API_KEY in the simulated dotenv → script raises a clear
+        # message rather than crashing inside _call_openai.
+        monkeypatch.setattr(
+            _llm,
+            "_load_env_file",
+            lambda *a, **k: {"GATE_KEEPER_LLM_PROVIDER": "openai"},
+        )
+
+        entries_dir = _single_entry_dir(tmp_path)
+        specs = matrix.parse_models("openai:gpt-4o-mini")
+
+        with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+            matrix.run_matrix(entries_dir, specs, reproducibility=1)
+
+
+# ---------------------------------------------------------------------------
+# main (CLI entry point)
+# ---------------------------------------------------------------------------
+
+
+class TestMainCli:
+    def test_main_writes_report_to_out(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(_llm, "_load_env_file", lambda *a, **k: dict(_BASE_ENV))
+        monkeypatch.setattr(_llm, "_call_openai", _stub_openai_pass)
+
+        entries_dir = _single_entry_dir(tmp_path)
+        out_path = tmp_path / "report.json"
+
+        rc = matrix.main(
+            [
+                "--models",
+                "openai:gpt-4o-mini",
+                "--entries-dir",
+                str(entries_dir),
+                "--out",
+                str(out_path),
+            ]
+        )
+        assert rc == 0
+        assert out_path.is_file()
+
+        report = json.loads(out_path.read_text(encoding="utf-8"))
+        assert report["aggregate"]["total"] == 1
+        assert report["aggregate"]["correct"] == 1
+        assert len(report["models"]) == 1
+        assert report["models"][0]["label"] == "openai:gpt-4o-mini"


### PR DESCRIPTION
Closes #177 (slice 1 — see Follow-up section).

## Summary

First slice of #177 under umbrella #164. Adds a standalone
`scripts/llm_rubric_model_matrix.py` that runs the existing semantic
fixture corpus across multiple OpenAI models and emits a JSON report with
per-(model, fixture) rows and a per-model rollup.

The script wraps `gate_keeper.bench.run_bench` in a per-model loop by
monkey-patching the module-level `llm_rubric._load_env_file` once per
model, reusing the existing OpenAI provider plumbing without adding a new
model-injection seam in the backend. Tests use the same mechanism, so
nothing in the test suite touches the network.

This is the LITE_SPEC slice from the issue body's explicit allowance:

> The implementation can also start as `scripts/llm_rubric_model_matrix.py`
> if adding CLI surface is too much for the first slice.

The slice is intentionally bounded to prove the matrix-loop architecture
works without committing to surface-area decisions.

## Scope (in this PR)

- `scripts/llm_rubric_model_matrix.py`
  - `--models openai:gpt-4o-mini,openai:gpt-4o` (comma-separated, ordered, deduped).
  - `--entries-dir` (defaults to `tests/fixtures/semantic/entries/`).
  - `--reproducibility N` (passed through to `bench.run_bench`).
  - `--out PATH` or stdout for the JSON report.
  - Per-model rows record: `id`, `category`, `expected`, `actual`,
    `status`, `failure_mode`, `latency_ms`, `tokens_in`, `tokens_out`,
    `model`.
  - Per-model rollup: `entries`, `correct`, `accuracy`, `tokens_in`,
    `tokens_out`, `latency_ms`, `unavailable`, `errors`,
    `reproducibility_n`.
  - Aggregate rollup across models: `total`, `correct`, `accuracy`.
- `tests/test_model_matrix_script.py` — hermetic, monkey-patches
  `_call_openai` and `_load_env_file` (mirrors `tests/test_cli_bench.py`).
  9 test cases covering `parse_models`, `run_matrix`, and `main`.

## Follow-up (out of scope, file as separate issues)

The full surface from #177 is intentionally not implemented here. Each of
the items below should be filed as a follow-up issue:

- `gate-keeper bench --model-matrix CONFIG --format json` CLI integration.
- YAML config DSL (`docs/llm-model-matrix.yml`) with `provider`/`model`
  list shape per #177.
- Full metrics surface from #177's "Metrics to report":
  per-category accuracy, `llm_quote_fabrication` count/rate,
  `target_kind_mismatch` correctness for target-kind fixtures, latency
  summary stats (p50/p95), input/output token summary, estimated cost,
  unknown-pricing count.
- Multi-provider plumbing (Anthropic) — slice 1 is OpenAI-only because
  one provider with two distinct models (e.g. `gpt-4o-mini` vs `gpt-4o`)
  is sufficient to validate the matrix shape works.
- Compact Markdown summary alongside the JSON report.
- Documentation page (`docs/llm-model-matrix.md`) explaining how to run
  the opt-in live-provider benchmark and how to interpret the report.

## Validation

```sh
uv run pytest tests/test_model_matrix_script.py
# 9 passed in 0.10s

uvx ruff check .
# All checks passed!

uvx ruff format --check .
# (clean — script was auto-formatted)

uv run pyright scripts/llm_rubric_model_matrix.py tests/test_model_matrix_script.py
# 0 errors, 0 warnings, 0 informations
```

The full `uv run pytest` suite has 10 pre-existing failures on this
machine driven by the local `gate-keeper.env` dotenv being configured
with a real provider; those tests assume an unconfigured environment and
fail identically on `origin/main` (verified by stashing the new files
and re-running). They are **not** introduced by this PR and they pass on
CI, where no dotenv is mounted.

## Notes

- The matrix script does **not** require the issue's full metrics — those
  are explicitly deferred. The schema records enough raw per-row data
  (status, latency, tokens, failure_mode) that follow-up tooling can
  compute the deferred metrics from the same JSON without re-running
  the live calls.
- The per-iteration `_load_env_file` monkey-patch is wrapped in a
  `try/finally` (and an outer `try/finally`) so a partial run does not
  leak the override onto subsequent code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)