### PR TITLE
feat(llm-rubric): implement adaptive strategy with single→consensus escalation (#186)

### DIFF
--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -2668,7 +2668,11 @@ def _run_adaptive_strategy(request: JudgmentRequest) -> Diagnostic:
     # strategy success/failure paths populate evidence[0]).
     tier1_ev_data: dict[str, Any] = tier1_diag.evidence[0].data if tier1_diag.evidence else {}
 
-    tier1_call_count: int = int(tier1_ev_data.get("llm_call_count", 1))
+    # Default llm_call_count to 0, not 1: pre-call failure paths
+    # (provider_unconfigured, provider_error, etc.) do not execute any LLM
+    # request, so their evidence records omit llm_call_count.  Using 1 as a
+    # fallback would inflate call/cost telemetry for those paths.
+    tier1_call_count: int = int(tier1_ev_data.get("llm_call_count", 0))
     tier1_models: list[str] = list(tier1_ev_data.get("models", []))  # type: ignore[arg-type]
     tier1_cost: float | None = tier1_ev_data.get("cost_estimate_usd_total")  # type: ignore[assignment]
     tier1_latency: int = int(tier1_ev_data.get("latency_ms_total", 0))
@@ -2697,10 +2701,17 @@ def _run_adaptive_strategy(request: JudgmentRequest) -> Diagnostic:
             "latency_ms_total": tier1_latency,
         }
         # Build updated evidence list: overlay the first record, keep the rest.
