### PR TITLE
fix(bench): thread artifact_kind through fixture eval dispatch (#204)

### DIFF
--- a/src/gate_keeper/bench.py
+++ b/src/gate_keeper/bench.py
@@ -67,7 +67,7 @@ _REQUIRED_FIELDS = frozenset(
 # rubric backend renders the v3 artifact-kind block. Distinct name from the
 # pre-existing ``target.kind`` (path / inline) below — the two address
 # different concerns (artifact kind vs. how the target value is encoded).
-_OPTIONAL_FIELDS = frozenset({"notes", "rule_target_kind"})
+_OPTIONAL_FIELDS = frozenset({"notes", "rule_target_kind", "artifact_kind"})
 _TARGET_FIELDS = frozenset({"kind", "value"})
 _VALID_KINDS = ("path", "inline")
 _VALID_JUDGMENTS = ("pass", "fail", "unsupported")
@@ -89,6 +89,10 @@ class BenchEntry:
     source_path: Path
     # #169 — optional artifact-kind annotation on the synthesised rule.
     rule_target_kind: TargetKind = TargetKind.UNSPECIFIED
+    # #204 — optional caller-declared kind for the target artifact. When set
+    # and ``rule_target_kind`` is also set and differs, the bench harness fires
+    # the deterministic precheck (#178) before invoking the LLM provider.
+    artifact_kind: TargetKind | None = None
 
     def resolve_target(self, targets_root: Path) -> str:
         """Return the literal text the rule should be evaluated against."""
@@ -181,6 +185,24 @@ def parse_entry(data: Any, *, source_path: Path) -> BenchEntry:
                 f"{rule_target_kind_value!r} is not a valid TargetKind; expected one of {valid}"
             ) from exc
 
+    artifact_kind_value = data.get("artifact_kind")
+    if artifact_kind_value is None:
+        artifact_kind: TargetKind | None = None
+    else:
+        if not isinstance(artifact_kind_value, str):
+            raise ValueError(
+                f"BenchEntry({source_path.name}).artifact_kind: expected str, got "
+                f"{type(artifact_kind_value).__name__}"
+            )
+        try:
+            artifact_kind = TargetKind(artifact_kind_value)
+        except ValueError as exc:
+            valid = sorted(member.value for member in TargetKind)
+            raise ValueError(
+                f"BenchEntry({source_path.name}).artifact_kind: "
+                f"{artifact_kind_value!r} is not a valid TargetKind; expected one of {valid}"
+            ) from exc
+
     return BenchEntry(
         id=source_path.stem,
         rule_text=_expect_str(data["rule_text"], "rule_text"),
@@ -195,6 +217,7 @@ def parse_entry(data: Any, *, source_path: Path) -> BenchEntry:
         notes=notes_value,
         source_path=source_path,
         rule_target_kind=rule_target_kind,
+        artifact_kind=artifact_kind,
     )
 
 
@@ -349,6 +372,36 @@ def _evaluate_entry(entry: BenchEntry, targets_root: Path, n: int) -> PerRuleRes
 
     rule = _entry_to_rule(entry)
     target_text = entry.resolve_target(targets_root)
+
+    # #204 — deterministic target-kind-mismatch precheck (#178). When the
+    # fixture declares ``artifact_kind`` and the rule carries a differing
+    # ``target_kind`` annotation, short-circuit to UNSUPPORTED without
+    # invoking the LLM provider — mirrors the precheck in validator.validate.
+    if (
+        entry.artifact_kind is not None
+        and rule.target_kind is not TargetKind.UNSPECIFIED
+        and rule.target_kind is not entry.artifact_kind
+    ):
+        from gate_keeper.validator import _target_kind_mismatch_diagnostic  # noqa: PLC0415
+
+        diag = _target_kind_mismatch_diagnostic(rule, entry.artifact_kind)
+        matched = entry.expected_judgment == "unsupported"
+        return PerRuleResult(
+            id=entry.id,
+            category=entry.category,
+            intended_backend=entry.intended_backend,
+            expected=entry.expected_judgment,
+            actual="unsupported",
+            status="PASS" if matched else "FAIL",
+            reproducibility=1.0 if matched else 0.0,
+            primary_reason=diag.message,
+            failure_mode=None if matched else "kind_mismatch_unexpected",
+            tokens_in=0,
+            tokens_out=0,
+            latency_ms=0,
+            model=None,
+            prompt_version=None,
+        )
 
     pass_count = 0
     fail_count = 0

--- a/src/gate_keeper/bench.py
+++ b/src/gate_keeper/bench.py
@@ -46,6 +46,7 @@ from gate_keeper.models import (
     Status,
     TargetKind,
 )
+from gate_keeper.validator import target_kind_mismatch_diagnostic
 
 # ---------------------------------------------------------------------------
 # Entry loader
@@ -202,6 +203,11 @@ def parse_entry(data: Any, *, source_path: Path) -> BenchEntry:
                 f"BenchEntry({source_path.name}).artifact_kind: "
                 f"{artifact_kind_value!r} is not a valid TargetKind; expected one of {valid}"
             ) from exc
