### PR TITLE
feat(classifier): non-binding textlint suggestion for textlint-suitable rules (#215)

### DIFF
--- a/docs/backend-external.md
+++ b/docs/backend-external.md
@@ -150,11 +150,52 @@ These adapters ship with gate-keeper and self-register at CLI entry
 - Classifier rules that route Markdown text to `external_check` — the
   classifier still has no `external` branch; rules use `external_check`
   only when authored that way (or compiled from a future adapter-aware
-  classification pass).
+  classification pass). The classifier *can* emit a non-binding
+  suggestion pointing authors at this backend; see
+  [Classifier suggestion (#215)](#classifier-suggestion-215) below.
 - Concrete `--backend external` invocation flows; the choice is exposed
   for symmetry with the other backends, but the foundation has no adapters
   registered, so every rule routed there returns `unsupported` /
   `adapter_unknown` until #80 lands at least one adapter.
+
+## Classifier suggestion (#215)
+
+The classifier detects textlint-suitable patterns and reports them as
+**non-binding suggestions** on the Rule IR. The effective backend
+(`backend_hint` / `kind`) is **never** rewritten by the suggestion — the
+author keeps control of routing.
+
+When a heuristic matches (`use X instead of Y`, `must not use the term`,
+`passive voice`, `first-person pronouns`, `sentence length`,
+`capitalized as`, etc.), the classifier populates three advisory fields
+on the Rule:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `suggested_backend` | `str` | e.g. `"external+textlint"` |
+| `suggestion_confidence` | `float` in `[0.0, 1.0]` | heuristic confidence |
+| `suggestion_rationale` | `str` | short human-readable explanation |
+
+These fields are omitted from `to_dict()` output when absent so existing
+IR fixtures stay byte-identical.
+
+**Adopting a suggestion (author opt-in).** To actually route a rule to
+the external adapter, edit the compiled IR JSON to set:
+
+```json
+{
+  "kind": "external_check",
+  "backend_hint": "external",
+  "params": { "tool": "textlint" }
+}
+```
+
+Then run `gate-keeper validate --rules-format ir compiled.json --target …`.
+The validator uses the explicit `kind` / `backend_hint`, not
+`suggested_backend`. There is no auto-promotion: the suggestion is a hint
+only, the hand-edited IR is the source of truth. This preserves the
+fail-closed behaviour for authors who have not installed textlint while
+still surfacing the opportunity.
 
 ---
 

--- a/src/gate_keeper/classifier.py
+++ b/src/gate_keeper/classifier.py
@@ -152,6 +152,100 @@ _NORMATIVE_RE = re.compile(
 )
 
 # ---------------------------------------------------------------------------
+# Textlint suggestion heuristics (non-binding, issue #215)
+#
+# These patterns detect rules that are likely better served by textlint than
+# by the LLM rubric, and populate the advisory ``suggested_backend``,
+# ``suggestion_confidence``, and ``suggestion_rationale`` fields on the Rule.
+# They do NOT change the effective backend (``backend_hint`` / ``kind``).
+#
+# Precision over recall: only patterns with very low false-positive risk are
+# included.  Authors adopt the suggestion by explicitly setting
+# ``backend_hint="external"`` / ``kind="external_check"`` in the rule IR.
+# See ``docs/backend-external.md`` for the opt-in workflow.
+# ---------------------------------------------------------------------------
+
+# Cue 1 — Concrete term-substitution / terminology enforcement.
+# Matches: "use X instead of Y", "must not use the term", "correct term is".
+_TEXTLINT_TERM_SUB_RE = re.compile(
+    r"\buse\b.{1,60}\binstead\s+of\b"
+    r"|\bcorrect(?:ly\s+spell(?:ed)?|ly\s+capitaliz(?:ed)?|ed\s+as)\b"
+    r"|\bcorrect\s+term\s+is\b"
+    r"|\bmust\s+not\s+use\s+the\s+(?:term|word)\b"
+    r"|\bshould\s+not\s+use\s+the\s+(?:term|word)\b",
+    re.IGNORECASE,
+)
+
+# Cue 2 — Named prose-style constraint (passive voice, first-person pronouns,
+# sentence length).  These map directly to well-known textlint rules
+# (e.g. textlint-rule-no-passive-voice, textlint-rule-max-comma).
+_TEXTLINT_STYLE_RE = re.compile(
+    r"\bpassive\s+voice\b"
+    r"|\bfirst.person\s+pronouns?\b"
+    r"|\bsentence\s+length\b"
+    r"|\bno\s+more\s+than\s+\d+\s+words?\b"
+    r"|\bfewer\s+than\s+\d+\s+words?\b"
+    r"|\bmust\s+not\s+exceed\s+\d+\s+(?:words?|sentences?)\b",
+    re.IGNORECASE,
+)
+
+# Cue 3 — Capitalisation / spelling enforcement for prose terms or brand names.
+# "must be capitalized as X", "correct spelling/capitalization", etc.
+_TEXTLINT_CAPITALISE_RE = re.compile(
+    r"\bmust\s+be\s+(?:written|spelled|capitaliz(?:ed))\s+as\b"
+    r"|\bcorrect\s+(?:spelling|capitaliz(?:ation))\b"
+    r"|\bcapitaliz(?:ed|ation)\s+as\s+defined\b",
+    re.IGNORECASE,
+)
+
+
+def _suggest_textlint(rule: Rule) -> Rule:
+    """Annotate *rule* with a non-binding textlint suggestion when a heuristic matches.
+
+    Returns a new Rule with ``suggested_backend``, ``suggestion_confidence``,
+    and ``suggestion_rationale`` populated.  The effective backend
+    (``backend_hint`` / ``kind``) is left unchanged — the suggestion is
+    advisory output only.
+    """
+    text = rule.text
+
+    if _TEXTLINT_TERM_SUB_RE.search(text):
+        return replace(
+            rule,
+            suggested_backend="external+textlint",
+            suggestion_confidence=0.8,
+            suggestion_rationale=(
+                "term-substitution or terminology-enforcement pattern detected; "
+                "consider textlint-rule-terminology or textlint-rule-prh"
+            ),
+        )
+
+    if _TEXTLINT_STYLE_RE.search(text):
+        return replace(
+            rule,
+            suggested_backend="external+textlint",
+            suggestion_confidence=0.85,
+            suggestion_rationale=(
+                "named prose-style constraint detected (passive voice / first-person "
+                "pronouns / sentence length); consider a textlint style rule"
+            ),
+        )
+
+    if _TEXTLINT_CAPITALISE_RE.search(text):
+        return replace(
+            rule,
+            suggested_backend="external+textlint",
+            suggestion_confidence=0.75,
+            suggestion_rationale=(
+                "capitalisation or spelling-enforcement pattern detected; "
+                "consider textlint-rule-terminology or textlint-rule-prh"
+            ),
+        )
+
+    return rule
+
+
+# ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
@@ -360,11 +454,21 @@ def _classify_rule(rule: Rule) -> Rule:
 # ---------------------------------------------------------------------------
 
 
+def _classify_and_annotate(rule: Rule) -> Rule:
+    """Apply routing classification, then annotate with non-binding suggestions.
+
+    The textlint suggestion is layered on top of the effective routing
+    decision so it never changes the effective backend.  Authors adopt a
+    suggestion by editing the rule IR (see ``docs/backend-external.md``).
+    """
+    return _suggest_textlint(_classify_rule(rule))
+
+
 def classify(ruleset: RuleSet) -> RuleSet:
     """Classify all rules in *ruleset*, returning a new RuleSet with updated kind/backend/confidence."""
-    return RuleSet(rules=[_classify_rule(rule) for rule in ruleset.rules])
+    return RuleSet(rules=[_classify_and_annotate(rule) for rule in ruleset.rules])
 
 
 def classify_rule(rule: Rule) -> Rule:
     """Classify a single rule, returning a new Rule with updated kind/backend/confidence."""
-    return _classify_rule(rule)
+    return _classify_and_annotate(rule)

--- a/src/gate_keeper/models.py
+++ b/src/gate_keeper/models.py
@@ -8,6 +8,7 @@ documented in docs/rule-ir.md and exemplified by tests/fixtures/ir/.
 from __future__ import annotations
 
 import enum
+import math
 from dataclasses import dataclass
 from typing import Any
 
@@ -208,6 +209,10 @@ class Rule:
             target_kind = _coerce_enum(TargetKind, target_kind_raw, "Rule.target_kind")
 
         # ``suggestion_confidence`` is an optional float in [0.0, 1.0].
+        # Reject non-finite values (NaN/Inf) and out-of-range numbers up
+        # front so hand-authored or transformed IR cannot smuggle
+        # unnormalised confidence scores past the loader (codex review
+        # feedback on #227).
         suggestion_confidence_raw = data.get("suggestion_confidence")
         if suggestion_confidence_raw is None:
             suggestion_confidence: float | None = None
@@ -220,6 +225,16 @@ class Rule:
                     f"got {type(suggestion_confidence_raw).__name__}"
                 )
             suggestion_confidence = float(suggestion_confidence_raw)
+            if not math.isfinite(suggestion_confidence):
+                raise ValueError(
+                    f"Rule.suggestion_confidence: expected finite float in [0.0, 1.0], "
+                    f"got {suggestion_confidence_raw!r}"
+                )
+            if not (0.0 <= suggestion_confidence <= 1.0):
+                raise ValueError(
+                    f"Rule.suggestion_confidence: expected float in [0.0, 1.0], "
+                    f"got {suggestion_confidence_raw!r}"
+                )
 
         return cls(
             id=_expect_str(data["id"], "Rule.id"),

--- a/src/gate_keeper/models.py
+++ b/src/gate_keeper/models.py
@@ -170,6 +170,16 @@ class Rule:
     confidence: Confidence
     params: dict[str, Any]
     target_kind: TargetKind = TargetKind.UNSPECIFIED
+    # Non-binding suggestion fields populated by the classifier when a
+    # textlint-suitable pattern is detected (issue #215).  They are advisory
+    # output only — they do NOT change effective routing (``backend_hint`` /
+    # ``kind`` remain the source of truth for the validator).  Authors adopt
+    # the suggestion by setting ``backend_hint="external"`` and
+    # ``kind="external_check"`` in the rule IR explicitly; see
+    # ``docs/backend-external.md``.
+    suggested_backend: str | None = None
+    suggestion_confidence: float | None = None
+    suggestion_rationale: str | None = None
 
     @classmethod
     def from_dict(cls, data: Any) -> Rule:
@@ -184,13 +194,33 @@ class Rule:
             "confidence",
             "params",
         }
-        optional = {"target_kind"}
+        optional = {
+            "target_kind",
+            "suggested_backend",
+            "suggestion_confidence",
+            "suggestion_rationale",
+        }
         _require_keys(data, required, optional, "Rule")
         target_kind_raw = data.get("target_kind")
         if target_kind_raw is None:
             target_kind = TargetKind.UNSPECIFIED
         else:
             target_kind = _coerce_enum(TargetKind, target_kind_raw, "Rule.target_kind")
+
+        # ``suggestion_confidence`` is an optional float in [0.0, 1.0].
+        suggestion_confidence_raw = data.get("suggestion_confidence")
+        if suggestion_confidence_raw is None:
+            suggestion_confidence: float | None = None
+        else:
+            if isinstance(suggestion_confidence_raw, bool) or not isinstance(
+                suggestion_confidence_raw, (int, float)
+            ):
+                raise ValueError(
+                    f"Rule.suggestion_confidence: expected float, "
+                    f"got {type(suggestion_confidence_raw).__name__}"
+                )
+            suggestion_confidence = float(suggestion_confidence_raw)
+
         return cls(
             id=_expect_str(data["id"], "Rule.id"),
             title=_expect_str(data["title"], "Rule.title"),
@@ -202,6 +232,11 @@ class Rule:
             confidence=_coerce_enum(Confidence, data["confidence"], "Rule.confidence"),
             params=dict(_expect_dict(data["params"], "Rule.params")),
             target_kind=target_kind,
+            suggested_backend=_expect_optional_str(data.get("suggested_backend"), "Rule.suggested_backend"),
+            suggestion_confidence=suggestion_confidence,
+            suggestion_rationale=_expect_optional_str(
+                data.get("suggestion_rationale"), "Rule.suggestion_rationale"
+            ),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -220,6 +255,14 @@ class Rule:
         # IR fixtures remain byte-identical and the field stays opt-in.
         if self.target_kind is not TargetKind.UNSPECIFIED:
             result["target_kind"] = self.target_kind.value
+        # Suggestion fields are advisory output and omitted when absent so
+        # existing IR fixtures remain byte-identical.
+        if self.suggested_backend is not None:
+            result["suggested_backend"] = self.suggested_backend
+        if self.suggestion_confidence is not None:
+            result["suggestion_confidence"] = self.suggestion_confidence
+        if self.suggestion_rationale is not None:
+            result["suggestion_rationale"] = self.suggestion_rationale
         return result
 
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -661,3 +661,85 @@ class TestTextlintSuggestion:
         assert restored.suggested_backend == original.suggested_backend
         assert restored.suggestion_confidence == original.suggestion_confidence
         assert restored.suggestion_rationale == original.suggestion_rationale
+
+    # --- IR validation rejects out-of-range / non-finite confidence -----
+    # Codex review feedback on #227: ``suggestion_confidence`` must be a
+    # finite float in [0.0, 1.0]; hand-authored or transformed IR must not
+    # be able to smuggle invalid values past the loader.
+
+    @staticmethod
+    def _base_ir() -> dict[str, object]:
+        # Minimal valid Rule IR dict that tests can mutate.
+        return {
+            "id": "rule-test-L1",
+            "title": "t",
+            "source": {"path": "test.md", "line": 1},
+            "text": "x",
+            "kind": "semantic_rubric",
+            "severity": "warning",
+            "backend_hint": "llm-rubric",
+            "confidence": "low",
+            "params": {},
+        }
+
+    def test_suggestion_confidence_below_zero_rejected(self):
+        import pytest
+
+        data = self._base_ir()
+        data["suggestion_confidence"] = -0.1
+        with pytest.raises(ValueError, match=r"suggestion_confidence"):
+            Rule.from_dict(data)
+
+    def test_suggestion_confidence_above_one_rejected(self):
+        import pytest
+
+        data = self._base_ir()
+        data["suggestion_confidence"] = 1.7
+        with pytest.raises(ValueError, match=r"suggestion_confidence"):
+            Rule.from_dict(data)
+
+    def test_suggestion_confidence_nan_rejected(self):
+        import pytest
+
+        data = self._base_ir()
+        data["suggestion_confidence"] = float("nan")
+        with pytest.raises(ValueError, match=r"finite"):
+            Rule.from_dict(data)
+
+    def test_suggestion_confidence_inf_rejected(self):
+        import pytest
+
+        data = self._base_ir()
+        data["suggestion_confidence"] = float("inf")
+        with pytest.raises(ValueError, match=r"finite"):
+            Rule.from_dict(data)
+
+    def test_suggestion_confidence_boundary_zero_accepted(self):
+        data = self._base_ir()
+        data["suggestion_confidence"] = 0.0
+        rule = Rule.from_dict(data)
+        assert rule.suggestion_confidence == 0.0
+
+    def test_suggestion_confidence_boundary_one_accepted(self):
+        data = self._base_ir()
+        data["suggestion_confidence"] = 1.0
+        rule = Rule.from_dict(data)
+        assert rule.suggestion_confidence == 1.0
+
+    def test_suggestion_confidence_non_numeric_rejected(self):
+        import pytest
+
+        data = self._base_ir()
+        data["suggestion_confidence"] = "high"
+        with pytest.raises(ValueError, match=r"expected float"):
+            Rule.from_dict(data)
+
+    def test_suggestion_confidence_bool_rejected(self):
+        import pytest
+
+        data = self._base_ir()
+        # ``True`` is technically an ``int`` in Python, so the loader must
+        # reject it explicitly to avoid silently coercing to ``1.0``.
+        data["suggestion_confidence"] = True
+        with pytest.raises(ValueError, match=r"expected float"):
+            Rule.from_dict(data)

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -538,3 +538,126 @@ class TestDraftRequiresPRContext:
         rule = _classify_text("PR must not be in draft state before review")
         assert rule.backend_hint is Backend.GITHUB
         assert rule.kind is RuleKind.GITHUB_NOT_DRAFT
+
+
+# ---------------------------------------------------------------------------
+# Issue #215: non-binding textlint suggestion fields
+# ---------------------------------------------------------------------------
+
+
+class TestTextlintSuggestion:
+    """Classifier emits an advisory ``suggested_backend`` for textlint-suitable rules.
+
+    The suggestion is non-binding: effective routing (``backend_hint`` /
+    ``kind``) must be unchanged.  Authors adopt the suggestion by editing
+    the rule IR explicitly (see ``docs/backend-external.md``).
+    """
+
+    # --- Positive cases — heuristics should match -----------------------
+
+    def test_term_substitution_emits_suggestion(self):
+        rule = _classify_text("Documentation must use 'GitHub' instead of 'github'.")
+        assert rule.suggested_backend == "external+textlint"
+        assert rule.suggestion_confidence is not None
+        assert 0.0 < rule.suggestion_confidence <= 1.0
+        assert rule.suggestion_rationale
+        assert "term" in rule.suggestion_rationale.lower()
+
+    def test_must_not_use_the_term_emits_suggestion(self):
+        rule = _classify_text("Authors must not use the term 'simply' in documentation.")
+        assert rule.suggested_backend == "external+textlint"
+        assert rule.suggestion_rationale
+
+    def test_passive_voice_emits_suggestion(self):
+        rule = _classify_text("The changelog entry must not use passive voice.")
+        assert rule.suggested_backend == "external+textlint"
+        assert rule.suggestion_rationale
+        rationale_l = rule.suggestion_rationale.lower()
+        assert "passive" in rationale_l or "style" in rationale_l
+
+    def test_first_person_pronoun_emits_suggestion(self):
+        rule = _classify_text("Release notes must not use first-person pronouns.")
+        assert rule.suggested_backend == "external+textlint"
+
+    def test_sentence_length_emits_suggestion(self):
+        rule = _classify_text("Each sentence must not exceed 25 words.")
+        assert rule.suggested_backend == "external+textlint"
+
+    def test_capitalisation_emits_suggestion(self):
+        rule = _classify_text("Product names must be capitalized as defined in the brand guide.")
+        assert rule.suggested_backend == "external+textlint"
+
+    # --- Negative cases — heuristics must NOT match ---------------------
+
+    def test_file_existence_rule_has_no_suggestion(self):
+        rule = _classify_text("The CHANGELOG file must exist before release.")
+        assert rule.suggested_backend is None
+        assert rule.suggestion_confidence is None
+        assert rule.suggestion_rationale is None
+
+    def test_ci_check_rule_has_no_suggestion(self):
+        rule = _classify_text("CI checks must pass before merging.")
+        assert rule.suggested_backend is None
+
+    def test_generic_text_required_has_no_suggestion(self):
+        # ``must contain`` matches the byte-level text_required filesystem
+        # path; on its own that is NOT a textlint pattern and the
+        # suggestion field must remain absent.
+        rule = _classify_text("The README must contain a usage section.")
+        assert rule.suggested_backend is None
+
+    def test_generic_quality_rule_has_no_suggestion(self):
+        rule = _classify_text("Code quality must meet team standards.")
+        assert rule.suggested_backend is None
+
+    def test_pr_state_rule_has_no_suggestion(self):
+        rule = _classify_text("The pull request must not be a draft.")
+        assert rule.suggested_backend is None
+
+    # --- Effective routing must be unchanged ----------------------------
+
+    def test_suggestion_does_not_change_backend(self):
+        # A rule that matches a textlint suggestion AND falls through to
+        # llm-rubric must still route to llm-rubric — the suggestion is
+        # non-binding output only.
+        rule = _classify_text("The changelog entry must not use passive voice.")
+        assert rule.backend_hint is Backend.LLM_RUBRIC
+        assert rule.kind is RuleKind.SEMANTIC_RUBRIC
+        # Suggestion is still surfaced for the author.
+        assert rule.suggested_backend == "external+textlint"
+
+    def test_suggestion_does_not_change_filesystem_routing(self):
+        # If a rule matches BOTH a filesystem heuristic AND a textlint
+        # suggestion, the effective backend stays filesystem.  ``must
+        # contain`` triggers filesystem/text_required, AND ``must not use
+        # the term`` triggers the textlint terminology heuristic.
+        rule = _classify_text("Docs must contain a glossary; authors must not use the term 'simply'.")
+        # text_required wins for effective routing.
+        assert rule.backend_hint is Backend.FILESYSTEM
+        # But the textlint suggestion is still emitted because the rule
+        # text also matches the term-enforcement heuristic.
+        assert rule.suggested_backend == "external+textlint"
+
+    # --- Suggestion fields round-trip through IR ------------------------
+
+    def test_suggestion_fields_serialize_to_dict(self):
+        rule = _classify_text("The changelog entry must not use passive voice.")
+        data = rule.to_dict()
+        assert data["suggested_backend"] == "external+textlint"
+        assert isinstance(data["suggestion_confidence"], float)
+        assert isinstance(data["suggestion_rationale"], str)
+
+    def test_no_suggestion_omits_fields_from_dict(self):
+        rule = _classify_text("The CHANGELOG file must exist before release.")
+        data = rule.to_dict()
+        assert "suggested_backend" not in data
+        assert "suggestion_confidence" not in data
+        assert "suggestion_rationale" not in data
+
+    def test_suggestion_fields_round_trip_through_from_dict(self):
+        original = _classify_text("The changelog entry must not use passive voice.")
+        data = original.to_dict()
+        restored = Rule.from_dict(data)
+        assert restored.suggested_backend == original.suggested_backend
+        assert restored.suggestion_confidence == original.suggestion_confidence
+        assert restored.suggestion_rationale == original.suggestion_rationale


### PR DESCRIPTION
## Summary

Per the [owner decision on #215](https://github.com/t-uda/gate-keeper/issues/215), the classifier now detects textlint-suitable patterns and emits a **non-binding** ``suggested_backend`` annotation on the Rule IR. Effective routing (``backend_hint`` / ``kind``) is unchanged — the suggestion is advisory output only. Authors adopt a suggestion by setting ``backend_hint=external`` / ``kind=external_check`` in the rule IR explicitly; there is no auto-promotion.

### Heuristics (high precision, low recall)

- **Term-substitution / terminology enforcement** — "use X instead of Y", "must not use the term".
- **Named prose-style constraints** — passive voice, first-person pronouns, sentence length.
- **Capitalisation / spelling enforcement** — "must be capitalized as", "correct spelling".

### IR surface

The Rule IR gains three optional fields, all of which are omitted from ``to_dict()`` output when absent so existing fixtures stay byte-identical:

| Field | Type | Meaning |
| --- | --- | --- |
| ``suggested_backend`` | ``str \| None`` | e.g. ``"external+textlint"`` |
| ``suggestion_confidence`` | ``float \| None`` in ``[0.0, 1.0]`` | heuristic confidence |
| ``suggestion_rationale`` | ``str \| None`` | short human-readable explanation |

### Docs

``docs/backend-external.md`` gains a "Classifier suggestion (#215)" section that documents the advisory fields and the author opt-in workflow (edit IR JSON to set ``kind=external_check``, ``backend_hint=external``, ``params.tool=textlint``).

## Test plan

- [x] ``uv run pytest tests/test_classifier.py`` — 75 passed (16 new cases covering positive, negative, routing invariance, and IR round-trip).
- [x] ``uvx ruff check .`` / ``uvx ruff format --check .`` — clean.
- [x] ``uv run pyright`` — clean (project-config'd run).
- [x] Manual review: pre-existing LLM-rubric stub test failures on ``main`` (network-dependent, ``test_llm_rubric_backend.py::TestLlmRubricBackendStub``) are **unchanged** by this slice — they fail the same way before and after.

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)