+        # Nest tier1 evidence as {kind, data} so the original evidence kind
+        # (e.g. provider_unconfigured, llm_quote_fabrication) is preserved for
+        # downstream programmatic inspection.
         updated_ev = [
             Evidence(
                 kind="llm_adaptive",
-                data={**tier1_ev_data, **adaptive_overlay, "tier1_evidence": tier1_ev_data},
+                data={
+                    **tier1_ev_data,
+                    **adaptive_overlay,
+                    "tier1_evidence": {"kind": tier1_ev_kind, "data": tier1_ev_data},
+                },
             )
         ] + list(tier1_diag.evidence[1:])
         return Diagnostic(
@@ -2732,10 +2743,13 @@ def _run_adaptive_strategy(request: JudgmentRequest) -> Diagnostic:
 
     tier2_ev_data: dict[str, Any] = tier2_diag.evidence[0].data if tier2_diag.evidence else {}
 
-    tier2_call_count: int = int(tier2_ev_data.get("llm_call_count", 3))
+    # Default llm_call_count to 0 for the same reason as Tier 1: if consensus
+    # returns early (e.g. provider_unconfigured), no LLM calls were made.
+    tier2_call_count: int = int(tier2_ev_data.get("llm_call_count", 0))
     tier2_models: list[str] = list(tier2_ev_data.get("models", []))  # type: ignore[arg-type]
     tier2_cost: float | None = tier2_ev_data.get("cost_estimate_usd_total")  # type: ignore[assignment]
     tier2_latency: int = int(tier2_ev_data.get("latency_ms_total", 0))
+    tier2_ev_kind: str = tier2_diag.evidence[0].kind if tier2_diag.evidence else ""
 
     # Aggregate telemetry across both tiers.
     total_call_count = tier1_call_count + tier2_call_count
@@ -2746,6 +2760,9 @@ def _run_adaptive_strategy(request: JudgmentRequest) -> Diagnostic:
         total_cost = tier1_cost + tier2_cost
     total_latency = tier1_latency + tier2_latency
 
+    # Nest both tier evidence objects as {kind, data} so the original inner
+    # evidence kinds (e.g. llm_consensus, consensus_tie, provider_unconfigured)
+    # are preserved for downstream programmatic inspection.
     adaptive_overlay_t2: dict[str, Any] = {
         "llm_strategy": "adaptive",
         "adaptive_tier": 2,
@@ -2754,7 +2771,8 @@ def _run_adaptive_strategy(request: JudgmentRequest) -> Diagnostic:
         "models": total_models,
         "cost_estimate_usd_total": total_cost,
         "latency_ms_total": total_latency,
-        "tier1_evidence": tier1_ev_data,
+        "tier1_evidence": {"kind": tier1_ev_kind, "data": tier1_ev_data},
+        "tier2_evidence": {"kind": tier2_ev_kind, "data": tier2_ev_data},
     }
     updated_ev_t2 = [
         Evidence(

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -26,25 +26,24 @@ from gate_keeper.targets import TargetSpec
 name = "llm-rubric"
 
 # ---------------------------------------------------------------------------
-# Strategy registry (#183)
+# Strategy registry (#183 / #184 / #185 / #186)
 #
 # Strategy ids surface in the rule IR via ``rule.params["strategy"]``. The
 # default ``single`` preserves the pre-#183 behaviour byte-for-byte (one
-# provider call, one parsed judgment, one diagnostic) and is the only
-# concrete strategy shipped in this slice. ``consensus`` / ``review`` /
-# ``adaptive`` are reserved ids — declared in :data:`KNOWN_STRATEGIES` so
-# the rule IR can validate the value, but invoking them returns
-# ``UNAVAILABLE`` with ``strategy_not_implemented`` evidence so callers
-# discover the gap explicitly rather than silently falling back to
-# ``single``. Higher-effort strategies are opt-in and experimental until
-# benchmarked; the seam exists so they can be plugged in without
-# duplicating provider-call code, not as a green-light to enable them in
-# CI.
+# provider call, one parsed judgment, one diagnostic).  All four ids in
+# :data:`KNOWN_STRATEGIES` are now concrete implementations:
+#   - ``single``   — one provider call (reference impl, #183)
+#   - ``consensus`` — majority-vote panel (#184)
+#   - ``review``   — two-pass primary+reviewer (#185)
+#   - ``adaptive`` — cheap single with optional consensus escalation (#186)
+# Higher-effort strategies are opt-in and experimental until benchmarked;
+# the seam exists so they can be composed without duplicating provider-call
+# code, not as a green-light to enable them in CI.
 # ---------------------------------------------------------------------------
 
-#: All strategy ids the IR layer recognises. Only ``single`` has a concrete
-#: implementation in this slice; the others are seam placeholders that
-#: dispatch to ``UNAVAILABLE`` with ``strategy_not_implemented`` evidence.
+#: All strategy ids the IR layer recognises.  All four now have concrete
+#: implementations: ``single`` (#183), ``consensus`` (#184), ``review``
+#: (#185), ``adaptive`` (#186).
 KNOWN_STRATEGIES: frozenset[str] = frozenset({"single", "consensus", "review", "adaptive"})
 
 #: Default strategy id when ``rule.params["strategy"]`` is unset. Preserves
@@ -73,9 +72,9 @@ class JudgmentRequest:
 class StrategyTelemetry:
     """Aggregated per-strategy telemetry recorded into evidence (#183).
 
-    The ``single`` strategy fills these from one provider call. Future
-    multi-call strategies (``consensus`` / ``review`` / ``adaptive``)
-    aggregate across calls — ``call_count`` rises above 1, ``models``
+    The ``single`` strategy fills these from one provider call. Multi-call
+    strategies (``consensus`` / ``review`` / ``adaptive``) aggregate across
+    calls — ``call_count`` rises above 1, ``models``
     can carry distinct entries, ``cost_estimate_usd_total`` and
     ``latency_ms_total`` sum across calls. ``cost_estimate_usd_total``
     is ``None`` iff any individual call had unknown pricing (preserving
@@ -1717,12 +1716,13 @@ def _run_single_strategy(request: JudgmentRequest) -> Diagnostic:
 def _run_not_implemented_strategy(request: JudgmentRequest, strategy_id: str) -> Diagnostic:
     """Reserved-id placeholder (#183). Records the gap fail-closed.
 
-    ``adaptive`` is declared in :data:`KNOWN_STRATEGIES` so the rule IR
-    layer can validate the value before reaching the backend, but its
-    concrete body is out of scope for this slice. Invoking it returns
-    ``UNAVAILABLE`` with ``strategy_not_implemented`` evidence rather than
-    silently falling back to ``single`` — a rule that asks for ``adaptive``
-    should not receive a single-call verdict in disguise.
+    All four strategy ids in :data:`KNOWN_STRATEGIES` are now concrete
+    implementations (#183–#186); this function is retained as a fallback for
+    any future reserved ids added to :data:`KNOWN_STRATEGIES` before their
+    concrete body is implemented. Invoking it returns ``UNAVAILABLE`` with
+    ``strategy_not_implemented`` evidence rather than silently falling back to
+    ``single`` — a rule that asks for a not-yet-implemented strategy should not
+    receive a single-call verdict in disguise.
     """
     rubric_input = _build_rubric_input(request.rule, request.target)
     return _strategy_unavailable(
@@ -2607,14 +2607,180 @@ def _run_review_strategy(request: JudgmentRequest) -> Diagnostic:
     )
 
 
-#: Concrete strategy registry (#183 / #184 / #185). Maps strategy id to its
-#: :class:`Strategy` callable. ``single``, ``consensus``, and ``review`` are
-#: implemented; ``adaptive`` is reserved and dispatches through
-#: ``_run_not_implemented_strategy`` so the gap is observable.
+# ---------------------------------------------------------------------------
+# Adaptive strategy (#186)
+# ---------------------------------------------------------------------------
+
+
+def _run_adaptive_strategy(request: JudgmentRequest) -> Diagnostic:
+    """Evaluate *request* with adaptive single→consensus escalation (#186).
+
+    Two-tier escalation policy: start cheap (Tier 1: single judge), then
+    escalate to consensus (Tier 2: panel of 3) only when the Tier 1 outcome
+    is ambiguous.  Escalation triggers (slice 1):
+
+    - ``target_kind_mismatch`` evidence from Tier 1 → escalate.  The model
+      produced an ``unsupported`` LLM verdict (rule premise does not apply to
+      this artifact kind); a consensus panel may resolve the ambiguity.
+    - ``llm_quote_fabrication`` / ``provider_error`` / ``provider_unconfigured``
+      / ``strategy_unavailable`` evidence → **fail-closed without escalation**.
+      Consensus cannot recover malformed provider responses; surfacing the
+      Tier 1 failure directly is the correct action.
+    - ``llm_judgment`` (``pass`` / ``fail``) from Tier 1 → commit to verdict,
+      no escalation.
+
+    Evidence shape (``llm_adaptive`` kind on any concrete verdict path):
+
+    .. code-block:: json
+
+        {
+            "llm_strategy": "adaptive",
+            "adaptive_tier": 1,
+            "adaptive_escalation_reason": null,
+            "llm_call_count": 1,
+            "models": ["gpt-4o-mini"],
+            "cost_estimate_usd_total": 0.0001,
+            "latency_ms_total": 120
+        }
+
+    When escalation fires (``adaptive_tier: 2``):
+
+    .. code-block:: json
+
+        {
+            "llm_strategy": "adaptive",
+            "adaptive_tier": 2,
+            "adaptive_escalation_reason": "tier1_unsupported",
+            "llm_call_count": 4,
+            "models": ["gpt-4o-mini", "gpt-4o-mini", "gpt-4o-mini", "gpt-4o-mini"],
+            "cost_estimate_usd_total": 0.0004,
+            "latency_ms_total": 480
+        }
+
+    The ``llm_adaptive`` evidence dict wraps the inner strategy's evidence
+    dict so downstream consumers can inspect both the Tier 1 result and the
+    final escalated result when they differ.
+    """
+    # --- Tier 1: run single strategy ---
+    tier1_diag = _run_single_strategy(request)
+
+    # Extract tier-1 telemetry from the first evidence record (all single-
+    # strategy success/failure paths populate evidence[0]).
+    tier1_ev_data: dict[str, Any] = tier1_diag.evidence[0].data if tier1_diag.evidence else {}
+
+    tier1_call_count: int = int(tier1_ev_data.get("llm_call_count", 1))
+    tier1_models: list[str] = list(tier1_ev_data.get("models", []))  # type: ignore[arg-type]
+    tier1_cost: float | None = tier1_ev_data.get("cost_estimate_usd_total")  # type: ignore[assignment]
+    tier1_latency: int = int(tier1_ev_data.get("latency_ms_total", 0))
+
+    # Determine whether Tier 1 warrants escalation.
+    #
+    # Escalation gate: trigger iff the first evidence record has kind
+    # ``target_kind_mismatch`` — the model produced an LLM-level
+    # ``"unsupported"`` verdict (rule premise does not apply to this artifact
+    # kind).  All other outcomes are either conclusive (PASS/FAIL) or
+    # fail-closed (UNAVAILABLE, llm_quote_fabrication) — consensus cannot
+    # recover those and surfacing the Tier 1 result directly is correct.
+    tier1_ev_kind = tier1_diag.evidence[0].kind if tier1_diag.evidence else ""
+    should_escalate = tier1_ev_kind == "target_kind_mismatch"
+
+    if not should_escalate:
+        # Tier 1 is conclusive (PASS/FAIL) or already fail-closed (UNAVAILABLE).
+        # Re-emit with adaptive wrapper fields merged into evidence.
+        adaptive_overlay: dict[str, Any] = {
+            "llm_strategy": "adaptive",
+            "adaptive_tier": 1,
+            "adaptive_escalation_reason": None,
+            "llm_call_count": tier1_call_count,
+            "models": tier1_models,
+            "cost_estimate_usd_total": tier1_cost,
+            "latency_ms_total": tier1_latency,
+        }
+        # Build updated evidence list: overlay the first record, keep the rest.
+        updated_ev = [
+            Evidence(
+                kind="llm_adaptive",
+                data={**tier1_ev_data, **adaptive_overlay, "tier1_evidence": tier1_ev_data},
+            )
+        ] + list(tier1_diag.evidence[1:])
+        return Diagnostic(
+            rule_id=tier1_diag.rule_id,
+            source=tier1_diag.source,
+            backend=tier1_diag.backend,
+            status=tier1_diag.status,
+            severity=tier1_diag.severity,
+            message=tier1_diag.message,
+            evidence=updated_ev,
+            remediation=tier1_diag.remediation,
+        )
+
+    # --- Tier 2: escalate to consensus ---
+    # Build a consensus request with panel_size=3 (the default) by injecting
+    # consensus_panel_size into a copy of the rule params.
+    rule = request.rule
+    escalation_params = dict(rule.params)
+    escalation_params["strategy"] = "consensus"
+    escalation_params.setdefault("consensus_panel_size", 3)
+
+    escalation_rule = dataclasses.replace(rule, params=escalation_params)
+    escalation_request = JudgmentRequest(
+        rule=escalation_rule,
+        target=request.target,
+        artifact_kind=request.artifact_kind,
+    )
+    tier2_diag = _run_consensus_strategy(escalation_request)
+
+    tier2_ev_data: dict[str, Any] = tier2_diag.evidence[0].data if tier2_diag.evidence else {}
+
+    tier2_call_count: int = int(tier2_ev_data.get("llm_call_count", 3))
+    tier2_models: list[str] = list(tier2_ev_data.get("models", []))  # type: ignore[arg-type]
+    tier2_cost: float | None = tier2_ev_data.get("cost_estimate_usd_total")  # type: ignore[assignment]
+    tier2_latency: int = int(tier2_ev_data.get("latency_ms_total", 0))
+
+    # Aggregate telemetry across both tiers.
+    total_call_count = tier1_call_count + tier2_call_count
+    total_models = tier1_models + tier2_models
+    if tier1_cost is None or tier2_cost is None:
+        total_cost: float | None = None
+    else:
+        total_cost = tier1_cost + tier2_cost
+    total_latency = tier1_latency + tier2_latency
+
+    adaptive_overlay_t2: dict[str, Any] = {
+        "llm_strategy": "adaptive",
+        "adaptive_tier": 2,
+        "adaptive_escalation_reason": "tier1_unsupported",
+        "llm_call_count": total_call_count,
+        "models": total_models,
+        "cost_estimate_usd_total": total_cost,
+        "latency_ms_total": total_latency,
+        "tier1_evidence": tier1_ev_data,
+    }
+    updated_ev_t2 = [
+        Evidence(
+            kind="llm_adaptive",
+            data={**tier2_ev_data, **adaptive_overlay_t2},
+        )
+    ] + list(tier2_diag.evidence[1:])
+    return Diagnostic(
+        rule_id=tier2_diag.rule_id,
+        source=tier2_diag.source,
+        backend=tier2_diag.backend,
+        status=tier2_diag.status,
+        severity=tier2_diag.severity,
+        message=tier2_diag.message,
+        evidence=updated_ev_t2,
+        remediation=tier2_diag.remediation,
+    )
+
+
+#: Concrete strategy registry (#183 / #184 / #185 / #186). Maps strategy id to its
+#: :class:`Strategy` callable. All four known strategies are now concrete.
 _STRATEGIES: dict[str, Strategy] = {
     "single": _run_single_strategy,
     "consensus": _run_consensus_strategy,
     "review": _run_review_strategy,
+    "adaptive": _run_adaptive_strategy,
 }
 
 
@@ -2648,13 +2814,12 @@ def check(
     ``TargetSpec`` values are unwrapped to the underlying path so callers
     can mix CLI surfaces freely.
 
-    Strategy dispatch (#183 / #184 / #185). The judgment strategy is
+    Strategy dispatch (#183 / #184 / #185 / #186). The judgment strategy is
     selected from ``rule.params["strategy"]`` and defaults to
     :data:`DEFAULT_STRATEGY` (``"single"``) for backward compatibility.
-    ``"single"``, ``"consensus"``, and ``"review"`` are concrete
-    implementations; ``"adaptive"`` is reserved and returns
-    ``UNAVAILABLE`` with ``strategy_unavailable`` evidence so callers
-    discover the gap explicitly. Unknown ids likewise fail closed.
+    All four known strategy ids — ``"single"``, ``"consensus"``,
+    ``"review"``, and ``"adaptive"`` — are now concrete implementations.
+    Unknown ids fail closed with ``strategy_unavailable`` evidence.
     Strategy-aggregated metadata (``llm_strategy``, ``llm_call_count``,
     ``models``, ``cost_estimate_usd_total``, ``latency_ms_total``) is
     appended to every successful evidence dict; the legacy single-call

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -2911,19 +2911,15 @@ class TestStrategySeam:
         assert callable(llm_backend._STRATEGIES["single"])
 
     def test_strategies_registry_omits_reserved_ids(self):
-        """Reserved-but-unimplemented ids must not appear in the live registry.
+        """All four known strategy ids now have concrete implementations.
 
-        ``consensus`` is now implemented (#184) and ``review`` is now
-        implemented (#185); both live in the registry. ``adaptive`` remains
-        reserved (unimplemented) and must not silently dispatch to a single-
-        call strategy in disguise.
+        ``consensus`` is implemented (#184), ``review`` is implemented (#185),
+        and ``adaptive`` is implemented (#186). All must appear in the registry.
         """
-        for reserved in ("adaptive",):
-            assert reserved not in llm_backend._STRATEGIES
-        # consensus IS implemented in #184.
+        # All four are now concrete.
         assert "consensus" in llm_backend._STRATEGIES
-        # review IS implemented in #185.
         assert "review" in llm_backend._STRATEGIES
+        assert "adaptive" in llm_backend._STRATEGIES
 
     def test_default_pass_evidence_carries_strategy_metadata(self, monkeypatch, tmp_path):
         """Issue #183 acceptance: success evidence advertises strategy fields."""
@@ -2972,32 +2968,18 @@ class TestStrategySeam:
         assert diag.evidence[0].data["llm_strategy"] == "single"
         assert diag.evidence[0].data["llm_call_count"] == 1
 
-    @pytest.mark.parametrize("strategy_id", ["adaptive"])
-    def test_reserved_strategy_returns_unavailable(self, monkeypatch, tmp_path, strategy_id):
-        """Still-reserved ids dispatch through ``strategy_not_implemented``.
+    def test_all_four_known_strategies_are_concrete(self):
+        """All four known strategy ids are now concrete implementations (#186).
 
-        ``consensus`` is now implemented (#184) and ``review`` is now
-        implemented (#185); both are removed from this parametrize.
-        ``adaptive`` remains unimplemented. Provider stubs are still wired
-        so a regression where the seam silently falls back to ``single``
-        would surface as a PASS verdict; the assertion catches that.
+        ``consensus`` (#184), ``review`` (#185), and ``adaptive`` (#186) are
+        all fully implemented. No known strategy dispatches through
+        ``_run_not_implemented_strategy`` any more.
         """
-        _patch_env(monkeypatch, self._ENV)
-        provider_called: dict[str, int] = {"n": 0}
-
-        def _spy(*_a, **_k):
-            provider_called["n"] += 1
-            return _stub_response(_VALID_PASS_JSON)
-
-        monkeypatch.setattr(llm_backend, "_call_openai", _spy)
-        rule = _semantic_rule_with_strategy(strategy_id)
-        diag = llm_backend.check(rule, _target_with_artifact(tmp_path))
-        assert diag.status is Status.UNAVAILABLE
-        assert diag.evidence[0].kind == "strategy_unavailable"
-        assert diag.evidence[0].data["requested_strategy"] == strategy_id
-        assert diag.evidence[0].data["failure_mode"] == "strategy_not_implemented"
-        # Critically: provider is NOT called for an unimplemented strategy.
-        assert provider_called["n"] == 0
+        for strategy_id in llm_backend.KNOWN_STRATEGIES:
+            assert strategy_id in llm_backend._STRATEGIES, (
+                f"Expected {strategy_id!r} to be a concrete strategy but it is absent "
+                "from _STRATEGIES. Update this test when new reserved ids are added."
+            )
 
     def test_unknown_strategy_returns_unavailable(self, monkeypatch, tmp_path):
         """Strings outside ``KNOWN_STRATEGIES`` fail closed with ``unknown_strategy``."""
@@ -3620,3 +3602,264 @@ class TestReviewStrategy:
         diag = llm_backend.check(self._rule(), _target_with_artifact(tmp_path))
         assert diag.status is Status.UNAVAILABLE
         assert diag.evidence[0].kind == "provider_unconfigured"
+
+
+# ---------------------------------------------------------------------------
+# Adaptive strategy (#186): single→consensus escalation
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptiveStrategy:
+    """Issue #186 — adaptive escalation policy (single → consensus).
+
+    All tests use fake provider stubs; no live LLM calls are made.
+
+    Escalation triggers:
+    - Tier 1 evidence kind ``target_kind_mismatch`` → escalate to consensus.
+    - Any other Tier 1 outcome → commit directly (no escalation).
+    """
+
+    _ENV = {
+        "GATE_KEEPER_LLM_PROVIDER": "openai",
+        "OPENAI_API_KEY": "sk-openai-test",
+    }
+
+    # JSON payload the model returns when it declares the rule does not apply
+    # to the artifact kind. Requires a rule with target_kind != UNSPECIFIED
+    # so that the single-strategy path emits target_kind_mismatch evidence.
+    _UNSUPPORTED_JSON = json.dumps(
+        {
+            "judgment": "unsupported",
+            "primary_reason": "The rule targets PR descriptions; this is a commit message.",
+            "supporting_evidence_quotes": [],
+            "suggested_action": None,
+        }
+    )
+
+    def _rule(self, *, with_target_kind: bool = False) -> "Rule":
+        from gate_keeper.models import TargetKind
+
+        return Rule(
+            id="stub-adaptive-rule",
+            title="Stub adaptive rule",
+            source=SourceLocation(path="rules.md", line=1),
+            text="The documentation should be clear and comprehensive",
+            kind=RuleKind.SEMANTIC_RUBRIC,
+            severity=Severity.ERROR,
+            backend_hint=Backend.LLM_RUBRIC,
+            confidence=Confidence.LOW,
+            params={"strategy": "adaptive"},
+            target_kind=TargetKind.PR_DESCRIPTION if with_target_kind else TargetKind.UNSPECIFIED,
+        )
+
+    def _make_spy(self, responses: list[str]) -> "tuple[list[tuple], object]":
+        """Return (calls_log, spy_fn) where spy_fn cycles through *responses*."""
+        calls: list[tuple] = []
+        idx = {"i": 0}
+
+        def _spy(api_key, system, user, model):
+            calls.append((api_key, model))
+            text = responses[idx["i"] % len(responses)]
+            idx["i"] += 1
+            return _stub_response(text, {"latency_ms": 50, "tokens_in": 100, "tokens_out": 20})
+
+        return calls, _spy
+
+    # ---- dispatcher routing ----
+
+    def test_adaptive_routes_to_adaptive_strategy(self, monkeypatch, tmp_path):
+        """``params.strategy=adaptive`` dispatches to ``_run_adaptive_strategy``."""
+        _patch_env(monkeypatch, self._ENV)
+        calls, spy = self._make_spy([_VALID_PASS_JSON])
+        monkeypatch.setattr(llm_backend, "_call_openai", spy)
+        diag = llm_backend.check(self._rule(), _target_with_artifact(tmp_path))
+        assert diag.evidence[0].kind == "llm_adaptive"
+        assert diag.evidence[0].data["llm_strategy"] == "adaptive"
+
+    # ---- Tier 1 pass → commit, no escalation ----
+
+    def test_tier1_pass_commits_no_escalation(self, monkeypatch, tmp_path):
+        """Tier 1 pass → PASS at adaptive_tier=1, provider called exactly once."""
+        _patch_env(monkeypatch, self._ENV)
+        calls, spy = self._make_spy([_VALID_PASS_JSON])
+        monkeypatch.setattr(llm_backend, "_call_openai", spy)
+        diag = llm_backend.check(self._rule(), _target_with_artifact(tmp_path))
+        assert diag.status is Status.PASS
+        data = diag.evidence[0].data
+        assert data["adaptive_tier"] == 1
+        assert data["adaptive_escalation_reason"] is None
+        assert data["llm_call_count"] == 1
+        # Only one provider call was made.
+        assert len(calls) == 1
+
+    # ---- Tier 1 fail → commit, no escalation ----
+
+    def test_tier1_fail_commits_no_escalation(self, monkeypatch, tmp_path):
+        """Tier 1 fail → FAIL at adaptive_tier=1, provider called exactly once."""
+        _patch_env(monkeypatch, self._ENV)
+        calls, spy = self._make_spy([_VALID_FAIL_JSON])
+        monkeypatch.setattr(llm_backend, "_call_openai", spy)
+        diag = llm_backend.check(self._rule(), _target_with_artifact(tmp_path))
+        assert diag.status is Status.FAIL
+        data = diag.evidence[0].data
+        assert data["adaptive_tier"] == 1
+        assert data["adaptive_escalation_reason"] is None
+        assert data["llm_call_count"] == 1
+        assert len(calls) == 1
+        assert diag.remediation is not None
+
+    # ---- Tier 1 target_kind_mismatch → escalate to consensus ----
+
+    def test_tier1_target_kind_mismatch_escalates(self, monkeypatch, tmp_path):
+        """Tier 1 target_kind_mismatch → escalate; 1+3=4 provider calls total."""
+        _patch_env(monkeypatch, self._ENV)
+        # First call: unsupported (tier 1). Next three: consensus panel (tier 2).
+        responses = [self._UNSUPPORTED_JSON] + [_VALID_PASS_JSON] * 3
+        calls, spy = self._make_spy(responses)
+        monkeypatch.setattr(llm_backend, "_call_openai", spy)
+        rule = self._rule(with_target_kind=True)
+        diag = llm_backend.check(rule, _target_with_artifact(tmp_path))
+        # 4 total calls: 1 for tier-1 single + 3 for tier-2 consensus panel.
+        assert len(calls) == 4
+        data = diag.evidence[0].data
+        assert data["adaptive_tier"] == 2
+        assert data["adaptive_escalation_reason"] == "tier1_unsupported"
+        assert data["llm_call_count"] == 4
+
+    def test_tier1_target_kind_mismatch_escalation_verdict_from_consensus(self, monkeypatch, tmp_path):
+        """After escalation, the final verdict comes from the consensus result."""
+        _patch_env(monkeypatch, self._ENV)
+        responses = [self._UNSUPPORTED_JSON] + [_VALID_FAIL_JSON] * 3
+        _, spy = self._make_spy(responses)
+        monkeypatch.setattr(llm_backend, "_call_openai", spy)
+        rule = self._rule(with_target_kind=True)
+        diag = llm_backend.check(rule, _target_with_artifact(tmp_path))
+        assert diag.status is Status.FAIL
+        data = diag.evidence[0].data
+        assert data["adaptive_tier"] == 2
+        assert data["adaptive_escalation_reason"] == "tier1_unsupported"
+
+    def test_tier1_unsupported_without_target_kind_does_not_escalate(self, monkeypatch, tmp_path):
+        """Stray unsupported from unspecified target_kind → UNAVAILABLE, no escalation.
+
+        The single strategy treats unsupported-without-target_kind as a
+        provider contract violation (UNAVAILABLE with provider_error evidence).
+        Adaptive must not escalate that — it is fail-closed, not ambiguous.
+        """
+        _patch_env(monkeypatch, self._ENV)
+        calls, spy = self._make_spy([self._UNSUPPORTED_JSON])
+        monkeypatch.setattr(llm_backend, "_call_openai", spy)
+        # Rule without target_kind: unsupported verdict is treated as provider error.
+        rule = self._rule(with_target_kind=False)
+        diag = llm_backend.check(rule, _target_with_artifact(tmp_path))
+        assert diag.status is Status.UNAVAILABLE
+        # Only one provider call — no escalation.
+        assert len(calls) == 1
+        data = diag.evidence[0].data
+        assert data["adaptive_tier"] == 1
+        assert data["adaptive_escalation_reason"] is None
+
+    # ---- Tier 1 unavailable (parse error) → fail-closed, no escalation ----
+
+    def test_tier1_parse_failure_failclosed_no_escalation(self, monkeypatch, tmp_path):
+        """Tier 1 parse failure → UNAVAILABLE at adaptive_tier=1, no escalation."""
+        _patch_env(monkeypatch, self._ENV)
+        calls, spy = self._make_spy(["not valid json {{{{"])
+        monkeypatch.setattr(llm_backend, "_call_openai", spy)
+        diag = llm_backend.check(self._rule(), _target_with_artifact(tmp_path))
+        assert diag.status is Status.UNAVAILABLE
+        # Only one call — no escalation.
+        assert len(calls) == 1
+        data = diag.evidence[0].data
+        assert data["adaptive_tier"] == 1
+        assert data["adaptive_escalation_reason"] is None
+
+    # ---- Tier 1 unavailable (fabricated quotes) → fail-closed, no escalation ----
+
+    def test_tier1_fabricated_quotes_failclosed_no_escalation(self, monkeypatch, tmp_path):
+        """Tier 1 quote fabrication → UNSUPPORTED(llm_quote_fabrication) at tier=1, no escalation."""
+        _patch_env(monkeypatch, self._ENV)
+        fabricated_payload = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "All good.",
+                "supporting_evidence_quotes": ["This phrase does not exist in the artifact at all."],
+                "suggested_action": None,
+            }
+        )
+        calls, spy = self._make_spy([fabricated_payload])
+        monkeypatch.setattr(llm_backend, "_call_openai", spy)
+        diag = llm_backend.check(self._rule(), _target_with_artifact(tmp_path))
+        # Quote fabrication returns UNSUPPORTED (not UNAVAILABLE), but adaptive
+        # must NOT escalate it — evidence kind is llm_quote_fabrication, not
+        # target_kind_mismatch.
+        assert diag.status is Status.UNSUPPORTED
+        # Only one call — no escalation.
+        assert len(calls) == 1
+        data = diag.evidence[0].data
+        assert data["adaptive_tier"] == 1
+        assert data["adaptive_escalation_reason"] is None
+
+    # ---- Telemetry accumulation ----
+
+    def test_telemetry_tier1_call_count_is_1(self, monkeypatch, tmp_path):
+        """Tier 1 (no escalation): llm_call_count=1, one model entry."""
+        _patch_env(monkeypatch, self._ENV)
+        _, spy = self._make_spy([_VALID_PASS_JSON])
+        monkeypatch.setattr(llm_backend, "_call_openai", spy)
+        diag = llm_backend.check(self._rule(), _target_with_artifact(tmp_path))
+        data = diag.evidence[0].data
+        assert data["llm_call_count"] == 1
+        assert len(data["models"]) == 1
+
+    def test_telemetry_tier2_call_count_accumulates_across_tiers(self, monkeypatch, tmp_path):
+        """Tier 2 (escalated): llm_call_count=4 (1 single + 3 consensus)."""
+        _patch_env(monkeypatch, self._ENV)
+        responses = [self._UNSUPPORTED_JSON] + [_VALID_PASS_JSON] * 3
+        _, spy = self._make_spy(responses)
+        monkeypatch.setattr(llm_backend, "_call_openai", spy)
+        rule = self._rule(with_target_kind=True)
+        diag = llm_backend.check(rule, _target_with_artifact(tmp_path))
+        data = diag.evidence[0].data
+        assert data["llm_call_count"] == 4
+        assert len(data["models"]) == 4
+
+    def test_telemetry_latency_accumulates_across_tiers(self, monkeypatch, tmp_path):
+        """latency_ms_total sums Tier 1 and Tier 2 latencies."""
+        _patch_env(monkeypatch, self._ENV)
+        idx = {"i": 0}
+        responses = [self._UNSUPPORTED_JSON] + [_VALID_PASS_JSON] * 3
+
+        def _spy(api_key, system, user, model):
+            text = responses[idx["i"] % len(responses)]
+            idx["i"] += 1
+            return _stub_response(text, {"latency_ms": 100, "tokens_in": 100, "tokens_out": 20})
+
+        monkeypatch.setattr(llm_backend, "_call_openai", _spy)
+        rule = self._rule(with_target_kind=True)
+        diag = llm_backend.check(rule, _target_with_artifact(tmp_path))
+        data = diag.evidence[0].data
+        # 4 calls × 100 ms = 400 ms total.
+        assert data["latency_ms_total"] == 400
+
+    def test_tier1_evidence_preserved_in_tier2(self, monkeypatch, tmp_path):
+        """When Tier 2 fires, Tier 1 evidence is nested under ``tier1_evidence``."""
+        _patch_env(monkeypatch, self._ENV)
+        responses = [self._UNSUPPORTED_JSON] + [_VALID_PASS_JSON] * 3
+        _, spy = self._make_spy(responses)
+        monkeypatch.setattr(llm_backend, "_call_openai", spy)
+        rule = self._rule(with_target_kind=True)
+        diag = llm_backend.check(rule, _target_with_artifact(tmp_path))
+        data = diag.evidence[0].data
+        assert "tier1_evidence" in data
+        t1 = data["tier1_evidence"]
+        assert t1["judgment"] == "unsupported"
+
+    # ---- unconfigured ----
+
+    def test_unconfigured_returns_unavailable_adaptive(self, monkeypatch, tmp_path):
+        """Adaptive path respects the unconfigured check the same as single."""
+        monkeypatch.setattr(llm_backend, "_load_env_file", lambda *_a, **_k: {})
+        diag = llm_backend.check(self._rule(), _target_with_artifact(tmp_path))
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "llm_adaptive"

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -3843,7 +3843,11 @@ class TestAdaptiveStrategy:
         assert data["latency_ms_total"] == 400
 
     def test_tier1_evidence_preserved_in_tier2(self, monkeypatch, tmp_path):
-        """When Tier 2 fires, Tier 1 evidence is nested under ``tier1_evidence``."""
+        """When Tier 2 fires, Tier 1 evidence is nested under ``tier1_evidence``.
+
+        The nested value is ``{kind, data}`` so the original evidence kind is
+        auditable alongside the inner evidence payload.
+        """
         _patch_env(monkeypatch, self._ENV)
         responses = [self._UNSUPPORTED_JSON] + [_VALID_PASS_JSON] * 3
         _, spy = self._make_spy(responses)
@@ -3853,7 +3857,10 @@ class TestAdaptiveStrategy:
         data = diag.evidence[0].data
         assert "tier1_evidence" in data
         t1 = data["tier1_evidence"]
-        assert t1["judgment"] == "unsupported"
+        # tier1_evidence is now {kind, data} to preserve the original evidence kind.
+        assert "kind" in t1
+        assert "data" in t1
+        assert t1["data"]["judgment"] == "unsupported"
 
     # ---- unconfigured ----
 


### PR DESCRIPTION
## Summary

- Implements `_run_adaptive_strategy` composing `_run_single_strategy` (Tier 1) with `_run_consensus_strategy` (Tier 2)
- Escalation trigger: Tier 1 `target_kind_mismatch` evidence → escalate to consensus panel of 3; all other outcomes (PASS/FAIL/UNAVAILABLE/`llm_quote_fabrication`) commit directly at Tier 1
- Evidence shape: `llm_adaptive` kind with `adaptive_tier` (1 or 2), `adaptive_escalation_reason` (`"tier1_unsupported"` or `null`), aggregated `llm_call_count` / `models` / `cost_estimate_usd_total` / `latency_ms_total` across tiers, `tier1_evidence` nested on Tier 2 path
- All 4 strategies now concrete; `_STRATEGIES` registry updated; `TestStrategySeam` updated accordingly
- 13 new tests in `TestAdaptiveStrategy` covering all escalation paths, fail-closed paths, and telemetry accumulation

Closes #186. Refs: #164, #183, #197, #184, #185.

## Validation

```
uv run pytest tests/test_llm_rubric_backend.py::TestAdaptiveStrategy -q   → 13 passed
uv run pytest tests/test_llm_rubric_backend.py::TestStrategySeam -q       → 12 passed
uvx ruff check src/gate_keeper/backends/llm_rubric.py                      → All checks passed
```

Pre-existing failures on `main` (real-LLM-call test harness issues, unrelated to this PR): `TestLlmRubricBackendStub` and `test_llm_rubric_backend_accepted_but_unavailable` — no new failures introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)