### PR TITLE
ci(dogfooding): pass actual PR body as --target (#189)

### DIFF
--- a/.github/workflows/dogfooding.yml
+++ b/.github/workflows/dogfooding.yml
@@ -96,16 +96,20 @@ jobs:
         id: validate
         continue-on-error: true
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set +x
           # `--format json` so the post step can transform reliably; failures
           # are tolerated by continue-on-error and surface as a "no advisory"
           # log in the post step.
-          # `--target $PR_URL` matches the PR URL contract; if backend can't
-          # fetch the PR it falls back to deterministic-no-evidence path.
+          # Pass the actual PR body text as --target so the llm-rubric backend
+          # evaluates real prose rather than a URL literal (fixes #189).
+          # github.event.pull_request.body is null for body-less PRs; default
+          # to a single space to keep CLI arg parsing consistent. The rule will
+          # then produce an "insufficient content" evidence result naturally.
+          BODY="${PR_BODY:- }"
           uv run gate-keeper validate docs/dogfooding-rules.md \
-            --target "$PR_URL" \
+            --target "$BODY" \
             --artifact-kind pr_description \
             --backend llm-rubric \
             --format json \


### PR DESCRIPTION
## Summary

- **Root cause**: `dogfooding.yml` was passing `--target "$PR_URL"` to `gate-keeper validate`. The `#178` deterministic precheck recognized the URL literal as not being pr_description text and short-circuited to `UNSUPPORTED` before calling the LLM — producing zero rubric telemetry on every PR.
- **Fix**: Replace `PR_URL` env var with `PR_BODY` (`github.event.pull_request.body`), default to a single space for body-less PRs, and pass `"$BODY"` as `--target`. The `--artifact-kind pr_description` flag (added in #198) is retained.
- **Verified locally**: Smoke-tested with a sample body string — the CLI now produces real `pass`/`fail` verdicts from the llm-rubric backend instead of all-UNSUPPORTED rows.

## Test plan

- [x] CI dogfooding job on this PR posts an advisory comment with real rubric verdicts (not 3×UNSUPPORTED): **confirmed** — advisory comment shows FAIL for L23 (real LLM judgment), UNSUPPORTED for L24 (quote fabrication defense), UNSUPPORTED for L25 (target_kind mismatch skip). The URL-detection all-UNSUPPORTED path is gone.
- [x] Body-less PR scenario: `PR_BODY` defaults to `" "` via `${PR_BODY:- }` — deferred manual validation (cannot automate without opening a body-less PR); the shell default is a standard Bash parameter expansion with no blocking ambiguity.

Closes #189. Refs: #164, #178, #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)