### PR TITLE
feat(bench): add --model-matrix CLI flag (slice 2a) (#205)

### DIFF
--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -852,7 +852,7 @@ def _cmd_bench(args: argparse.Namespace) -> int:
             return EXIT_USAGE
 
         try:
-            rows = run_matrix(config_path, entries_dir)
+            rows = run_matrix(config, entries_dir)
         except (MatrixConfigError, RuntimeError, FileNotFoundError, ValueError) as exc:
             print(f"error: --model-matrix: {exc}", file=sys.stderr)
             return EXIT_USAGE

--- a/src/gate_keeper/cli.py
+++ b/src/gate_keeper/cli.py
@@ -304,7 +304,26 @@ def build_parser() -> argparse.ArgumentParser:
     )
     bench_parser.add_argument(
         "entries_dir",
-        help="directory of JSON benchmark entries (e.g. tests/fixtures/semantic/entries/)",
+        nargs="?",
+        default=None,
+        help=(
+            "directory of JSON benchmark entries (e.g. tests/fixtures/semantic/entries/). "
+            "Required unless --model-matrix is given (the config's 'fixtures' key takes "
+            "precedence when both are supplied)."
+        ),
+    )
+    bench_parser.add_argument(
+        "--model-matrix",
+        dest="model_matrix",
+        default=None,
+        metavar="CONFIG",
+        help=(
+            "path to a YAML matrix config file; runs the bench corpus once per model "
+            "listed in the config and emits a flat JSON array to stdout. "
+            "When provided, --reproducibility and --baseline are ignored "
+            "(use the config's 'reproducibility' key instead). "
+            "Slice 2a scope: OpenAI provider only."
+        ),
     )
     bench_parser.add_argument(
         "--reproducibility",
@@ -766,10 +785,16 @@ def _cmd_diagnose(args: argparse.Namespace) -> int:
 def _cmd_bench(args: argparse.Namespace) -> int:
     """Evaluate a fixture-corpus benchmark against the LLM-rubric backend.
 
-    Loads JSON entries under *entries_dir*, evaluates each one ``--reproducibility``
-    times via the LLM-rubric backend, and prints aggregate accuracy /
-    reproducibility / token metrics plus a per-entry breakdown. Output format is
-    ``text`` (default) or ``json``.
+    When ``--model-matrix CONFIG`` is given, reads the YAML config, runs the
+    bench corpus once per listed model, and emits a flat JSON array to stdout
+    (one record per (model, fixture) result). ``--reproducibility`` and
+    ``--baseline`` are ignored in matrix mode; use the config's
+    ``reproducibility`` key instead.
+
+    Without ``--model-matrix``, loads JSON entries under *entries_dir*,
+    evaluates each one ``--reproducibility`` times via the LLM-rubric backend,
+    and prints aggregate accuracy / reproducibility / token metrics plus a
+    per-entry breakdown. Output format is ``text`` (default) or ``json``.
 
     Exit codes
     ----------
@@ -784,6 +809,66 @@ def _cmd_bench(args: argparse.Namespace) -> int:
     canonical baseline file is added by the follow-up issue (#132).
     """
     from gate_keeper import bench as _bench
+
+    # ------------------------------------------------------------------
+    # Matrix mode: --model-matrix CONFIG
+    # ------------------------------------------------------------------
+    if args.model_matrix is not None:
+        from gate_keeper.matrix import MatrixConfigError, load_config, render_flat_json, run_matrix
+
+        config_path = Path(args.model_matrix)
+        if not config_path.is_file():
+            print(
+                f"error: --model-matrix: {args.model_matrix}: no such file",
+                file=sys.stderr,
+            )
+            return EXIT_USAGE
+
+        try:
+            config = load_config(config_path)
+        except MatrixConfigError as exc:
+            print(f"error: --model-matrix: {exc}", file=sys.stderr)
+            return EXIT_USAGE
+
+        # Resolve entries_dir: config 'fixtures' key takes precedence, then
+        # the positional entries_dir argument, then fail closed.
+        if config["fixtures"] is not None:
+            entries_dir = config["fixtures"]
+        elif args.entries_dir is not None:
+            entries_dir = Path(args.entries_dir)
+        else:
+            print(
+                "error: bench --model-matrix requires either a 'fixtures' key in the config "
+                "or an entries_dir positional argument",
+                file=sys.stderr,
+            )
+            return EXIT_USAGE
+
+        if not entries_dir.is_dir():
+            print(
+                f"error: entries directory does not exist or is not a directory: {entries_dir}",
+                file=sys.stderr,
+            )
+            return EXIT_USAGE
+
+        try:
+            rows = run_matrix(config_path, entries_dir)
+        except (MatrixConfigError, RuntimeError, FileNotFoundError, ValueError) as exc:
+            print(f"error: --model-matrix: {exc}", file=sys.stderr)
+            return EXIT_USAGE
+
+        print(render_flat_json(rows))
+        return EXIT_OK
+
+    # ------------------------------------------------------------------
+    # Standard single-model bench mode
+    # ------------------------------------------------------------------
+    if args.entries_dir is None:
+        print(
+            "error: bench requires an entries_dir positional argument or --model-matrix CONFIG",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
 
     entries_dir = Path(args.entries_dir)
     if not entries_dir.is_dir():

--- a/src/gate_keeper/matrix.py
+++ b/src/gate_keeper/matrix.py
@@ -1,0 +1,271 @@
+"""Model-matrix config loader and driver for ``bench --model-matrix`` (#205, slice 2a).
+
+This module defines the minimum-viable YAML config DSL for matrix runs and
+the driver function that reads a config file, iterates over models, and
+collects results into a flat JSON-serialisable structure.
+
+YAML config shape
+-----------------
+
+::
+
+    models:
+      - openai:gpt-4o-mini
+      - openai:gpt-4o
+    fixtures: tests/fixtures/semantic/entries/  # relative to the config file
+    reproducibility: 1   # optional, default 1
+
+The output is a flat JSON array — one record per (model, fixture) result —
+reusing the ``PerRuleResult.to_dict()`` shape from ``bench`` augmented with
+``provider`` and ``model_label`` fields so downstream consumers don't need
+new parsers.
+
+Out of scope for slice 2a
+--------------------------
+
+- Per-category metrics rollup (slice 2b).
+- Markdown summary output (slice 2b).
+- Anthropic provider plumbing (slice 2c).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from gate_keeper.backends import llm_rubric as _llm
+
+# ---------------------------------------------------------------------------
+# Config DSL
+# ---------------------------------------------------------------------------
+
+_REQUIRED_CONFIG_KEYS = frozenset({"models"})
+_OPTIONAL_CONFIG_KEYS = frozenset({"fixtures", "reproducibility"})
+
+_SUPPORTED_PROVIDERS = ("openai",)
+
+
+class MatrixConfigError(ValueError):
+    """Raised when the YAML config does not conform to the expected schema."""
+
+
+def load_config(config_path: Path) -> dict[str, Any]:
+    """Read and validate a matrix YAML config file.
+
+    Returns the validated config as a plain dict with the following keys:
+
+    - ``models``: list of ``"provider:model"`` strings (non-empty).
+    - ``fixtures``: ``Path | None`` — resolved entries directory, or ``None``
+      when omitted (the CLI resolves the default).
+    - ``reproducibility``: int >= 1.
+
+    Raises :class:`MatrixConfigError` on schema violations, ``OSError`` on
+    read errors, and ``yaml.YAMLError`` on malformed YAML.
+    """
+    try:
+        raw = config_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise MatrixConfigError(f"cannot read config {config_path}: {exc.strerror}") from exc
+
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise MatrixConfigError(f"invalid YAML in {config_path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise MatrixConfigError(
+            f"config {config_path}: expected a YAML mapping at the top level, got {type(data).__name__}"
+        )
+
+    keys = set(data)
+    missing = _REQUIRED_CONFIG_KEYS - keys
+    if missing:
+        raise MatrixConfigError(f"config {config_path}: missing required keys: {sorted(missing)}")
+    unknown = keys - _REQUIRED_CONFIG_KEYS - _OPTIONAL_CONFIG_KEYS
+    if unknown:
+        raise MatrixConfigError(f"config {config_path}: unknown keys: {sorted(unknown)}")
+
+    # models
+    models_raw = data["models"]
+    if not isinstance(models_raw, list) or not models_raw:
+        raise MatrixConfigError(
+            f"config {config_path}: 'models' must be a non-empty list of 'provider:model' strings"
+        )
+    for i, entry in enumerate(models_raw):
+        if not isinstance(entry, str) or not entry.strip():
+            raise MatrixConfigError(f"config {config_path}: 'models[{i}]' must be a non-empty string")
+
+    # fixtures (optional — CLI provides the default entries_dir when absent)
+    fixtures_raw = data.get("fixtures")
+    if fixtures_raw is not None:
+        if not isinstance(fixtures_raw, str) or not fixtures_raw.strip():
+            raise MatrixConfigError(f"config {config_path}: 'fixtures' must be a non-empty path string")
+        fixtures_path: Path | None = Path(fixtures_raw)
+        if not fixtures_path.is_absolute():
+            # Resolve relative to the config file's parent directory.
+            fixtures_path = (config_path.parent / fixtures_path).resolve()
+    else:
+        fixtures_path = None
+
+    # reproducibility (optional, default 1)
+    reproducibility_raw = data.get("reproducibility", 1)
+    if not isinstance(reproducibility_raw, int) or isinstance(reproducibility_raw, bool):
+        raise MatrixConfigError(
+            f"config {config_path}: 'reproducibility' must be an integer, "
+            f"got {type(reproducibility_raw).__name__}"
+        )
+    if reproducibility_raw < 1:
+        raise MatrixConfigError(
+            f"config {config_path}: 'reproducibility' must be >= 1, got {reproducibility_raw}"
+        )
+
+    return {
+        "models": [m.strip() for m in models_raw],
+        "fixtures": fixtures_path,
+        "reproducibility": reproducibility_raw,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Model spec helpers (mirrored from scripts/llm_rubric_model_matrix.py so the
+# package does not depend on the scripts/ tree at runtime)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """A single (provider, model) pair parsed from a ``"provider:model"`` string."""
+
+    provider: str
+    model: str
+
+    @property
+    def label(self) -> str:
+        return f"{self.provider}:{self.model}"
+
+
+def parse_model_specs(raw_models: list[str]) -> list[ModelSpec]:
+    """Parse a list of ``"provider:model"`` strings into :class:`ModelSpec` objects.
+
+    Bare model names (no colon) are treated as ``openai:<name>`` for
+    convenience. Duplicates are de-duplicated (first occurrence wins).
+
+    Raises :class:`MatrixConfigError` on unknown providers or empty model names.
+    """
+    out: list[ModelSpec] = []
+    seen: set[tuple[str, str]] = set()
+    for raw in raw_models:
+        token = raw.strip()
+        if not token:
+            continue
+        if ":" not in token:
+            # Bare name — default to openai provider.
+            provider, model = "openai", token
+        else:
+            provider, model = token.split(":", 1)
+            provider = provider.strip()
+            model = model.strip()
+        if provider not in _SUPPORTED_PROVIDERS:
+            raise MatrixConfigError(
+                f"model {token!r}: provider {provider!r} not supported in this slice; "
+                f"expected one of {list(_SUPPORTED_PROVIDERS)}"
+            )
+        if not model:
+            raise MatrixConfigError(f"model {token!r}: model identifier is empty")
+        key = (provider, model)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(ModelSpec(provider=provider, model=model))
+    if not out:
+        raise MatrixConfigError("models list must contain at least one provider:model entry")
+    return out
+
+
+def _build_env_for_model(spec: ModelSpec, base_env: dict[str, str]) -> dict[str, str]:
+    """Return a per-model env dict for the llm_rubric loader."""
+    env = dict(base_env)
+    env["GATE_KEEPER_LLM_PROVIDER"] = spec.provider
+    if spec.provider == "openai":
+        env["GATE_KEEPER_OPENAI_MODEL"] = spec.model
+        if "OPENAI_API_KEY" not in env:
+            raise RuntimeError(
+                "llm-rubric dotenv has no OPENAI_API_KEY; configure it before "
+                "running the model matrix (see docs/llm-rubric.md)."
+            )
+    else:  # pragma: no cover — guarded by parse_model_specs
+        raise RuntimeError(f"unsupported provider: {spec.provider!r}")
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def run_matrix(
+    config_path: Path,
+    entries_dir: Path,
+) -> list[dict[str, Any]]:
+    """Run the bench corpus for each model in the config and return flat JSON rows.
+
+    Each element of the returned list is a ``PerRuleResult.to_dict()`` record
+    augmented with ``"provider"`` and ``"model_label"`` fields identifying
+    which model produced the row. This flat shape lets downstream consumers
+    (jq, pandas, etc.) filter/group without needing to unwrap a nested
+    per-model envelope.
+
+    The loader monkey-patches ``llm_rubric._load_env_file`` once per model so
+    ``bench.run_bench`` picks up the per-model override without requiring a new
+    injection seam in the backend. The original loader is always restored after
+    each iteration.
+    """
+    from gate_keeper import bench as _bench
+
+    config = load_config(config_path)
+    model_specs = parse_model_specs(config["models"])
+
+    base_env = _llm._load_env_file()
+    original_loader = _llm._load_env_file
+
+    flat_rows: list[dict[str, Any]] = []
+    try:
+        for spec in model_specs:
+            env = _build_env_for_model(spec, base_env)
+            _llm._load_env_file = lambda *_a, _env=env, **_k: dict(_env)  # type: ignore[assignment]
+            try:
+                bench_result = _bench.run_bench(
+                    entries_dir,
+                    reproducibility=config["reproducibility"],
+                )
+            finally:
+                _llm._load_env_file = original_loader  # type: ignore[assignment]
+
+            for row in bench_result.per_rule:
+                record = row.to_dict()
+                record["provider"] = spec.provider
+                record["model_label"] = spec.label
+                flat_rows.append(record)
+    finally:
+        _llm._load_env_file = original_loader  # type: ignore[assignment]
+
+    return flat_rows
+
+
+def render_flat_json(rows: list[dict[str, Any]]) -> str:
+    """Render the flat row list as deterministic JSON."""
+    return json.dumps(rows, sort_keys=True, indent=2)
+
+
+__all__ = [
+    "MatrixConfigError",
+    "ModelSpec",
+    "load_config",
+    "parse_model_specs",
+    "render_flat_json",
+    "run_matrix",
+]

--- a/src/gate_keeper/matrix.py
+++ b/src/gate_keeper/matrix.py
@@ -63,8 +63,9 @@ def load_config(config_path: Path) -> dict[str, Any]:
       when omitted (the CLI resolves the default).
     - ``reproducibility``: int >= 1.
 
-    Raises :class:`MatrixConfigError` on schema violations, ``OSError`` on
-    read errors, and ``yaml.YAMLError`` on malformed YAML.
+    Raises :class:`MatrixConfigError` on schema violations (including I/O
+    errors and malformed YAML — both are wrapped into :class:`MatrixConfigError`
+    with a descriptive message).
     """
     try:
         raw = config_path.read_text(encoding="utf-8")
@@ -192,9 +193,9 @@ def _build_env_for_model(spec: ModelSpec, base_env: dict[str, str]) -> dict[str,
     env["GATE_KEEPER_LLM_PROVIDER"] = spec.provider
     if spec.provider == "openai":
         env["GATE_KEEPER_OPENAI_MODEL"] = spec.model
-        if "OPENAI_API_KEY" not in env:
+        if not env.get("OPENAI_API_KEY", "").strip():
             raise RuntimeError(
-                "llm-rubric dotenv has no OPENAI_API_KEY; configure it before "
+                "llm-rubric dotenv has no OPENAI_API_KEY (or it is blank); configure it before "
                 "running the model matrix (see docs/llm-rubric.md)."
             )
     else:  # pragma: no cover — guarded by parse_model_specs
@@ -208,10 +209,14 @@ def _build_env_for_model(spec: ModelSpec, base_env: dict[str, str]) -> dict[str,
 
 
 def run_matrix(
-    config_path: Path,
+    config: dict[str, Any],
     entries_dir: Path,
 ) -> list[dict[str, Any]]:
     """Run the bench corpus for each model in the config and return flat JSON rows.
+
+    *config* must be the validated dict returned by :func:`load_config` — the
+    caller is expected to parse the config once and pass it here, so there is no
+    duplicate I/O or TOCTOU risk.
 
     Each element of the returned list is a ``PerRuleResult.to_dict()`` record
     augmented with ``"provider"`` and ``"model_label"`` fields identifying
@@ -226,7 +231,6 @@ def run_matrix(
     """
     from gate_keeper import bench as _bench
 
-    config = load_config(config_path)
     model_specs = parse_model_specs(config["models"])
 
     base_env = _llm._load_env_file()

--- a/tests/fixtures/matrix/config.yaml
+++ b/tests/fixtures/matrix/config.yaml
@@ -1,0 +1,4 @@
+models:
+  - openai:gpt-4o-mini
+  - openai:gpt-4o
+reproducibility: 1

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -175,7 +175,7 @@ class TestRunMatrix:
             f"reproducibility: 1\n"
         )
 
-        rows = _matrix.run_matrix(cfg, entries_dir)
+        rows = _matrix.run_matrix(_matrix.load_config(cfg), entries_dir)
 
         assert len(rows) == 2
         labels = [r["model_label"] for r in rows]
@@ -203,7 +203,7 @@ class TestRunMatrix:
         cfg = tmp_path / "config.yaml"
         cfg.write_text(f"models:\n  - openai:gpt-4o-mini\nfixtures: {entries_dir}\n")
 
-        _matrix.run_matrix(cfg, entries_dir)
+        _matrix.run_matrix(_matrix.load_config(cfg), entries_dir)
         assert _llm._load_env_file is _sentinel_loader
 
 

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -1,0 +1,271 @@
+"""Unit tests for ``gate_keeper.matrix`` — YAML config parser and CLI integration.
+
+Real provider calls are not made here (paid API). The ``_call_openai`` helper
+and ``_load_env_file`` are monkeypatched to stub responses, mirroring the
+pattern in ``tests/test_cli_bench.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gate_keeper import matrix as _matrix
+from gate_keeper.backends import llm_rubric as _llm
+from gate_keeper.cli import main
+
+_OPENAI_ENV = {
+    "GATE_KEEPER_LLM_PROVIDER": "openai",
+    "OPENAI_API_KEY": "sk-test-stub-not-real",
+}
+
+
+def _stub_openai_pass(*_args, **_kwargs) -> tuple[str, dict[str, int]]:
+    body = json.dumps(
+        {
+            "judgment": "pass",
+            "primary_reason": "The artefact satisfies the rule.",
+            "supporting_evidence_quotes": ["example artefact body"],
+            "suggested_action": None,
+        }
+    )
+    return body, {"latency_ms": 10, "tokens_in": 50, "tokens_out": 12}
+
+
+def _single_entry_dir(tmp_path: Path) -> Path:
+    entries = tmp_path / "entries"
+    entries.mkdir()
+    entry = {
+        "rule_text": "The artefact satisfies the example rule.",
+        "target": {"kind": "inline", "value": "example artefact body"},
+        "expected_judgment": "pass",
+        "expected_rationale_keywords": ["satisfies"],
+        "category": "clarity",
+        "intended_backend": "llm-rubric",
+    }
+    (entries / "smoke-01.json").write_text(json.dumps(entry))
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# load_config
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfig:
+    def test_minimal_config(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("models:\n  - openai:gpt-4o-mini\n")
+        result = _matrix.load_config(cfg)
+        assert result["models"] == ["openai:gpt-4o-mini"]
+        assert result["fixtures"] is None
+        assert result["reproducibility"] == 1
+
+    def test_full_config_relative_fixtures(self, tmp_path):
+        entries = tmp_path / "entries"
+        entries.mkdir()
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("models:\n  - openai:gpt-4o-mini\nfixtures: entries\nreproducibility: 3\n")
+        result = _matrix.load_config(cfg)
+        assert result["models"] == ["openai:gpt-4o-mini"]
+        assert result["fixtures"] == entries.resolve()
+        assert result["reproducibility"] == 3
+
+    def test_absolute_fixtures_path(self, tmp_path):
+        entries = tmp_path / "entries"
+        entries.mkdir()
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(f"models:\n  - openai:gpt-4o-mini\nfixtures: {entries}\n")
+        result = _matrix.load_config(cfg)
+        assert result["fixtures"] == entries
+
+    def test_missing_models_key_raises(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("reproducibility: 1\n")
+        with pytest.raises(_matrix.MatrixConfigError, match="missing required keys"):
+            _matrix.load_config(cfg)
+
+    def test_unknown_key_raises(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("models:\n  - openai:gpt-4o-mini\nextra_key: oops\n")
+        with pytest.raises(_matrix.MatrixConfigError, match="unknown keys"):
+            _matrix.load_config(cfg)
+
+    def test_empty_models_list_raises(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("models: []\n")
+        with pytest.raises(_matrix.MatrixConfigError, match="non-empty list"):
+            _matrix.load_config(cfg)
+
+    def test_reproducibility_zero_raises(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("models:\n  - openai:gpt-4o-mini\nreproducibility: 0\n")
+        with pytest.raises(_matrix.MatrixConfigError, match=">= 1"):
+            _matrix.load_config(cfg)
+
+    def test_reproducibility_float_raises(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("models:\n  - openai:gpt-4o-mini\nreproducibility: 1.5\n")
+        with pytest.raises(_matrix.MatrixConfigError, match="integer"):
+            _matrix.load_config(cfg)
+
+    def test_invalid_yaml_raises(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("models: [\n")
+        with pytest.raises(_matrix.MatrixConfigError, match="invalid YAML"):
+            _matrix.load_config(cfg)
+
+    def test_nonexistent_file_raises(self, tmp_path):
+        cfg = tmp_path / "no-such.yaml"
+        with pytest.raises(_matrix.MatrixConfigError, match="cannot read config"):
+            _matrix.load_config(cfg)
+
+    def test_top_level_not_mapping_raises(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("- just\n- a\n- list\n")
+        with pytest.raises(_matrix.MatrixConfigError, match="expected a YAML mapping"):
+            _matrix.load_config(cfg)
+
+
+# ---------------------------------------------------------------------------
+# parse_model_specs
+# ---------------------------------------------------------------------------
+
+
+class TestParseModelSpecs:
+    def test_two_qualified_models(self):
+        specs = _matrix.parse_model_specs(["openai:gpt-4o-mini", "openai:gpt-4o"])
+        assert [s.label for s in specs] == ["openai:gpt-4o-mini", "openai:gpt-4o"]
+
+    def test_bare_name_defaults_to_openai(self):
+        specs = _matrix.parse_model_specs(["gpt-4o-mini"])
+        assert specs[0].provider == "openai"
+        assert specs[0].model == "gpt-4o-mini"
+
+    def test_deduplication(self):
+        specs = _matrix.parse_model_specs(["openai:gpt-4o", "openai:gpt-4o"])
+        assert len(specs) == 1
+
+    def test_unsupported_provider_raises(self):
+        with pytest.raises(_matrix.MatrixConfigError, match="not supported"):
+            _matrix.parse_model_specs(["anthropic:claude-haiku-4-5"])
+
+    def test_empty_list_raises(self):
+        with pytest.raises(_matrix.MatrixConfigError, match="at least one"):
+            _matrix.parse_model_specs([])
+
+
+# ---------------------------------------------------------------------------
+# run_matrix (hermetic — monkeypatched provider)
+# ---------------------------------------------------------------------------
+
+
+class TestRunMatrix:
+    def test_flat_rows_two_models(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(_llm, "_load_env_file", lambda *a, **k: dict(_OPENAI_ENV))
+        monkeypatch.setattr(_llm, "_call_openai", _stub_openai_pass)
+
+        entries_dir = _single_entry_dir(tmp_path)
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            f"models:\n  - openai:gpt-4o-mini\n  - openai:gpt-4o\n"
+            f"fixtures: {entries_dir}\n"
+            f"reproducibility: 1\n"
+        )
+
+        rows = _matrix.run_matrix(cfg, entries_dir)
+
+        assert len(rows) == 2
+        labels = [r["model_label"] for r in rows]
+        assert labels == ["openai:gpt-4o-mini", "openai:gpt-4o"]
+        for row in rows:
+            assert row["id"] == "smoke-01"
+            assert row["status"] == "PASS"
+            assert row["provider"] == "openai"
+            assert "model_label" in row
+            # Standard PerRuleResult fields must be present.
+            assert "category" in row
+            assert "expected" in row
+            assert "actual" in row
+
+    def test_restores_loader_after_run(self, monkeypatch, tmp_path):
+        sentinel = dict(_OPENAI_ENV)
+
+        def _sentinel_loader(*_a, **_k):
+            return dict(sentinel)
+
+        monkeypatch.setattr(_llm, "_load_env_file", _sentinel_loader)
+        monkeypatch.setattr(_llm, "_call_openai", _stub_openai_pass)
+
+        entries_dir = _single_entry_dir(tmp_path)
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(f"models:\n  - openai:gpt-4o-mini\nfixtures: {entries_dir}\n")
+
+        _matrix.run_matrix(cfg, entries_dir)
+        assert _llm._load_env_file is _sentinel_loader
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — bench --model-matrix
+# ---------------------------------------------------------------------------
+
+
+class TestCliBenchModelMatrix:
+    def test_help_shows_model_matrix_flag(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            main(["bench", "--help"])
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "--model-matrix" in out
+
+    def test_matrix_emits_flat_json(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setattr(_llm, "_load_env_file", lambda *a, **k: dict(_OPENAI_ENV))
+        monkeypatch.setattr(_llm, "_call_openai", _stub_openai_pass)
+
+        entries_dir = _single_entry_dir(tmp_path)
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(f"models:\n  - openai:gpt-4o-mini\nfixtures: {entries_dir}\n")
+
+        rc = main(["bench", "--model-matrix", str(cfg)])
+        assert rc == 0
+        rows = json.loads(capsys.readouterr().out)
+        assert isinstance(rows, list)
+        assert len(rows) == 1
+        assert rows[0]["model_label"] == "openai:gpt-4o-mini"
+        assert rows[0]["status"] == "PASS"
+
+    def test_matrix_entries_dir_from_positional(self, monkeypatch, tmp_path, capsys):
+        """entries_dir positional arg is used when 'fixtures' key is absent from config."""
+        monkeypatch.setattr(_llm, "_load_env_file", lambda *a, **k: dict(_OPENAI_ENV))
+        monkeypatch.setattr(_llm, "_call_openai", _stub_openai_pass)
+
+        entries_dir = _single_entry_dir(tmp_path)
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("models:\n  - openai:gpt-4o-mini\n")
+
+        rc = main(["bench", str(entries_dir), "--model-matrix", str(cfg)])
+        assert rc == 0
+        rows = json.loads(capsys.readouterr().out)
+        assert len(rows) == 1
+
+    def test_matrix_missing_config_exit_2(self, capsys):
+        rc = main(["bench", "--model-matrix", "/no/such/config.yaml"])
+        assert rc == 2
+        assert "no such file" in capsys.readouterr().err
+
+    def test_matrix_no_entries_dir_exit_2(self, tmp_path, capsys):
+        """Neither 'fixtures' in config nor positional entries_dir → usage error."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("models:\n  - openai:gpt-4o-mini\n")
+        rc = main(["bench", "--model-matrix", str(cfg)])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "entries_dir" in err or "fixtures" in err
+
+    def test_standard_bench_still_requires_entries_dir(self, capsys):
+        """Omitting entries_dir without --model-matrix must still give usage error."""
+        rc = main(["bench"])
+        assert rc == 2
+        assert "entries_dir" in capsys.readouterr().err or rc == 2


### PR DESCRIPTION
## Summary

- Adds `bench --model-matrix CONFIG` CLI flag that reads a YAML config, runs the bench fixture corpus once per listed model, and emits a flat JSON array to stdout (one record per (model, fixture) result).
- New `src/gate_keeper/matrix.py` module: YAML config DSL loader, `ModelSpec`/`parse_model_specs` helpers (self-contained — no `scripts/` import at runtime), `run_matrix` driver reusing the existing monkey-patch seam from slice 1, and `render_flat_json`.
- Output shape reuses `PerRuleResult.to_dict()` + `provider` / `model_label` fields — downstream consumers need no new parsers.
- 24 hermetic unit tests covering config validation, model spec parsing, `run_matrix`, and CLI integration.
- Sample config at `tests/fixtures/matrix/config.yaml`.

## Slice scope (2a only)

- No per-category metrics rollup (slice 2b).
- No Markdown summary (slice 2b).
- No Anthropic provider plumbing (slice 2c).
- OpenAI provider only in this slice.

## Test plan

- [x] `uv run pytest tests/test_matrix.py -x` — 24 passed
- [x] `uv run pytest -x` — only pre-existing failures (6 in `test_llm_rubric_backend.py` + 1 in `test_cli_validate.py`, all reproducible on clean `main`)
- [x] `uvx ruff check .` — all checks passed
- [x] `uvx ruff format --check .` — 71 files already formatted
- [x] `bench --help` shows `--model-matrix` flag

Closes #205 (slice 2a).
Refs: #164, #177 (slice 1 = #195).

🤖 Generated with [Claude Code](https://claude.com/claude-code)