+        if artifact_kind is TargetKind.UNSPECIFIED:
+            raise ValueError(
+                f"BenchEntry({source_path.name}).artifact_kind: "
+                "'unspecified' is not a valid value; use null/absent to mean 'no kind override'"
+            )
 
     return BenchEntry(
         id=source_path.stem,
@@ -382,9 +388,7 @@ def _evaluate_entry(entry: BenchEntry, targets_root: Path, n: int) -> PerRuleRes
         and rule.target_kind is not TargetKind.UNSPECIFIED
         and rule.target_kind is not entry.artifact_kind
     ):
-        from gate_keeper.validator import _target_kind_mismatch_diagnostic  # noqa: PLC0415
-
-        diag = _target_kind_mismatch_diagnostic(rule, entry.artifact_kind)
+        diag = target_kind_mismatch_diagnostic(rule, entry.artifact_kind)
         matched = entry.expected_judgment == "unsupported"
         return PerRuleResult(
             id=entry.id,

--- a/src/gate_keeper/validator.py
+++ b/src/gate_keeper/validator.py
@@ -207,7 +207,7 @@ def _run_n(
     )
 
 
-def _target_kind_mismatch_diagnostic(
+def target_kind_mismatch_diagnostic(
     rule: Rule,
     artifact_kind: TargetKind,
 ) -> Diagnostic:
@@ -334,7 +334,7 @@ def validate(
             and rule.target_kind is not TargetKind.UNSPECIFIED
             and rule.target_kind is not artifact_kind
         ):
-            diagnostics.append(_target_kind_mismatch_diagnostic(rule, artifact_kind))
+            diagnostics.append(target_kind_mismatch_diagnostic(rule, artifact_kind))
             continue
 
         check_fn = _registry.get(resolved_name)

--- a/tests/fixtures/semantic/entries/target-kind-mismatch-01-pr-rule-on-commit.json
+++ b/tests/fixtures/semantic/entries/target-kind-mismatch-01-pr-rule-on-commit.json
@@ -1,6 +1,7 @@
 {
   "rule_text": "The PR description should name the user-visible change in the first sentence.",
   "rule_target_kind": "pr_description",
+  "artifact_kind": "commit_message",
   "target": {
     "kind": "inline",
     "value": "fix(parser): handle CRLF in evidence blocks\n\nThe evidence-block parser was reading raw bytes and treating CR as part of the\ntoken on Windows-authored docs, producing a heading_missing diagnostic on\nfiles that visibly contained the heading. Normalise line endings before the\nshape check so authors on either OS see consistent results.\n"

--- a/tests/fixtures/semantic/entries/target-kind-mismatch-02-commit-rule-on-pr.json
+++ b/tests/fixtures/semantic/entries/target-kind-mismatch-02-commit-rule-on-pr.json
@@ -1,6 +1,7 @@
 {
   "rule_text": "The commit message body explains why the change was made, naming the failure mode and the rationale.",
   "rule_target_kind": "commit_message",
+  "artifact_kind": "pr_description",
   "target": {
     "kind": "path",
     "value": "pr_description_strong.md"

--- a/tests/semantic_fixtures.py
+++ b/tests/semantic_fixtures.py
@@ -86,6 +86,8 @@ class FixtureEntry:
     notes: str | None
     source_path: Path
     rule_target_kind: RuleTargetKind = RuleTargetKind.UNSPECIFIED
+    # #204 — optional caller-declared kind for the target artifact.
+    artifact_kind: RuleTargetKind | None = None
 
 
 _REQUIRED = {
@@ -96,7 +98,7 @@ _REQUIRED = {
     "category",
     "intended_backend",
 }
-_OPTIONAL = {"notes", "rule_target_kind"}
+_OPTIONAL = {"notes", "rule_target_kind", "artifact_kind"}
 _TARGET_REQUIRED = {"kind", "value"}
 
 
@@ -165,6 +167,11 @@ def parse_entry(data: Any, *, source_path: Path) -> FixtureEntry:
         rule_target_kind = RuleTargetKind.UNSPECIFIED
     else:
         rule_target_kind = _coerce_enum(RuleTargetKind, rule_target_kind_value, "rule_target_kind")
+    artifact_kind_value = obj.get("artifact_kind")
+    if artifact_kind_value is None:
+        artifact_kind: RuleTargetKind | None = None
+    else:
+        artifact_kind = _coerce_enum(RuleTargetKind, artifact_kind_value, "artifact_kind")
     return FixtureEntry(
         id=source_path.stem,
         rule_text=_expect_str(obj["rule_text"], "rule_text"),
@@ -178,6 +185,7 @@ def parse_entry(data: Any, *, source_path: Path) -> FixtureEntry:
         notes=notes_value,
         source_path=source_path,
         rule_target_kind=rule_target_kind,
+        artifact_kind=artifact_kind,
     )
 
 

--- a/tests/semantic_fixtures.py
+++ b/tests/semantic_fixtures.py
@@ -171,7 +171,13 @@ def parse_entry(data: Any, *, source_path: Path) -> FixtureEntry:
     if artifact_kind_value is None:
         artifact_kind: RuleTargetKind | None = None
     else:
-        artifact_kind = _coerce_enum(RuleTargetKind, artifact_kind_value, "artifact_kind")
+        coerced = _coerce_enum(RuleTargetKind, artifact_kind_value, "artifact_kind")
+        if coerced is RuleTargetKind.UNSPECIFIED:
+            raise ValueError(
+                f"FixtureEntry({source_path.name}).artifact_kind: "
+                "'unspecified' is not a valid value; use null/absent to mean 'no kind override'"
+            )
+        artifact_kind = coerced
     return FixtureEntry(
         id=source_path.stem,
         rule_text=_expect_str(obj["rule_text"], "rule_text"),


### PR DESCRIPTION
## Summary

- Adds `artifact_kind` field to `BenchEntry` (and `parse_entry`) so fixtures can declare the artifact kind of the evaluation target.
- Wires `artifact_kind` into `_evaluate_entry` to fire the deterministic target-kind-mismatch precheck (#178) before invoking the LLM provider, mirroring `validator.validate` behaviour.
- Annotates `target-kind-mismatch-01` and `target-kind-mismatch-02` fixtures with the correct `artifact_kind` values so they short-circuit to `unsupported` with `reproducibility=1.0` and `status=SUCCESS`.

Closes #204. Refs: #164, #178.

## Test plan

- [x] `target-kind-mismatch-01-pr-rule-on-commit` bench → `PASS rep=1.00` (no LLM call)
- [x] `target-kind-mismatch-02-commit-rule-on-pr` bench → `PASS rep=1.00` (no LLM call)
- [x] `uv run pytest -x` passes (pre-existing unrelated failure excluded)
- [x] `uvx ruff check .` → clean
- [x] `uvx pyright src/gate_keeper/bench.py` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)