### PR TITLE
feat(dependency-gates): implement Mode B target-stamped freshness checks (#181)

### DIFF
--- a/docs/design/dependency-gates.md
+++ b/docs/design/dependency-gates.md
@@ -13,7 +13,13 @@ Tracking umbrella: #159. Coordinates children #156 (code↔doc / doc↔doc depen
 > - IR rule file `docs/dependency-gate-rules.json` exercisable via `gate-keeper validate --rules-format ir ... --allow-command-adapter`.
 > - Loader and validator tests, including a `@pytest.mark.integration` end-to-end round-trip.
 >
-> **Out of slice (deferred):** PR-trailer ack transport, MCP validator transport, cycle-detection rule, in-repo #158 reference validator, automatic dependency discovery, any new `RuleKind`. See §7 for the full out-of-scope list.
+> **Issue #181 (Mode B slice).** Adds target-stamped freshness checking:
+>
+> - Stamp parser at `scripts/dependency_gates/_stamp.py` (frontmatter + canonical syntax, see §3.3).
+> - Mode B branch in the validator emits one of `dependent_artifact_unaffected`, `dependent_artifact_stale_by_hash`, `target_stamp_missing`, `target_stamp_malformed`, `dependent_artifact_source_missing`, or `dependent_artifact_target_missing`.
+> - Whole-file SHA-256 source hashing (no anchors); single source per target; target frontmatter required (no inline lines).
+>
+> **Out of slice (deferred):** PR-trailer ack transport, MCP validator transport, cycle-detection rule, in-repo #158 reference validator, automatic dependency discovery, any new `RuleKind`, opaque source anchors, multi-source-per-target stamp representation, automatic stamp rewriting, semantic equivalence between source and target, cross-repository source hashing. See §7 for the full out-of-scope list.
 
 ---
 
@@ -36,13 +42,13 @@ The seven rules below are load-bearing. The slice-1 implementation honours them.
 
 ### 2.1 Manifest schema is graph-shaped
 
-Top-level `nodes` (id, path, anchor?, kind?) and `edges` (from-id, to-id, relation, mode?, pair_id?). A `pairs:` sugar form is accepted as input but the loader desugars it to nodes+edges before any consumer sees it.
+Top-level `nodes` (`id`, `path`, `anchor`?, `kind`?) and `edges` (`from`-id, `to`-id, `relation`, `mode`?, `pair_id`?). A `pairs:` sugar form is accepted as input but the loader desugars it to nodes+edges before any consumer sees it.
 
 A pair is just two nodes connected by an edge. A graph is the strict superset of a list of pairs. Choosing the superset gives one loader, one schema, one validation pass.
 
 ### 2.2 Anchor is opaque to the loader
 
-A node's `anchor` is a string. The loader stores it verbatim and does not interpret it. Validators that consume an edge interpret the anchor in whatever vocabulary fits — Markdown heading, LaTeX label, Lean declaration, code symbol id, regex selector.
+A node's `anchor` is a string. The loader stores it verbatim and does not interpret it. Validators that consume an edge interpret the anchor in whatever vocabulary fits — Markdown heading, LaTeX label, Lean declaration, code symbol ID, regular-expression selector.
 
 Anchor *resolution* is a per-validator concern. Pinning an anchor grammar in the manifest schema would conflate the manifest's contract (what edges exist) with each validator's contract (how it locates content within a file).
 
@@ -93,11 +99,15 @@ Slice-1 vocabulary:
 - `dependent_artifact_co_changed` — source changed and target also changed in the same set.
 - `dependent_artifact_acked` — source changed, target unchanged, valid ack file present.
 - `dependent_artifact_changed_without_target_update` — source changed, target unchanged, no valid ack.
-- `dependent_artifact_stale_by_hash` — Mode B: target's `tracks:` sha does not match the source's current sha. (Reserved; emitted only once Mode B is implemented in slice 2.)
+- `dependent_artifact_stale_by_hash` — Mode B: target's `tracks:` digest does not match the source's current SHA-256. Emitted by the issue #181 Mode B implementation.
+- `target_stamp_missing` — Mode B: target has no `tracks:` field in YAML frontmatter (issue #181).
+- `target_stamp_malformed` — Mode B: frontmatter unparseable, `tracks:` not in canonical `<source-id>@sha256:<digest>` form, or stamp source-ID does not match the manifest source ID (issue #181).
+- `dependent_artifact_source_missing` — Mode B: manifest source path absent on disk; emitted as `unavailable` (issue #181).
+- `dependent_artifact_target_missing` — Mode B: manifest target path absent on disk; emitted as `unavailable` (issue #181).
 - `ack_invalid` — ack file exists but cannot be parsed as a YAML mapping; emitted as FAIL so the author is not left wondering why a file they committed was silently ignored.
 - `edge_not_applicable` — the validator was invoked on a target that does not appear in any edge; emitted as PASS so the rule is safe to enable on multiple targets.
-- `changed_file_source_unresolved` — Mode A: git unavailable or base ref unresolvable; emitted as `unavailable`.
-- `stamped_mode_not_implemented` — an edge declares `mode: stamped` but slice-1 only implements Mode A; emitted as `unavailable` so the deferred mode is surfaced explicitly rather than silently miscategorised.
+- `changed_file_source_unresolved` — Mode A: Git unavailable or base ref unresolvable; emitted as `unavailable`.
+- `stamped_mode_not_implemented` — historical from the slice-1-only era. Mode B is implemented as of issue #181; this evidence kind is retained for any future unrecognised mode value (defensive guard against direct construction outside the manifest loader's enum).
 
 New subtypes are added as needed. `Status` enum values are unchanged; only the evidence vocabulary grows.
 
@@ -130,7 +140,7 @@ pairs:                     # optional sugar; desugared on load
     target: en-foo
 ```
 
-A `pairs[].source` and `pairs[].target` reference node ids. Each `pairs` entry produces two directed edges with `pair_id` set to `pairs[].id`.
+A `pairs[].source` and `pairs[].target` reference node IDs. Each `pairs` entry produces two directed edges with `pair_id` set to `pairs[].id`.
 
 ### 3.2 JSON-Schema fragment
 
@@ -190,10 +200,43 @@ A `pairs[].source` and `pairs[].target` reference node ids. Each `pairs` entry p
 
 The loader additionally enforces:
 
-- node ids are unique;
-- every `edges[].from` and `edges[].to` references a known node id;
-- every `pairs[].source` and `pairs[].target` references a known node id;
+- node IDs are unique;
+- every `edges[].from` and `edges[].to` references a known node ID;
+- every `pairs[].source` and `pairs[].target` references a known node ID;
 - `pair_id` set on a desugared edge equals the originating `pairs[].id`.
+
+### 3.3 Canonical stamp syntax (Mode B)
+
+A target whose incoming edge declares `mode: stamped` records the source revision it tracks via a YAML frontmatter `tracks:` field:
+
+```markdown
+---
+tracks: <source-node-id>@sha256:<64-hex-digit-digest>
+---
+# CLI reference
+
+...
+```
+
+Slice-1 (issue #181) constraints:
+
+- **Frontmatter required.** The stamp must live in a YAML frontmatter block opened with `---` on the very first line and closed with `---` on its own line. Inline tracking lines outside frontmatter are deliberately ignored in this slice.
+- **Whole-file source hashing.** The digest is `sha256(source_file_bytes)` exactly — opaque source anchors are deferred (see §7).
+- **Algorithm prefix is mandatory.** Only `sha256:` is accepted; the prefix is part of the canonical syntax so future algorithms can coexist without changing the schema.
+- **Lowercase 64-hex-digit digest.** Uppercase digests and short digests are rejected as `target_stamp_malformed`.
+- **Single source per target.** A target with multiple incoming stamped edges must currently satisfy each independently, with no multi-source representation. Multi-source stamp aggregation is deferred (see §7).
+- **`<source-node-id>` references the manifest `from` node ID.** A mismatch surfaces as `target_stamp_malformed` so the author is not left wondering why a stamp is silently rejected.
+
+The validator emits one of the following Mode B evidence kinds (extends §2.7):
+
+- `dependent_artifact_unaffected` (PASS, `mode: stamped`) — stamp's digest equals current source SHA-256.
+- `dependent_artifact_stale_by_hash` (FAIL) — stamp present but digest does not match current source.
+- `target_stamp_missing` (FAIL) — target has no `tracks:` field in frontmatter.
+- `target_stamp_malformed` (FAIL) — frontmatter unparseable, `tracks:` value not in canonical syntax, or stamp source-ID does not match the manifest source ID.
+- `dependent_artifact_source_missing` (UNAVAILABLE) — manifest source path does not exist on disk.
+- `dependent_artifact_target_missing` (UNAVAILABLE) — manifest target path does not exist on disk.
+
+The validator never auto-edits a stamp; on a stale or malformed stamp the diagnostic's `remediation` field carries the canonical replacement string.
 
 ---
 
@@ -201,7 +244,7 @@ The loader additionally enforces:
 
 ### 4.1 Manifest path
 
-`.gate-keeper/dependency-manifest.yml`. Co-located with `.gate-keeper/acks/`. The `external_check` rule passes `params.manifest` to the validator; absent, the validator falls back to this default.
+`.gate-keeper/dependency-manifest.yml`. Sits alongside `.gate-keeper/acks/`. The `external_check` rule passes `params.manifest` to the validator; absent, the validator falls back to this default.
 
 ### 4.2 Validator script location
 
@@ -211,7 +254,7 @@ The loader additionally enforces:
 
 The validator computes `git diff --name-only ${GATE_KEEPER_BASE_REF:-origin/main}...HEAD` internally via `subprocess.run(..., shell=False)`. No new CLI flag in slice 1.
 
-If git is unavailable or the base ref does not resolve, the validator emits `Status.UNAVAILABLE` with evidence `kind: changed_file_source_unresolved` rather than treating "all files changed" as a fallback. Fail-closed.
+If Git is unavailable or the base ref does not resolve, the validator emits `Status.UNAVAILABLE` with evidence `kind: changed_file_source_unresolved` rather than treating "all files changed" as a fallback. Fail-closed.
 
 `GATE_KEEPER_BASE_REF` may be set in CI or by the developer; default `origin/main` works for both PR-context CI and `git rebase`-style local workflows.
 
@@ -242,7 +285,7 @@ This note settles slice 1. The following remain deferred:
 - MCP transport for validators.
 - Cycle-detection rule (`documentation_dependency_graph_acyclic` candidate from #156 stays deferred).
 - Cross-repository graphs.
-- An in-repo #158-family reference validator. The repo has no `*.ja.md` / `*.en.md` pair, no Lean files, and no in-repo formalization↔explanation pair. The #158 manifest shape is exercised at the loader-fixture level (bidirectional `pairs:` desugaring; `mode: stamped` parsing) until a real pair exists.
+- An in-repo #158-family reference validator. The repository has no `*.ja.md` / `*.en.md` pair, no Lean files, and no in-repo formalization↔explanation pair. The #158 manifest shape is exercised at the loader-fixture level (bidirectional `pairs:` desugaring; `mode: stamped` parsing) until a real pair exists.
 - Promoting any failure subtype to a `RuleKind`.
 - A new CLI flag for the changed-file set; the validator owns its diff source.
 - Semantic equivalence checks (translation faithfulness, formalization correctness). These remain advisory and route to `semantic_rubric` if and when wired; this note does not couple to that path.

--- a/scripts/dependency_gates/_stamp.py
+++ b/scripts/dependency_gates/_stamp.py
@@ -109,12 +109,22 @@ def read_target_stamp(path: Path) -> Stamp | None:
     """Read *path* and return its parsed stamp, or ``None`` when absent.
 
     Returns ``None`` only when no frontmatter exists or frontmatter has no
-    ``tracks`` key. All other failure modes raise ``StampError``.
+    ``tracks`` key. All other failure modes raise ``StampError``, including:
+
+    - ``OSError`` (file missing, permission denied, etc.) — surfaced as
+      ``cannot read target ...``.
+    - ``UnicodeDecodeError`` (target contains non-UTF-8 / binary bytes) —
+      surfaced as ``cannot decode target ...``. Frontmatter is defined over
+      UTF-8 text, so decode failure means the target cannot carry a stamp;
+      the validator maps this to ``target_stamp_malformed`` rather than
+      crashing.
     """
     try:
         text = path.read_text(encoding="utf-8")
     except OSError as exc:
         raise StampError(f"cannot read target {path}: {exc}") from exc
+    except UnicodeDecodeError as exc:
+        raise StampError(f"cannot decode target {path} as UTF-8: {exc}") from exc
     frontmatter = extract_frontmatter(text)
     if frontmatter is None:
         return None

--- a/scripts/dependency_gates/_stamp.py
+++ b/scripts/dependency_gates/_stamp.py
@@ -1,0 +1,123 @@
+"""Stamp parsing for Mode B (target-stamped freshness) dependency gates.
+
+A stamped target records the source revision it tracks via a YAML frontmatter
+``tracks:`` field, e.g.::
+
+    ---
+    tracks: cli-implementation@sha256:abc123...
+    ---
+    # CLI reference
+
+    ...
+
+Slice 1 (issue #181): whole-file SHA-256 of the source artifact bytes; one
+source per target; frontmatter required (no inline tracking line outside
+frontmatter). See docs/design/dependency-gates.md §3.3 (Stamp syntax).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Canonical stamp syntax: ``<source-node-id>@sha256:<64 lowercase hex chars>``.
+# The node id allows the conventional manifest character set (alnum, dash,
+# underscore, slash, colon, dot). Whitespace is rejected.
+_STAMP_RE = re.compile(r"^(?P<source_id>\S+)@sha256:(?P<digest>[0-9a-f]{64})$")
+
+# Frontmatter must open with ``---`` on the very first line and close with
+# ``---`` on its own line. An empty frontmatter (``---\n---\n``) is valid and
+# parses to ``{}``.
+_FRONTMATTER_RE = re.compile(
+    r"\A---\r?\n(.*?)^---\r?\n",
+    re.DOTALL | re.MULTILINE,
+)
+
+
+class StampError(ValueError):
+    """Raised when a target's frontmatter cannot be parsed or the stamp is malformed."""
+
+
+@dataclass(frozen=True)
+class Stamp:
+    """Parsed ``tracks:`` value pointing at a specific source digest."""
+
+    source_id: str
+    algorithm: str  # always "sha256" in slice 1
+    digest: str
+
+    def matches(self, *, source_id: str, digest: str) -> bool:
+        """Return True iff stamp source_id and digest both match the supplied values."""
+        return self.source_id == source_id and self.digest == digest
+
+
+def extract_frontmatter(text: str) -> dict[str, Any] | None:
+    """Return the parsed YAML frontmatter of *text*, or ``None`` if absent.
+
+    A frontmatter block must open with ``---`` on the very first line and
+    close with ``---`` on its own line. Inline tracking lines outside
+    frontmatter are deliberately ignored in slice 1.
+
+    Raises ``StampError`` if frontmatter is present but cannot be parsed as a
+    YAML mapping.
+    """
+    match = _FRONTMATTER_RE.match(text)
+    if match is None:
+        return None
+    body = match.group(1)
+    try:
+        data = yaml.safe_load(body)
+    except yaml.YAMLError as exc:
+        raise StampError(f"frontmatter YAML parse error: {exc}") from exc
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise StampError(f"frontmatter must be a mapping, got {type(data).__name__}")
+    return data
+
+
+def parse_stamp(value: Any) -> Stamp:
+    """Parse a ``tracks:`` value into a :class:`Stamp`.
+
+    Slice 1 accepts only the form ``<source-id>@sha256:<64 hex chars>``.
+    Lists, mappings, and other algorithms are rejected with ``StampError``.
+    """
+    if not isinstance(value, str):
+        raise StampError(
+            f"'tracks' must be a string of the form '<source-id>@sha256:<digest>', got {type(value).__name__}"
+        )
+    stripped = value.strip()
+    if not stripped:
+        raise StampError("'tracks' value is empty")
+    match = _STAMP_RE.match(stripped)
+    if match is None:
+        raise StampError(
+            f"'tracks' value {value!r} is not in canonical form '<source-id>@sha256:<64-hex-digest>'"
+        )
+    return Stamp(
+        source_id=match.group("source_id"),
+        algorithm="sha256",
+        digest=match.group("digest"),
+    )
+
+
+def read_target_stamp(path: Path) -> Stamp | None:
+    """Read *path* and return its parsed stamp, or ``None`` when absent.
+
+    Returns ``None`` only when no frontmatter exists or frontmatter has no
+    ``tracks`` key. All other failure modes raise ``StampError``.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise StampError(f"cannot read target {path}: {exc}") from exc
+    frontmatter = extract_frontmatter(text)
+    if frontmatter is None:
+        return None
+    if "tracks" not in frontmatter:
+        return None
+    return parse_stamp(frontmatter["tracks"])

--- a/scripts/dependency_gates/check_cli_reference.py
+++ b/scripts/dependency_gates/check_cli_reference.py
@@ -30,6 +30,10 @@ if __package__ in (None, ""):
         compute_changed_files,
         resolve_base_ref,
     )
+    from dependency_gates._stamp import (  # noqa: E402
+        StampError,
+        read_target_stamp,
+    )
     from dependency_gates.manifest import (  # noqa: E402
         Edge,
         Manifest,
@@ -42,6 +46,10 @@ else:
         ChangedFilesError,
         compute_changed_files,
         resolve_base_ref,
+    )
+    from ._stamp import (
+        StampError,
+        read_target_stamp,
     )
     from .manifest import (
         Edge,
@@ -105,29 +113,41 @@ def _run(*, repo_root: Path, manifest_path: Path, target: str) -> Outcome:
             evidence_data={"target": target_rel},
         )
 
-    missing = [node.path for node in manifest.nodes if not (repo_root / node.path).exists()]
-    if missing:
-        return Outcome(
-            status="fail",
-            message=f"manifest references missing path(s): {missing}",
-            evidence_kind="manifest_target_missing",
-            evidence_data={"missing_paths": missing},
-            remediation=("Update the manifest entries or restore the referenced files."),
-        )
+    # Mode A's manifest_target_missing check covers every node globally;
+    # Mode B handles missing source/target per-edge (with `unavailable`
+    # evidence) so the global check applies only when at least one applicable
+    # edge needs Mode A semantics.
+    has_mode_a_edge = any(edge.mode == "affected_set" for edge in edges)
+    if has_mode_a_edge:
+        missing = [node.path for node in manifest.nodes if not (repo_root / node.path).exists()]
+        if missing:
+            return Outcome(
+                status="fail",
+                message=f"manifest references missing path(s): {missing}",
+                evidence_kind="manifest_target_missing",
+                evidence_data={"missing_paths": missing},
+                remediation=("Update the manifest entries or restore the referenced files."),
+            )
 
-    base_ref = resolve_base_ref()
-    try:
-        changed = compute_changed_files(repo_root, base_ref)
-    except ChangedFilesError as exc:
-        return Outcome(
-            status="unavailable",
-            message=f"cannot compute changed-file set: {exc}",
-            evidence_kind="changed_file_source_unresolved",
-            evidence_data={"base_ref": base_ref, "error": str(exc)},
-            remediation=(
-                "Set GATE_KEEPER_BASE_REF to a resolvable git ref, or run inside a git working tree."
-            ),
-        )
+    # Mode A needs the changed-file set; Mode B is a pure target-side check.
+    # Defer the diff invocation until at least one applicable edge needs it,
+    # so a manifest containing only stamped edges does not fail when git is
+    # unavailable.
+    changed: frozenset[str] = frozenset()
+    if has_mode_a_edge:
+        base_ref = resolve_base_ref()
+        try:
+            changed = compute_changed_files(repo_root, base_ref)
+        except ChangedFilesError as exc:
+            return Outcome(
+                status="unavailable",
+                message=f"cannot compute changed-file set: {exc}",
+                evidence_kind="changed_file_source_unresolved",
+                evidence_data={"base_ref": base_ref, "error": str(exc)},
+                remediation=(
+                    "Set GATE_KEEPER_BASE_REF to a resolvable git ref, or run inside a git working tree."
+                ),
+            )
 
     return _evaluate_edges(
         manifest=manifest,
@@ -186,19 +206,30 @@ def _evaluate_edge(
     target_path = target_node.path
     edge_id = _edge_id(edge, source_node, target_node)
 
+    if edge.mode == "stamped":
+        return _evaluate_stamped_edge(
+            edge=edge,
+            source_node=source_node,
+            target_node=target_node,
+            edge_id=edge_id,
+            repo_root=repo_root,
+        )
+
     if edge.mode != "affected_set":
+        # Defensive: the manifest loader already restricts ``mode`` to the
+        # documented enum, so unknown modes can only arrive via direct
+        # construction (e.g. tests). Surface them rather than silently
+        # mis-evaluating.
         return Outcome(
             status="unavailable",
-            message=(f"edge {edge_id}: mode {edge.mode!r} is not implemented in slice 1 (affected_set only)"),
+            message=(f"edge {edge_id}: mode {edge.mode!r} is not a recognised dependency-gate mode"),
             evidence_kind="stamped_mode_not_implemented",
             evidence_data={
                 "edge_id": edge_id,
                 "mode": edge.mode,
             },
             remediation=(
-                "Slice 1 implements Mode A (affected_set) only. "
-                "Mode B (stamped) is reserved for a future slice; see "
-                "docs/design/dependency-gates.md §6."
+                "Use 'affected_set' (Mode A) or 'stamped' (Mode B); see docs/design/dependency-gates.md §2.4."
             ),
         )
 
@@ -266,6 +297,154 @@ def _evaluate_edge(
             f"Update {target_path} to reflect the change in {source_path}, "
             f"or commit a reviewer ack at "
             f".gate-keeper/acks/{edge_id}.yml with source_sha={source_sha}."
+        ),
+    )
+
+
+def _evaluate_stamped_edge(
+    *,
+    edge: Edge,
+    source_node: Node,
+    target_node: Node,
+    edge_id: str,
+    repo_root: Path,
+) -> Outcome:
+    """Mode B: target frontmatter must record ``tracks: <source-id>@sha256:<digest>``.
+
+    The validator compares the stamp digest against the current source file's
+    SHA-256 and emits one of:
+
+    - ``dependent_artifact_unaffected``        (pass) — stamp matches source.
+    - ``dependent_artifact_stale_by_hash``     (fail) — stamp present but stale.
+    - ``target_stamp_missing``                 (fail) — no ``tracks:`` in target frontmatter.
+    - ``target_stamp_malformed``               (fail) — frontmatter or stamp unparseable.
+    - ``dependent_artifact_source_missing``    (unavailable) — source path absent.
+    - ``dependent_artifact_target_missing``    (unavailable) — target path absent.
+
+    Slice 1 (issue #181): whole-file source hashing; one source per target;
+    stamp must live in YAML frontmatter (no inline lines).
+    """
+    source_path = source_node.path
+    target_path = target_node.path
+    source_abs = repo_root / source_path
+    target_abs = repo_root / target_path
+
+    if not source_abs.is_file():
+        return Outcome(
+            status="unavailable",
+            message=f"edge {edge_id}: source file {source_path} not found",
+            evidence_kind="dependent_artifact_source_missing",
+            evidence_data={
+                "edge_id": edge_id,
+                "source_path": source_path,
+                "target_path": target_path,
+            },
+            remediation=(
+                f"Restore {source_path} or fix the manifest 'from' node to reference an existing file."
+            ),
+        )
+    if not target_abs.is_file():
+        return Outcome(
+            status="unavailable",
+            message=f"edge {edge_id}: target file {target_path} not found",
+            evidence_kind="dependent_artifact_target_missing",
+            evidence_data={
+                "edge_id": edge_id,
+                "source_path": source_path,
+                "target_path": target_path,
+            },
+            remediation=(
+                f"Restore {target_path} or fix the manifest 'to' node to reference an existing file."
+            ),
+        )
+
+    source_sha = _file_sha256(source_abs)
+    expected_stamp = f"{source_node.id}@sha256:{source_sha}"
+
+    try:
+        stamp = read_target_stamp(target_abs)
+    except StampError as exc:
+        return Outcome(
+            status="fail",
+            message=f"edge {edge_id}: target stamp malformed: {exc}",
+            evidence_kind="target_stamp_malformed",
+            evidence_data={
+                "edge_id": edge_id,
+                "source_path": source_path,
+                "target_path": target_path,
+                "error": str(exc),
+            },
+            remediation=(f"Fix the YAML frontmatter of {target_path}; set 'tracks: {expected_stamp}'."),
+        )
+
+    if stamp is None:
+        return Outcome(
+            status="fail",
+            message=f"edge {edge_id}: {target_path} has no 'tracks:' stamp in frontmatter",
+            evidence_kind="target_stamp_missing",
+            evidence_data={
+                "edge_id": edge_id,
+                "source_path": source_path,
+                "target_path": target_path,
+                "expected_stamp": expected_stamp,
+            },
+            remediation=(
+                f"Add a YAML frontmatter block to {target_path} containing 'tracks: {expected_stamp}'."
+            ),
+        )
+
+    if stamp.source_id != source_node.id:
+        return Outcome(
+            status="fail",
+            message=(
+                f"edge {edge_id}: target stamp source-id {stamp.source_id!r} "
+                f"does not match manifest source {source_node.id!r}"
+            ),
+            evidence_kind="target_stamp_malformed",
+            evidence_data={
+                "edge_id": edge_id,
+                "source_path": source_path,
+                "target_path": target_path,
+                "stamp_source_id": stamp.source_id,
+                "expected_source_id": source_node.id,
+            },
+            remediation=(f"Update the 'tracks:' field in {target_path} to '{expected_stamp}'."),
+        )
+
+    if stamp.digest == source_sha:
+        return Outcome(
+            status="pass",
+            message=(f"edge {edge_id}: target stamp matches current source sha"),
+            evidence_kind="dependent_artifact_unaffected",
+            evidence_data={
+                "edge_id": edge_id,
+                "source_path": source_path,
+                "target_path": target_path,
+                "source_sha": source_sha,
+                "stamp": expected_stamp,
+                "mode": "stamped",
+            },
+        )
+
+    return Outcome(
+        status="fail",
+        message=(
+            f"edge {edge_id}: target stamp tracks sha256:{stamp.digest} but "
+            f"source {source_path} is now sha256:{source_sha}"
+        ),
+        evidence_kind="dependent_artifact_stale_by_hash",
+        evidence_data={
+            "edge_id": edge_id,
+            "source_path": source_path,
+            "target_path": target_path,
+            "source_sha": source_sha,
+            "stamp_digest": stamp.digest,
+            "stamp_source_id": stamp.source_id,
+            "expected_stamp": expected_stamp,
+        },
+        remediation=(
+            f"Re-review {target_path} against the new source and update "
+            f"the 'tracks:' field to '{expected_stamp}'."
         ),
     )
 

--- a/tests/fixtures/dependency_gates/stamped_manifest.yml
+++ b/tests/fixtures/dependency_gates/stamped_manifest.yml
@@ -1,0 +1,37 @@
+# Fixture manifest exercising Mode B (target-stamped) edges.
+#
+# Used by tests/test_dependency_validator.py and as a worked example of the
+# stamp syntax documented in docs/design/dependency-gates.md §3.3.
+#
+# Schema: docs/design/dependency-gates.md §3.
+
+nodes:
+  - id: lean-theorem
+    path: theorems/foo.lean
+    kind: code
+  - id: appendix-explanation
+    path: docs/appendix-foo.md
+    kind: reference
+  - id: cli-implementation
+    path: src/gate_keeper/cli.py
+    kind: code
+  - id: cli-reference
+    path: docs/cli-reference.md
+    kind: reference
+
+edges:
+  # Mode B (stamped): the appendix explanation pins the exact Lean-theorem
+  # source it tracks. Slice-1 (issue #181) implements whole-file source
+  # hashing, so the digest is sha256(source-file-bytes).
+  - from: lean-theorem
+    to: appendix-explanation
+    relation: explains
+    mode: stamped
+
+  # Mode A (affected_set): the CLI reference must co-change or carry an ack
+  # whenever the CLI implementation changes. Default mode; explicit here for
+  # the fixture's pedagogical value.
+  - from: cli-implementation
+    to: cli-reference
+    relation: documents
+    mode: affected_set

--- a/tests/test_dependency_stamp.py
+++ b/tests/test_dependency_stamp.py
@@ -1,0 +1,132 @@
+"""Unit tests for ``scripts/dependency_gates/_stamp`` (issue #181).
+
+Covers stamp parsing in isolation from the validator dispatch, mirroring the
+``test_dependency_manifest`` style for ``manifest.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_ROOT = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_ROOT))
+
+from dependency_gates._stamp import (  # noqa: E402
+    Stamp,
+    StampError,
+    extract_frontmatter,
+    parse_stamp,
+    read_target_stamp,
+)
+
+GOOD_DIGEST = "a" * 64
+
+
+class TestParseStamp:
+    def test_canonical_form_parses(self):
+        stamp = parse_stamp(f"src@sha256:{GOOD_DIGEST}")
+        assert stamp == Stamp(source_id="src", algorithm="sha256", digest=GOOD_DIGEST)
+
+    def test_node_id_with_dash_underscore_dot(self):
+        stamp = parse_stamp(f"my.node_id-1@sha256:{GOOD_DIGEST}")
+        assert stamp.source_id == "my.node_id-1"
+
+    def test_leading_trailing_whitespace_stripped(self):
+        stamp = parse_stamp(f"  src@sha256:{GOOD_DIGEST}  ")
+        assert stamp.source_id == "src"
+
+    def test_empty_string_rejected(self):
+        with pytest.raises(StampError, match="empty"):
+            parse_stamp("")
+
+    def test_non_string_rejected(self):
+        with pytest.raises(StampError, match="must be a string"):
+            parse_stamp(["src", "sha256", GOOD_DIGEST])
+
+    def test_missing_algorithm_rejected(self):
+        with pytest.raises(StampError, match="canonical form"):
+            parse_stamp(f"src:{GOOD_DIGEST}")
+
+    def test_uppercase_digest_rejected(self):
+        # Stamps are case-sensitive on the digest to match git's lowercase
+        # convention; explicit failure is better than silent normalisation.
+        with pytest.raises(StampError, match="canonical form"):
+            parse_stamp("src@sha256:" + ("A" * 64))
+
+    def test_short_digest_rejected(self):
+        with pytest.raises(StampError, match="canonical form"):
+            parse_stamp("src@sha256:abcd")
+
+    def test_unsupported_algorithm_rejected(self):
+        with pytest.raises(StampError, match="canonical form"):
+            parse_stamp(f"src@md5:{'a' * 32}")
+
+
+class TestExtractFrontmatter:
+    def test_basic_frontmatter(self):
+        text = "---\ntitle: Hello\n---\nbody\n"
+        assert extract_frontmatter(text) == {"title": "Hello"}
+
+    def test_no_frontmatter(self):
+        assert extract_frontmatter("just body\n") is None
+
+    def test_empty_frontmatter(self):
+        assert extract_frontmatter("---\n---\nbody\n") == {}
+
+    def test_crlf_line_endings(self):
+        text = "---\r\ntitle: x\r\n---\r\nbody\r\n"
+        assert extract_frontmatter(text) == {"title": "x"}
+
+    def test_non_mapping_rejected(self):
+        with pytest.raises(StampError, match="must be a mapping"):
+            extract_frontmatter("---\n- a\n- b\n---\nbody\n")
+
+    def test_yaml_parse_error_rejected(self):
+        with pytest.raises(StampError, match="parse error"):
+            extract_frontmatter("---\n: : :\n  - bad\n---\nbody\n")
+
+    def test_frontmatter_must_be_at_start(self):
+        # A doc that has --- markers later in the file but not at start has
+        # no frontmatter.
+        text = "intro paragraph\n---\ntitle: x\n---\nbody\n"
+        assert extract_frontmatter(text) is None
+
+
+class TestReadTargetStamp:
+    def test_no_frontmatter_returns_none(self, tmp_path: Path):
+        p = tmp_path / "doc.md"
+        p.write_text("just text\n", encoding="utf-8")
+        assert read_target_stamp(p) is None
+
+    def test_no_tracks_key_returns_none(self, tmp_path: Path):
+        p = tmp_path / "doc.md"
+        p.write_text("---\ntitle: x\n---\nbody\n", encoding="utf-8")
+        assert read_target_stamp(p) is None
+
+    def test_valid_stamp(self, tmp_path: Path):
+        p = tmp_path / "doc.md"
+        p.write_text(
+            f"---\ntracks: src@sha256:{GOOD_DIGEST}\n---\nbody\n",
+            encoding="utf-8",
+        )
+        stamp = read_target_stamp(p)
+        assert stamp is not None
+        assert stamp.source_id == "src"
+        assert stamp.digest == GOOD_DIGEST
+
+    def test_malformed_stamp_raises(self, tmp_path: Path):
+        p = tmp_path / "doc.md"
+        p.write_text(
+            "---\ntracks: not-a-stamp\n---\nbody\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(StampError):
+            read_target_stamp(p)
+
+    def test_missing_file_raises(self, tmp_path: Path):
+        with pytest.raises(StampError, match="cannot read"):
+            read_target_stamp(tmp_path / "no-such.md")

--- a/tests/test_dependency_stamp.py
+++ b/tests/test_dependency_stamp.py
@@ -130,3 +130,26 @@ class TestReadTargetStamp:
     def test_missing_file_raises(self, tmp_path: Path):
         with pytest.raises(StampError, match="cannot read"):
             read_target_stamp(tmp_path / "no-such.md")
+
+    def test_non_utf8_bytes_raises_stamp_error(self, tmp_path: Path):
+        """Target containing non-UTF-8 bytes must surface as ``StampError``,
+        not propagate ``UnicodeDecodeError`` from ``Path.read_text``.
+
+        Regression for codex P2 on PR #196: ``read_target_stamp`` previously
+        only wrapped ``OSError``, so a stamped target with mojibake / binary
+        bytes crashed the validator instead of producing a malformed-stamp
+        diagnostic.
+        """
+        p = tmp_path / "doc.md"
+        # 0xff is not valid UTF-8 in any position; ``Path.read_text(encoding="utf-8")``
+        # raises ``UnicodeDecodeError`` on it.
+        p.write_bytes(b"---\ntracks: src@sha256:" + (b"a" * 64) + b"\n---\nbody \xff\n")
+        with pytest.raises(StampError, match="cannot decode"):
+            read_target_stamp(p)
+
+    def test_binary_target_raises_stamp_error(self, tmp_path: Path):
+        """A purely binary target file is reported as a malformed stamp."""
+        p = tmp_path / "doc.md"
+        p.write_bytes(b"\x00\x01\x02\xff\xfe\xfd")
+        with pytest.raises(StampError, match="cannot decode"):
+            read_target_stamp(p)

--- a/tests/test_dependency_validator.py
+++ b/tests/test_dependency_validator.py
@@ -351,6 +351,25 @@ def test_stamped_short_digest_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     assert out.evidence_kind == "target_stamp_malformed"
 
 
+def test_stamped_non_utf8_target_reports_malformed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Target file with non-UTF-8 bytes must surface as ``target_stamp_malformed``.
+
+    Regression for codex P2 on PR #196: the previous ``read_target_stamp``
+    only caught ``OSError``, so a target with mojibake / binary bytes
+    propagated ``UnicodeDecodeError`` past ``_evaluate_stamped_edge`` and
+    crashed the validator instead of producing a structured diagnostic.
+    """
+    _seed_stamped_repo(tmp_path)
+    # Overwrite the stamped target with bytes that are not valid UTF-8.
+    doc = tmp_path / "docs" / "cli-reference.md"
+    doc.write_bytes(b"---\ntracks: src@sha256:" + (b"a" * 64) + b"\n---\nbody \xff\n")
+    _patch_changed(monkeypatch, set())
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "fail"
+    assert out.evidence_kind == "target_stamp_malformed"
+    assert "decode" in out.evidence_data["error"]
+
+
 def test_stamped_wrong_source_id_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Stamp source-id does not match the manifest 'from' node id."""
     _seed_stamped_repo(tmp_path, stamp_source_id="some-other-source")

--- a/tests/test_dependency_validator.py
+++ b/tests/test_dependency_validator.py
@@ -194,14 +194,182 @@ def test_ack_non_mapping_body_rejected(tmp_path: Path, monkeypatch: pytest.Monke
     assert out.evidence_kind == "ack_invalid"
 
 
-def test_stamped_mode_not_implemented(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    # Manifest declares an edge with mode: stamped — slice 1 only implements A.
+def _seed_stamped_repo(
+    root: Path,
+    *,
+    source_text: str = "src body\n",
+    stamp_value: str | None = None,
+    stamp_source_id: str = "src",
+    extra_frontmatter: dict[str, str] | None = None,
+    target_has_frontmatter: bool = True,
+    extra_target_body: str = "doc\n",
+) -> tuple[Path, Path]:
+    """Materialise a stamped-mode pair under *root*.
+
+    By default the target frontmatter contains ``tracks:
+    <stamp_source_id>@sha256:<digest>`` matching the seeded source bytes.
+    Pass ``stamp_value`` to inject a literal frontmatter ``tracks:`` value
+    (used by the malformed/stale tests).
+    """
+    src = root / "src" / "gate_keeper" / "cli.py"
+    src.parent.mkdir(parents=True)
+    src.write_text(source_text, encoding="utf-8")
+
+    sha = hashlib.sha256(src.read_bytes()).hexdigest()
+    if stamp_value is None:
+        stamp_value = f"{stamp_source_id}@sha256:{sha}"
+
+    doc = root / "docs" / "cli-reference.md"
+    doc.parent.mkdir(parents=True)
+    if target_has_frontmatter:
+        front = {"tracks": stamp_value}
+        if extra_frontmatter:
+            front.update(extra_frontmatter)
+        body = "---\n"
+        for k, v in front.items():
+            body += f"{k}: {v}\n"
+        body += "---\n" + extra_target_body
+    else:
+        body = extra_target_body
+    doc.write_text(body, encoding="utf-8")
+
+    manifest_dir = root / ".gate-keeper"
+    manifest_dir.mkdir()
+    (manifest_dir / "dependency-manifest.yml").write_text(
+        dedent(
+            """
+            nodes:
+              - id: src
+                path: src/gate_keeper/cli.py
+              - id: tgt
+                path: docs/cli-reference.md
+            edges:
+              - from: src
+                to: tgt
+                relation: documents
+                mode: stamped
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    return src, doc
+
+
+def test_stamped_matching_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _seed_stamped_repo(tmp_path)
+    _patch_changed(monkeypatch, set())
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "pass"
+    assert out.evidence_kind == "dependent_artifact_unaffected"
+    assert out.evidence_data["mode"] == "stamped"
+
+
+def test_stamped_stale_digest_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Stamp digest does not match source's current sha256 → fail."""
+    _seed_stamped_repo(
+        tmp_path,
+        source_text="updated body\n",
+        stamp_value="src@sha256:" + ("0" * 64),
+    )
+    _patch_changed(monkeypatch, set())
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "fail"
+    assert out.evidence_kind == "dependent_artifact_stale_by_hash"
+    assert out.evidence_data["stamp_digest"] == "0" * 64
+    expected_sha = hashlib.sha256(b"updated body\n").hexdigest()
+    assert out.evidence_data["source_sha"] == expected_sha
+    assert out.remediation is not None
+    assert "tracks:" in out.remediation
+
+
+def test_stamped_missing_stamp_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Target has no ``tracks:`` field in frontmatter → fail."""
+    _seed_stamped_repo(tmp_path, target_has_frontmatter=False)
+    _patch_changed(monkeypatch, set())
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "fail"
+    assert out.evidence_kind == "target_stamp_missing"
+    assert "expected_stamp" in out.evidence_data
+
+
+def test_stamped_frontmatter_without_tracks_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Target has frontmatter but no ``tracks:`` key → fail (missing)."""
     src = tmp_path / "src" / "gate_keeper" / "cli.py"
     src.parent.mkdir(parents=True)
     src.write_text("body\n", encoding="utf-8")
     doc = tmp_path / "docs" / "cli-reference.md"
     doc.parent.mkdir(parents=True)
-    doc.write_text("doc\n", encoding="utf-8")
+    doc.write_text("---\ntitle: doc\n---\nbody\n", encoding="utf-8")
+    (tmp_path / ".gate-keeper").mkdir()
+    (tmp_path / ".gate-keeper" / "dependency-manifest.yml").write_text(
+        dedent(
+            """
+            nodes:
+              - id: src
+                path: src/gate_keeper/cli.py
+              - id: tgt
+                path: docs/cli-reference.md
+            edges:
+              - from: src
+                to: tgt
+                relation: documents
+                mode: stamped
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    _patch_changed(monkeypatch, set())
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "fail"
+    assert out.evidence_kind == "target_stamp_missing"
+
+
+def test_stamped_malformed_stamp_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Stamp present but not in canonical ``<id>@sha256:<hex>`` form."""
+    _seed_stamped_repo(tmp_path, stamp_value="not-a-valid-stamp")
+    _patch_changed(monkeypatch, set())
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "fail"
+    assert out.evidence_kind == "target_stamp_malformed"
+
+
+def test_stamped_wrong_algorithm_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Algorithm other than sha256 is rejected as malformed in slice 1."""
+    _seed_stamped_repo(tmp_path, stamp_value="src@md5:" + ("a" * 32))
+    _patch_changed(monkeypatch, set())
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "fail"
+    assert out.evidence_kind == "target_stamp_malformed"
+
+
+def test_stamped_short_digest_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A digest that isn't 64 lowercase hex chars is malformed."""
+    _seed_stamped_repo(tmp_path, stamp_value="src@sha256:abcd")
+    _patch_changed(monkeypatch, set())
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "fail"
+    assert out.evidence_kind == "target_stamp_malformed"
+
+
+def test_stamped_wrong_source_id_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Stamp source-id does not match the manifest 'from' node id."""
+    _seed_stamped_repo(tmp_path, stamp_source_id="some-other-source")
+    _patch_changed(monkeypatch, set())
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "fail"
+    assert out.evidence_kind == "target_stamp_malformed"
+    assert out.evidence_data["stamp_source_id"] == "some-other-source"
+    assert out.evidence_data["expected_source_id"] == "src"
+
+
+def test_stamped_missing_source_unavailable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Source path declared in manifest does not exist on disk."""
+    doc = tmp_path / "docs" / "cli-reference.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text(
+        "---\ntracks: src@sha256:" + ("0" * 64) + "\n---\nbody\n",
+        encoding="utf-8",
+    )
     (tmp_path / ".gate-keeper").mkdir()
     (tmp_path / ".gate-keeper" / "dependency-manifest.yml").write_text(
         dedent(
@@ -223,7 +391,106 @@ def test_stamped_mode_not_implemented(tmp_path: Path, monkeypatch: pytest.Monkey
     _patch_changed(monkeypatch, set())
     out = _run(tmp_path, "docs/cli-reference.md")
     assert out.status == "unavailable"
-    assert out.evidence_kind == "stamped_mode_not_implemented"
+    assert out.evidence_kind == "dependent_artifact_source_missing"
+
+
+def test_stamped_missing_target_unavailable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Target path declared in manifest does not exist on disk.
+
+    The validator is invoked with the target path string, so the path passes
+    the per-edge dispatch lookup; only the on-disk read surfaces the absence.
+    """
+    src = tmp_path / "src" / "gate_keeper" / "cli.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("body\n", encoding="utf-8")
+    (tmp_path / ".gate-keeper").mkdir()
+    (tmp_path / ".gate-keeper" / "dependency-manifest.yml").write_text(
+        dedent(
+            """
+            nodes:
+              - id: src
+                path: src/gate_keeper/cli.py
+              - id: tgt
+                path: docs/cli-reference.md
+            edges:
+              - from: src
+                to: tgt
+                relation: documents
+                mode: stamped
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    _patch_changed(monkeypatch, set())
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "unavailable"
+    assert out.evidence_kind == "dependent_artifact_target_missing"
+
+
+def test_stamped_does_not_invoke_changed_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A stamped-only manifest does not consult git diff (Mode B is target-side only)."""
+    _seed_stamped_repo(tmp_path)
+
+    def _boom(*_a: Any, **_kw: Any) -> Any:  # pragma: no cover - assertion path
+        raise AssertionError("compute_changed_files must not be called for stamped-only edges")
+
+    monkeypatch.setattr(validator, "compute_changed_files", _boom)
+    monkeypatch.setattr(validator, "resolve_base_ref", lambda env=None: "origin/main")
+    out = _run(tmp_path, "docs/cli-reference.md")
+    assert out.status == "pass"
+    assert out.evidence_kind == "dependent_artifact_unaffected"
+
+
+def test_fixture_manifest_loads_with_mixed_modes():
+    """The shipped fixture manifest covers both Mode A and Mode B edges."""
+    from dependency_gates.manifest import load_manifest
+
+    fixture = Path(__file__).resolve().parent / "fixtures" / "dependency_gates" / "stamped_manifest.yml"
+    manifest = load_manifest(fixture)
+    modes_by_to = {edge.to_id: edge.mode for edge in manifest.edges}
+    assert modes_by_to["appendix-explanation"] == "stamped"
+    assert modes_by_to["cli-reference"] == "affected_set"
+
+
+def test_stamped_pairs_desugar_propagates_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """``pairs:`` sugar with ``mode: stamped`` desugars into stamped edges."""
+    src = tmp_path / "src" / "gate_keeper" / "cli.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("body\n", encoding="utf-8")
+    sha = hashlib.sha256(src.read_bytes()).hexdigest()
+    doc = tmp_path / "docs" / "cli-reference.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text(
+        f"---\ntracks: src@sha256:{sha}\n---\nbody\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".gate-keeper").mkdir()
+    (tmp_path / ".gate-keeper" / "dependency-manifest.yml").write_text(
+        dedent(
+            """
+            nodes:
+              - id: src
+                path: src/gate_keeper/cli.py
+              - id: tgt
+                path: docs/cli-reference.md
+            pairs:
+              - id: cli-pair
+                relation: documents
+                source: src
+                target: tgt
+                mode: stamped
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    _patch_changed(monkeypatch, set())
+    out = _run(tmp_path, "docs/cli-reference.md")
+    # pairs desugar to two directed edges; the src->tgt direction passes
+    # because the target stamp matches. The tgt->src direction would also
+    # be evaluated but the validator is invoked with target=docs/cli-reference.md
+    # so only edges with to_id = tgt apply.
+    assert out.status == "pass"
+    assert out.evidence_kind == "dependent_artifact_unaffected"
 
 
 def test_multiple_edges_to_same_target_aggregated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
Closes #181. Umbrella #159 slice 2.

## Summary

Implements Mode B (target-stamped freshness) for dependency gates. An edge with `mode: stamped` no longer returns `stamped_mode_not_implemented`; the validator now compares the target frontmatter's `tracks:` stamp against the source artifact's current SHA-256.

## Design-question decisions (per issue body recommendations)

| Question | Decision |
|---|---|
| Hashing scope | **Whole-file** SHA-256 of source bytes. No opaque anchors in slice 1. |
| Canonical stamp syntax | `tracks: <source-node-id>@sha256:<64-hex-digit-digest>` in YAML frontmatter. |
| Auto-edit on stale | **No** — report only. Remediation strings carry the canonical replacement. |
| Frontmatter required | **Yes** — inline tracking lines outside frontmatter deliberately ignored in slice 1. |
| Multi-source representation | Single source per target for slice 1; multi-source aggregation deferred. |

## New evidence vocabulary (extends §2.7)

- `dependent_artifact_unaffected` (PASS, `mode: stamped`) — stamp digest equals current source SHA-256.
- `dependent_artifact_stale_by_hash` (FAIL) — stamp present but digest mismatched.
- `target_stamp_missing` (FAIL) — no `tracks:` field in target frontmatter.
- `target_stamp_malformed` (FAIL) — frontmatter unparseable, `tracks:` value not in canonical syntax, or stamp source-ID does not match the manifest source ID.
- `dependent_artifact_source_missing` (UNAVAILABLE) — manifest source path absent.
- `dependent_artifact_target_missing` (UNAVAILABLE) — manifest target path absent.

The validator now skips `compute_changed_files` (and therefore `git diff`) when no applicable edge is in `affected_set` mode, so a Mode-B-only manifest is fully git-independent.

## Files

- `scripts/dependency_gates/_stamp.py` — new. Frontmatter extractor + stamp parser.
- `scripts/dependency_gates/check_cli_reference.py` — `_evaluate_edge` dispatches to a new `_evaluate_stamped_edge`; the global `manifest_target_missing` check and `compute_changed_files` call are skipped when no Mode-A edges apply.
- `docs/design/dependency-gates.md` §3.3 — canonical stamp syntax; §2.7 extended with new evidence vocabulary; `stamped_mode_not_implemented` reframed as defensive guard. Pre-existing textlint terminology errors on lines I did not touch were also fixed (id→ID, git→Git, repo→repository, Co-located→Sits alongside).
- `tests/test_dependency_stamp.py` — new. 21 unit tests on stamp parsing (canonical / non-string / empty / wrong-algorithm / uppercase digest / short digest / frontmatter at start / CRLF / no `tracks:` key / etc.).
- `tests/test_dependency_validator.py` — replaces the now-obsolete `test_stamped_mode_not_implemented` with 12 Mode-B scenarios: matching stamp, stale digest, missing stamp, frontmatter-without-tracks, malformed stamp, wrong algorithm, short digest, wrong source-id, missing source, missing target, no-git-call assertion, `pairs:`-desugar mode propagation, and a fixture round-trip.
- `tests/fixtures/dependency_gates/stamped_manifest.yml` — new. Fixture covering one Mode B (Lean theorem → appendix explanation) and one Mode A (CLI implementation → CLI reference) edge.

## Validation

```sh
uv run pytest tests/test_dependency_stamp.py tests/test_dependency_validator.py tests/test_dependency_manifest.py
# 67 passed
uv run pytest --deselect <pre-existing-llm-rubric-failures-on-main>
# 1028 passed
uvx ruff check . && uvx ruff format --check scripts/ tests/
# All checks passed
uvx pyright scripts/dependency_gates/
# 0 errors (3 pre-existing yaml-source warnings)
node_modules/.bin/textlint docs/design/dependency-gates.md
# clean
```

The 10 `tests/test_llm_rubric_backend.py` / `tests/test_validator.py::TestAutoDispatch::test_llm_rule_dispatched_to_llm_stub` / `tests/test_cli_validate.py::TestBackendChoices::test_llm_rubric_backend_accepted_but_unavailable` / `tests/test_validator.py::TestExplicitBackend::test_llm_rubric_explicit_all_rules_unavailable` failures observed locally are pre-existing on `origin/main` (verified by checking out `origin/main` and re-running the failing test); they are unrelated to this slice.

## Deferred surface (follow-up issues / future slices)

- Opaque source anchors (only whole-file source hashing in slice 1).
- Multi-source-per-target stamp representation (e.g. a target tracking N sources).
- Inline tracking lines outside YAML frontmatter.
- Automatic stamp rewriting / repair tool.
- Semantic equivalence between source and target (translation faithfulness, formalization correctness).
- Cross-repository source hashing.
- Promotion of Mode B kinds to a core `RuleKind` (slice-2 promotion criterion in §6 still requires more validators to land first).

## Test plan

- [x] All Mode B scenarios pass (`tests/test_dependency_validator.py`).
- [x] Stamp parser unit tests pass (`tests/test_dependency_stamp.py`).
- [x] Mode A regressions pass (existing tests).
- [x] Manifest loader still parses `mode: stamped` (existing tests).
- [x] Fixture manifest round-trips through the loader.
- [x] Ruff / pyright / textlint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)