### PR TITLE
ci(dogfooding): pass --artifact-kind pr_description per docs/dogfooding.md (#198)

### DIFF
--- a/.github/workflows/dogfooding.yml
+++ b/.github/workflows/dogfooding.yml
@@ -106,6 +106,7 @@ jobs:
           # fetch the PR it falls back to deterministic-no-evidence path.
           uv run gate-keeper validate docs/dogfooding-rules.md \
             --target "$PR_URL" \
+            --artifact-kind pr_description \
             --backend llm-rubric \
             --format json \
             > /tmp/dogfood.json 2> /tmp/dogfood.err || echo "validate exited non-zero (advisory; see stderr below)"


### PR DESCRIPTION
## Summary

- Adds `--artifact-kind pr_description` to the `gate-keeper validate` invocation in `.github/workflows/dogfooding.yml`.
- Aligns the workflow with `docs/dogfooding.md` § "Artifact kind for self-gating runs (#178)", which prescribes this flag so that rules with `target_kind` annotations short-circuit deterministically (`Status.UNSUPPORTED`, `llm_called=false`) instead of routing through the LLM.
- The workflow targets `$PR_URL` (a PR body), so `pr_description` is the correct kind.

## Test plan

- [ ] CI passes (advisory-comment job runs and exits 0 / advisory-only, no new regressions)
- [ ] `dogfooding.yml` diff: exactly one line added (`--artifact-kind pr_description`)
- [ ] No Python source changes; `uvx ruff check .` passes

Closes #198. Refs: #178, #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)