### PR TITLE
docs(textlint): clarify info-severity mapping cross-link (#209)

### DIFF
--- a/docs/textlint/severity-policy.md
+++ b/docs/textlint/severity-policy.md
@@ -58,7 +58,7 @@ not a per-finding mapping (the adapter inherits `rule.severity` per the
 |---|---|---|
 | `error` | `Severity.ERROR` | Direct mapping. textlint `error`-level rules are fail-closed; the adapter produces `Status.FAIL` diagnostics for violations. |
 | `warning` | `Severity.WARNING` | Direct mapping. textlint `warning`-level rules are advisory in intent; the adapter may produce `Status.FAIL` or a lighter status for violations — see §3. |
-| `info` | `Severity.ADVISORY` | Direct mapping. Informational rules: textlint's `severity: info` findings map to `Severity.ADVISORY` (non-gating diagnostics). Implemented in `src/gate_keeper/adapters/textlint.py` (`textlint_severity_to_gate_keeper`, line 56), originally tracked in #94 (closed). |
+| `info` | `Severity.ADVISORY` | Direct mapping. Informational rules: textlint's `severity: info` findings map to `Severity.ADVISORY` rule-level metadata. **In the shipped adapter (§7), any finding regardless of message-level severity integer produces `Status.FAIL` and blocks the gate**; `Severity.ADVISORY` records rule intent only and does not suppress blocking. Per-severity status differentiation is a future axis (see §7). Implemented in `src/gate_keeper/adapters/textlint.py` (`textlint_severity_to_gate_keeper`, line 56), originally tracked in #94 (closed). |
 
 **Rationale for direct mapping**: textlint's three-level schema aligns with
 gate-keeper's three-level schema. A one-to-one mapping avoids information loss

--- a/docs/textlint/severity-policy.md
+++ b/docs/textlint/severity-policy.md
@@ -58,7 +58,7 @@ not a per-finding mapping (the adapter inherits `rule.severity` per the
 |---|---|---|
 | `error` | `Severity.ERROR` | Direct mapping. textlint `error`-level rules are fail-closed; the adapter produces `Status.FAIL` diagnostics for violations. |
 | `warning` | `Severity.WARNING` | Direct mapping. textlint `warning`-level rules are advisory in intent; the adapter may produce `Status.FAIL` or a lighter status for violations — see §3. |
-| `info` | `Severity.ADVISORY` | Direct mapping. Informational rules; adapter behavior TBD in #94. |
+| `info` | `Severity.ADVISORY` | Direct mapping. Informational rules: textlint's `severity: info` findings map to `Severity.ADVISORY` (non-gating diagnostics). Implemented in `src/gate_keeper/adapters/textlint.py` (`textlint_severity_to_gate_keeper`, line 56), originally tracked in #94 (closed). |
 
 **Rationale for direct mapping**: textlint's three-level schema aligns with
 gate-keeper's three-level schema. A one-to-one mapping avoids information loss


### PR DESCRIPTION
## Summary

- Replaces the stale "adapter behavior TBD in #94" note on line 61 of `docs/textlint/severity-policy.md` with a concrete description of the shipped behavior.
- The textlint adapter (`src/gate_keeper/adapters/textlint.py`, `textlint_severity_to_gate_keeper` at line 56) already maps `severity: info` → `Severity.ADVISORY`. This PR documents that fact with a code-path reference.
- Issue #94 (textlint adapter implementation) is closed; this closes the residual documentation gap.

Closes #209. Refs: #164, #80, #94.

## Test plan

- [ ] `docs/textlint/severity-policy.md` line 61 no longer contains "TBD".
- [ ] `uvx ruff check .` passes (docs-only change, no Python modified).
- [ ] `npx textlint docs/textlint/severity-policy.md` passes.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)