### PR TITLE
feat(llm-rubric): harden multi-target quote attribution (#225)

### DIFF
--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -178,7 +178,7 @@ context passed to the model:
 
 ### Structured judgment schema (`LlmJudgment`)
 
-The model is instructed (via `RUBRIC_PROMPT_TEMPLATE`, prompt version `PROMPT_VERSION = "v5"`)
+The model is instructed (via `RUBRIC_PROMPT_TEMPLATE`, prompt version `PROMPT_VERSION = "v6"`)
 to respond with a JSON object matching the `LlmJudgment` dataclass:
 
 ```json
@@ -588,6 +588,24 @@ Reference history:
   `tests/fixtures/semantic/entries/multi-target-01-…` but
   `baseline.json` is left at the v4 capture until the slice-2 prompt
   evaluation runs).
+- v6 (#225, slice 2): hardens multi-target quote attribution. The
+  multi-target instruction block now declares the `{target_id, quote}`
+  object form **required** for multi-target rules (slice 1 said it was
+  preferred but tolerated plain-string entries). Backend enforcement is
+  tightened in lockstep: a quote whose `target_id=A` must be a substring
+  of artifact A's text specifically (the concatenated-text grounding
+  used in slice 1 is replaced by per-target grounding); unknown
+  `target_id` values fail closed; missing `target_id` on a multi-target
+  rule fails closed; placeholder text from unreadable artifacts cannot
+  be quoted (the placeholder ID is excluded from the corpus). The
+  single-target path (rules without `params.targets`) is unchanged
+  from v5. v5 and v6 evidence are **not** interchangeable — a v5-era
+  multi-target evidence record showing
+  `supporting_evidence_quote_target_ids=["first_id", ...]` may reflect
+  the lenient slice-1 default attribution, whereas a v6 record only
+  ever shows IDs the model itself emitted (or `null` after the strict
+  fabrication guard). Baseline comparison runs must filter on
+  `prompt_version`.
 
 ### Per-model dispatch accuracy (#175)
 

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -151,18 +151,22 @@ _SUPPORTED_PROVIDERS = ("anthropic", "openai")
 #   downstream consumers can distinguish "rendered without a multi-target
 #   block because the rule did not declare one" from "rendered with the
 #   pre-v5 template that had no multi-target branch at all".
-# - v5 (#225, slice 2): harden multi-target quote attribution. For multi-target
-#   rules the grounding check is now performed **per-artifact**: a quote whose
-#   ``target_id=A`` must be a substring of artifact ``A``'s text, not merely of
-#   the concatenated multi-artifact prompt.  Unknown ``target_id`` values fail
-#   closed (rejected as fabricated rather than remapped to the first target).
-#   Missing ``target_id`` on a multi-target rule also fails closed: the stricter
-#   contract requires every quote to carry a known ``target_id``.  Placeholder
-#   text (``"(no path declared)"`` / ``"(unable to read artifact…)"``) can never
-#   satisfy the substring check because placeholder ids are excluded from the
-#   quotable corpus.  The ``PROMPT_VERSION`` constant is NOT bumped for this
-#   slice — the prompt template is unchanged; only server-side enforcement is
-#   tightened.
+# - v6 (#225, slice 2): harden multi-target quote attribution.  This bumps the
+#   prompt version because the multi-target instruction block changed in a
+#   model-facing way: the ``{target_id, quote}`` object form is now declared
+#   **required** for multi-target rules (slice 1 / v5 said it was preferred
+#   but tolerated plain-string entries).  Backend enforcement is also
+#   tightened in lockstep: a quote whose ``target_id=A`` must be a substring
+#   of artifact ``A``'s text specifically (not the concatenated prompt);
+#   unknown ``target_id`` values fail closed; missing ``target_id`` on a
+#   multi-target rule fails closed; placeholder text from unreadable artifacts
+#   cannot be quoted (the placeholder id is excluded from the corpus).  The
+#   version bump matters for reproducibility because v5 and v6 evidence are
+#   **not** interchangeable: a v5-era multi-target evidence record that shows
+#   ``supporting_evidence_quote_target_ids=["first_id", ...]`` may reflect the
+#   lenient slice-1 default attribution, whereas a v6 record only ever shows
+#   ids the model itself emitted (or ``null`` after the strict fabrication
+#   guard).  Baseline comparison runs must therefore filter on prompt_version.
 #
 # The ``PROMPT_VERSION`` constant is **not** bumped for #191. The rendered
 # template body (schema, instructions, constraints, examples) is unchanged;
@@ -172,7 +176,7 @@ _SUPPORTED_PROVIDERS = ("anthropic", "openai")
 # file *path* (and the substring grounding check follows the same
 # substitution). Reproducibility records keyed on ``prompt_version``
 # continue to mean the same thing.
-PROMPT_VERSION = "v5"
+PROMPT_VERSION = "v6"
 
 # ---------------------------------------------------------------------------
 # Per-model pricing table (#133)

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -151,6 +151,18 @@ _SUPPORTED_PROVIDERS = ("anthropic", "openai")
 #   downstream consumers can distinguish "rendered without a multi-target
 #   block because the rule did not declare one" from "rendered with the
 #   pre-v5 template that had no multi-target branch at all".
+# - v5 (#225, slice 2): harden multi-target quote attribution. For multi-target
+#   rules the grounding check is now performed **per-artifact**: a quote whose
+#   ``target_id=A`` must be a substring of artifact ``A``'s text, not merely of
+#   the concatenated multi-artifact prompt.  Unknown ``target_id`` values fail
+#   closed (rejected as fabricated rather than remapped to the first target).
+#   Missing ``target_id`` on a multi-target rule also fails closed: the stricter
+#   contract requires every quote to carry a known ``target_id``.  Placeholder
+#   text (``"(no path declared)"`` / ``"(unable to read artifact…)"``) can never
+#   satisfy the substring check because placeholder ids are excluded from the
+#   quotable corpus.  The ``PROMPT_VERSION`` constant is NOT bumped for this
+#   slice — the prompt template is unchanged; only server-side enforcement is
+#   tightened.
 #
 # The ``PROMPT_VERSION`` constant is **not** bumped for #191. The rendered
 # template body (schema, instructions, constraints, examples) is unchanged;
@@ -935,9 +947,11 @@ _MULTI_TARGET_INSTRUCTION_BLOCK = """\
 the ``## Target artifacts (multi)`` block above). When you cite supporting \
 evidence, each entry of ``supporting_evidence_quotes`` MUST be an object of \
 the form ``{"target_id": "<id>", "quote": "<near-verbatim substring>"}`` \
-where ``<id>`` matches one of the labelled artifacts above. Plain-string \
-entries are tolerated for backward compatibility but you SHOULD prefer the \
-object form so quote attribution is unambiguous.
+where ``<id>`` matches one of the labelled artifact ids above. The \
+``target_id`` field is **required**: plain-string entries without a \
+``target_id`` are not accepted for multi-target rules. The ``quote`` value \
+must be a near-verbatim substring drawn from the artifact identified by \
+``target_id``; it must not be drawn from a different artifact.
 """
 
 
@@ -1483,17 +1497,16 @@ def _build_artifact_text_for_grounding(
 ) -> str:
     """Return the flat artifact text used for substring grounding (#182).
 
-    For a multi-target rule, concatenates every declared artifact's text
-    (separated by newlines so adjacent artifacts do not run together and
-    create accidental substring matches across artifact boundaries) and
-    returns the result.  A quote drawn from any declared artifact then
-    satisfies the substring check.  This is the slice-1 contract: per-
-    artifact substring attribution (rejecting a quote that claims
-    ``target_id=A`` but only matches artifact ``B``) is deferred to
-    slice 2.
-
     For a single-target rule, returns the legacy
     :func:`_resolve_artifact_text` output byte-for-byte.
+
+    For a multi-target rule, concatenates every declared non-placeholder
+    artifact's text (separated by newlines so adjacent artifacts do not run
+    together and create accidental substring matches across artifact
+    boundaries).  This flat-text form is retained for span resolution and
+    for the ``consensus`` strategy; the primary ``single`` strategy uses
+    :func:`_find_per_target_fabricated_quotes` for strict per-target
+    grounding (slice 2, #225).
     """
     texts_by_id = _resolve_artifact_texts_for_rule(rule, target, artifact_kind)
     if len(texts_by_id) == 1 and _SINGLE_TARGET_SENTINEL_ID in texts_by_id:
@@ -1548,7 +1561,7 @@ def _resolve_quote_target_ids(
 ) -> list[str] | None:
     """Return per-quote target ids for a multi-target rule, or ``None`` (#182).
 
-    Slice-1 contract:
+    Slice-1 lenient contract (preserved for backward compat):
 
     - When the rule does not declare ``params.targets`` (or the list is
       empty), returns ``None`` so the legacy v4 evidence shape is
@@ -1560,9 +1573,13 @@ def _resolve_quote_target_ids(
       used the object form ``{"target_id": "...", "quote": "..."}``) or
       the first declared target's id as the default attribution.  Unknown
       ids (a ``target_id`` not present in ``params.targets``) are also
-      remapped to the first declared target's id — the slice-1 backend
-      does not fail-close on this, but surfaces the attribution so a
-      downstream consumer can inspect the evidence.
+      remapped to the first declared target's id.
+
+    .. note::
+        This is the **lenient** (slice-1) resolver.  For the strict
+        grounding check introduced in slice 2 (#225), use
+        :func:`_resolve_quote_target_ids_strict` which fails closed on
+        unknown or missing ``target_id`` values.
     """
     specs = _parse_multi_targets(rule)
     if not specs:
@@ -1581,6 +1598,56 @@ def _resolve_quote_target_ids(
     return resolved
 
 
+#: Sentinel ``target_id`` used by :func:`_resolve_quote_target_ids_strict`
+#: when the model omitted ``target_id`` or supplied an unknown value on a
+#: multi-target rule.  The sentinel will never appear in ``texts_by_id``
+#: (which is keyed by the rule author's declared ids), so any quote mapped
+#: to it is guaranteed to be rejected as fabricated by
+#: :func:`_find_per_target_fabricated_quotes`.
+_UNKNOWN_TARGET_ID = "__unknown_target__"
+
+
+def _resolve_quote_target_ids_strict(
+    rule: Rule,
+    parsed: "LlmJudgment",
+) -> list[str] | None:
+    """Return per-quote target ids for a multi-target rule with strict validation (#225).
+
+    Slice-2 strict contract:
+
+    - When the rule does not declare ``params.targets`` (or the list is
+      empty), returns ``None`` — identical to the lenient function.
+    - When the rule declares ``params.targets``, returns a list whose
+      length equals ``len(parsed.supporting_evidence_quotes)``.
+
+    Unlike the lenient resolver, unknown or missing ``target_id`` values are
+    **not** remapped to the first declared target.  Instead:
+
+    1. **Unknown ``target_id``** — a value not in ``params.targets`` is
+       replaced by :data:`_UNKNOWN_TARGET_ID`, which is guaranteed to miss
+       the corpus lookup in :func:`_find_per_target_fabricated_quotes`.
+    2. **Missing ``target_id``** — model emitted plain-string form or
+       object form without ``target_id`` — also mapped to
+       :data:`_UNKNOWN_TARGET_ID`, so the quote fails closed rather than
+       defaulting to the first target.
+    """
+    specs = _parse_multi_targets(rule)
+    if not specs:
+        return None
+    known_ids = {spec.id for spec in specs}
+    model_ids = parsed.supporting_evidence_quote_target_ids
+    resolved: list[str] = []
+    for i in range(len(parsed.supporting_evidence_quotes)):
+        candidate: str | None = None
+        if model_ids is not None and i < len(model_ids):
+            candidate = model_ids[i]
+        if candidate is None or candidate not in known_ids:
+            resolved.append(_UNKNOWN_TARGET_ID)
+        else:
+            resolved.append(candidate)
+    return resolved
+
+
 def _find_fabricated_quotes(quotes: list[str], artifact_text: str) -> list[str]:
     """Return quotes from *quotes* that are NOT substrings of *artifact_text*.
 
@@ -1596,6 +1663,51 @@ def _find_fabricated_quotes(quotes: list[str], artifact_text: str) -> list[str]:
             fabricated.append(quote if isinstance(quote, str) else "")
             continue
         if _normalise_for_substring(quote) not in normalised_artifact:
+            fabricated.append(quote)
+    return fabricated
+
+
+def _find_per_target_fabricated_quotes(
+    quotes: list[str],
+    resolved_target_ids: list[str],
+    texts_by_id: dict[str, str],
+) -> list[str]:
+    """Return quotes that fail the strict per-target grounding check (#225).
+
+    For each quote, the corresponding ``resolved_target_ids[i]`` entry
+    determines which artifact's text is the grounding corpus.
+
+    A quote is considered fabricated (and returned in the result list) when
+    any of the following hold:
+
+    - The quote is empty / not a string (degenerate case).
+    - The resolved ``target_id`` is not present as a key in ``texts_by_id``
+      (i.e., the target was unreadable / a placeholder — excluded from the
+      corpus by :func:`_resolve_artifact_texts_for_rule`, or the sentinel
+      :data:`_UNKNOWN_TARGET_ID` was assigned because the model omitted or
+      supplied an unknown ``target_id``).
+    - The quote is not a normalised substring of the specific artifact
+      identified by ``target_id``.
+
+    The third condition enforces the slice-2 contract: a quote claiming
+    ``target_id=A`` must be found **within artifact A**, not merely anywhere
+    in the concatenated multi-artifact prompt.  This closes the gap left by
+    the slice-1 implementation which accepted cross-artifact substring matches.
+
+    *quotes* and *resolved_target_ids* must have the same length (both
+    derived from the same ``LlmJudgment.supporting_evidence_quotes``).
+    """
+    fabricated: list[str] = []
+    for quote, tid in zip(quotes, resolved_target_ids):
+        if not isinstance(quote, str) or not quote.strip():
+            fabricated.append(quote if isinstance(quote, str) else "")
+            continue
+        if tid not in texts_by_id:
+            # Target is a placeholder, unknown, or the sentinel → un-quotable.
+            fabricated.append(quote)
+            continue
+        artifact_text = texts_by_id[tid]
+        if _normalise_for_substring(quote) not in _normalise_for_substring(artifact_text):
             fabricated.append(quote)
     return fabricated
 
@@ -2137,13 +2249,30 @@ def _run_single_strategy(request: JudgmentRequest) -> Diagnostic:
     # ``_resolve_artifact_text`` returns the file content (mirroring what
     # ``_build_prompt`` injected). Quotes are validated against what the
     # model actually saw.
-    # #182 — multi-target rules concatenate every declared artifact's text
-    # for the substring-grounding check so a quote drawn from any
-    # declared artifact is accepted; per-artifact substring attribution
-    # (rejecting a quote that claims ``target_id=A`` but only matches
-    # artifact ``B``) is deferred to slice 2.
-    artifact_text = _build_artifact_text_for_grounding(rule, target, artifact_kind)
-    fabricated = _find_fabricated_quotes(parsed.supporting_evidence_quotes, artifact_text)
+    # #225 (slice 2) — multi-target rules now perform strict per-target
+    # grounding: a quote claiming ``target_id=A`` must be a substring of
+    # artifact A's text specifically, not merely of the concatenated prompt.
+    # Unknown or missing ``target_id`` values fail closed. The single-target
+    # path is unchanged.
+    multi_targets = _parse_multi_targets(rule)
+    if multi_targets:
+        # Strict per-target grounding path for multi-target rules.
+        texts_by_id = _resolve_artifact_texts_for_rule(rule, target, artifact_kind)
+        strict_target_ids = _resolve_quote_target_ids_strict(rule, parsed)
+        assert strict_target_ids is not None  # non-empty multi_targets guarantees this
+        fabricated = _find_per_target_fabricated_quotes(
+            parsed.supporting_evidence_quotes,
+            strict_target_ids,
+            texts_by_id,
+        )
+        # Flat text for span resolution (best-effort; per-artifact span
+        # attribution is deferred to a future slice).
+        artifact_text = _build_artifact_text_for_grounding(rule, target, artifact_kind)
+    else:
+        # Single-target legacy path: flat substring check unchanged.
+        artifact_text = _build_artifact_text_for_grounding(rule, target, artifact_kind)
+        fabricated = _find_fabricated_quotes(parsed.supporting_evidence_quotes, artifact_text)
+        strict_target_ids = None
     if fabricated:
         return Diagnostic(
             rule_id=rule.id,
@@ -2205,15 +2334,15 @@ def _run_single_strategy(request: JudgmentRequest) -> Diagnostic:
         "cost_estimate_usd": cost,
         **strategy_meta,
     }
-    # #182 — when the rule declared ``params.targets``, surface a parallel
-    # ``supporting_evidence_quote_target_ids`` list on the evidence dict so
-    # downstream consumers can attribute each quote to a specific artifact.
-    # Missing per-quote ``target_id`` (model emitted plain strings or
-    # omitted the field) is defaulted to the first declared target's id
-    # per the slice-1 contract.
-    resolved_target_ids = _resolve_quote_target_ids(rule, parsed)
-    if resolved_target_ids is not None:
-        evidence_data["supporting_evidence_quote_target_ids"] = resolved_target_ids
+    # #225 — when the rule declared ``params.targets``, surface the strict
+    # resolved ``target_id`` list. Sentinels (_UNKNOWN_TARGET_ID) cannot
+    # appear here because their quotes were already rejected above; replace
+    # defensively with None for a clean wire format.
+    if strict_target_ids is not None:
+        clean_ids: list[str | None] = [
+            None if tid == _UNKNOWN_TARGET_ID else tid for tid in strict_target_ids
+        ]
+        evidence_data["supporting_evidence_quote_target_ids"] = clean_ids
     evidence = Evidence(kind="llm_judgment", data=evidence_data)
     if status is Status.PASS:
         return Diagnostic(

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -1906,7 +1906,11 @@ class TestPromptVersion:
         # #182 bumped v4 → v5 to introduce the multi-target rendering
         # branch (``## Target artifacts (multi)``). Single-target rules
         # render byte-identical text to v4; only the constant changes.
-        assert llm_backend.PROMPT_VERSION == "v5"
+        # #225 bumped v5 → v6 because the multi-target instruction block
+        # now declares the {target_id, quote} object form **required**
+        # (slice 1 said preferred) and backend enforcement is tightened
+        # in lockstep — v5 and v6 evidence are not interchangeable.
+        assert llm_backend.PROMPT_VERSION == "v6"
 
     def test_evidence_includes_prompt_version(self, monkeypatch, tmp_path):
         _patch_env(
@@ -1919,8 +1923,8 @@ class TestPromptVersion:
             lambda *_a, **_k: _stub_response(_VALID_PASS_JSON),
         )
         diag = llm_backend.check(_semantic_rule(), _target_with_artifact(tmp_path))
-        # #182 — PROMPT_VERSION is now v5.
-        assert diag.evidence[0].data["prompt_version"] == "v5"
+        # #225 — PROMPT_VERSION is now v6.
+        assert diag.evidence[0].data["prompt_version"] == "v6"
 
 
 # ---------------------------------------------------------------------------
@@ -2336,8 +2340,8 @@ class TestUnsupportedDispatch:
         assert diag.evidence[0].kind == "target_kind_mismatch"
         assert diag.evidence[0].data["judgment"] == "unsupported"
         assert diag.evidence[0].data["rule_target_kind"] == "pr_description"
-        # #182 — PROMPT_VERSION is now v5.
-        assert diag.evidence[0].data["prompt_version"] == "v5"
+        # #225 — PROMPT_VERSION is now v6.
+        assert diag.evidence[0].data["prompt_version"] == "v6"
 
     def test_unsupported_remediation_explains_mismatch(self, monkeypatch):
         from gate_keeper.models import TargetKind
@@ -4042,8 +4046,8 @@ class TestMultiTargetPromptRendering:
         with pytest.raises(ValueError, match=r"path traversal"):
             llm_backend._parse_multi_targets(rule)
 
-    def test_prompt_version_constant_is_v5(self):
-        assert llm_backend.PROMPT_VERSION == "v5"
+    def test_prompt_version_constant_is_v6(self):
+        assert llm_backend.PROMPT_VERSION == "v6"
 
 
 class TestMultiTargetQuoteParsing:

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -4192,16 +4192,21 @@ class TestMultiTargetEvidenceTargetIds:
         data = diag.evidence[0].data
         assert data["supporting_evidence_quote_target_ids"] == ["src", "dep"]
 
-    def test_multi_target_evidence_defaults_missing_target_id_to_first(self, monkeypatch, tmp_path):
-        """Quotes whose ``target_id`` is missing default to the first target's id."""
+    def test_multi_target_evidence_missing_target_id_fails_closed(self, monkeypatch, tmp_path):
+        """#225 (slice 2): missing ``target_id`` on a multi-target rule fails closed.
+
+        Slice-1 defaulted missing ``target_id`` to the first declared target's id.
+        Slice-2 tightens this: a quote without a ``target_id`` is rejected as
+        fabricated (cannot be attributed to any specific artifact).
+        """
         _patch_env(monkeypatch, self._ENV)
         target_a = tmp_path / "primary.md"
         target_a.write_text("alpha quote substring here.", encoding="utf-8")
         target_b = tmp_path / "other.md"
         target_b.write_text("beta quote substring here.", encoding="utf-8")
-        # Model emits the legacy string-list form; the rule still declares
-        # ``params.targets`` so the parser must default each quote's
-        # ``target_id`` to the first declared target's id.
+        # Model emits the legacy string-list form on a multi-target rule.
+        # The strict contract requires a known target_id, so the quote is
+        # rejected as un-attributed → verdict becomes UNSUPPORTED.
         response = json.dumps(
             {
                 "judgment": "pass",
@@ -4218,13 +4223,16 @@ class TestMultiTargetEvidenceTargetIds:
             ]
         )
         diag = llm_backend.check(rule, "ignored")
-        assert diag.status is Status.PASS, diag.evidence[0].to_dict()
-        data = diag.evidence[0].data
-        # Default attribution → first declared target's id.
-        assert data["supporting_evidence_quote_target_ids"] == ["primary"]
+        # Strict grounding: quote without target_id is rejected as fabricated.
+        assert diag.status is Status.UNSUPPORTED, diag.evidence[0].to_dict()
+        assert diag.evidence[0].kind == "llm_quote_fabrication"
 
-    def test_multi_target_evidence_unknown_target_id_remapped_to_first(self, monkeypatch, tmp_path):
-        """A model-emitted ``target_id`` not in ``params.targets`` is remapped to first."""
+    def test_multi_target_evidence_unknown_target_id_fails_closed(self, monkeypatch, tmp_path):
+        """#225 (slice 2): unknown ``target_id`` fails closed instead of remapping to first.
+
+        Slice-1 silently remapped an unknown id to the first declared target's id.
+        Slice-2 rejects the quote as fabricated because the target is unknown.
+        """
         _patch_env(monkeypatch, self._ENV)
         target_a = tmp_path / "src.md"
         target_a.write_text("alpha quote substring here.", encoding="utf-8")
@@ -4248,6 +4256,318 @@ class TestMultiTargetEvidenceTargetIds:
             ]
         )
         diag = llm_backend.check(rule, "ignored")
-        assert diag.status is Status.PASS
-        # Unknown id remaps to the first declared target's id.
-        assert diag.evidence[0].data["supporting_evidence_quote_target_ids"] == ["src"]
+        # Strict grounding: unknown target_id is rejected as fabricated.
+        assert diag.status is Status.UNSUPPORTED, diag.evidence[0].to_dict()
+        assert diag.evidence[0].kind == "llm_quote_fabrication"
+
+
+# ---------------------------------------------------------------------------
+# Strict per-target quote grounding (#225, slice 2)
+# ---------------------------------------------------------------------------
+
+
+class TestStrictPerTargetGrounding:
+    """#225 — per-artifact substring attribution for multi-target rules.
+
+    The slice-2 contract:
+    - A quote claiming ``target_id=A`` must be a substring of artifact A's
+      text specifically (not merely of the concatenated multi-artifact prompt).
+    - Unknown ``target_id`` values fail closed (quote rejected as fabricated).
+    - Missing ``target_id`` on a multi-target rule fails closed.
+    - Placeholder text ("(no path declared)", "(unable to read…)") can never
+      satisfy the substring check.
+    """
+
+    _ENV = {"GATE_KEEPER_LLM_PROVIDER": "openai", "OPENAI_API_KEY": "sk-test"}
+
+    def test_quote_grounded_in_correct_artifact_passes(self, monkeypatch, tmp_path):
+        """A quote attributed to the correct artifact passes validation."""
+        _patch_env(monkeypatch, self._ENV)
+        target_a = tmp_path / "a.md"
+        target_a.write_text("unique phrase from alpha artifact.", encoding="utf-8")
+        target_b = tmp_path / "b.md"
+        target_b.write_text("unique phrase from beta artifact.", encoding="utf-8")
+        response = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "Both artifacts agree.",
+                "supporting_evidence_quotes": [
+                    {"target_id": "alpha", "quote": "unique phrase from alpha artifact"},
+                    {"target_id": "beta", "quote": "unique phrase from beta artifact"},
+                ],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(llm_backend, "_call_openai", lambda *a, **k: _stub_response(response))
+        rule = _multi_target_rule(
+            [
+                {"id": "alpha", "kind": "documentation", "path": str(target_a)},
+                {"id": "beta", "kind": "documentation", "path": str(target_b)},
+            ]
+        )
+        diag = llm_backend.check(rule, "ignored")
+        assert diag.status is Status.PASS, diag.evidence[0].to_dict()
+        data = diag.evidence[0].data
+        assert data["supporting_evidence_quote_target_ids"] == ["alpha", "beta"]
+
+    def test_cross_artifact_quote_rejected(self, monkeypatch, tmp_path):
+        """A quote attributed to artifact A but only present in artifact B is rejected.
+
+        Slice-1 would accept this because it concatenated all artifact texts.
+        Slice-2 must reject it because the quote is not in A's text.
+        """
+        _patch_env(monkeypatch, self._ENV)
+        target_a = tmp_path / "a.md"
+        target_a.write_text("content only in artifact alpha.", encoding="utf-8")
+        target_b = tmp_path / "b.md"
+        target_b.write_text("content only in artifact beta.", encoding="utf-8")
+        # Model quotes from beta but claims target_id="alpha".
+        response = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "OK.",
+                "supporting_evidence_quotes": [
+                    {"target_id": "alpha", "quote": "content only in artifact beta"},
+                ],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(llm_backend, "_call_openai", lambda *a, **k: _stub_response(response))
+        rule = _multi_target_rule(
+            [
+                {"id": "alpha", "kind": "documentation", "path": str(target_a)},
+                {"id": "beta", "kind": "documentation", "path": str(target_b)},
+            ]
+        )
+        diag = llm_backend.check(rule, "ignored")
+        # Quote not in alpha's text → fabrication (even though it's in beta's).
+        assert diag.status is Status.UNSUPPORTED, diag.evidence[0].to_dict()
+        assert diag.evidence[0].kind == "llm_quote_fabrication"
+        assert "content only in artifact beta" in diag.evidence[0].data["fabricated_quotes"]
+
+    def test_placeholder_quote_rejected(self, monkeypatch, tmp_path):
+        """A quote drawn from a placeholder artifact is rejected.
+
+        Artifacts whose paths cannot be read produce placeholder text like
+        "(unable to read artifact at …)".  The placeholder id is excluded from
+        the quotable corpus; any quote attributed to it is fabricated.
+        """
+        _patch_env(monkeypatch, self._ENV)
+        missing_path = str(tmp_path / "does_not_exist.md")
+        target_b = tmp_path / "b.md"
+        target_b.write_text("real content from beta.", encoding="utf-8")
+        # Model quotes the placeholder text itself.
+        placeholder_text = f"(unable to read artifact at {missing_path})"
+        response = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "OK.",
+                "supporting_evidence_quotes": [
+                    {"target_id": "ghost", "quote": placeholder_text},
+                ],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(llm_backend, "_call_openai", lambda *a, **k: _stub_response(response))
+        rule = _multi_target_rule(
+            [
+                {"id": "ghost", "kind": "documentation", "path": missing_path},
+                {"id": "real", "kind": "documentation", "path": str(target_b)},
+            ]
+        )
+        diag = llm_backend.check(rule, "ignored")
+        # ghost is a placeholder → excluded from corpus → quote fabricated.
+        assert diag.status is Status.UNSUPPORTED, diag.evidence[0].to_dict()
+        assert diag.evidence[0].kind == "llm_quote_fabrication"
+
+    def test_no_path_placeholder_quote_rejected(self, monkeypatch, tmp_path):
+        """A quote attributed to a no-path target is rejected.
+
+        When a target spec has no ``path`` declared, the artifact text is
+        ``"(no path declared)"``.  Any quote attributed to that target must
+        be rejected as fabricated.
+        """
+        _patch_env(monkeypatch, self._ENV)
+        target_b = tmp_path / "b.md"
+        target_b.write_text("actual content of beta.", encoding="utf-8")
+        response = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "OK.",
+                "supporting_evidence_quotes": [
+                    {"target_id": "pathless", "quote": "(no path declared)"},
+                ],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(llm_backend, "_call_openai", lambda *a, **k: _stub_response(response))
+        # "pathless" has no path → placeholder text in prompt; excluded from corpus.
+        rule = _multi_target_rule(
+            [
+                {"id": "pathless", "kind": "documentation"},
+                {"id": "real", "kind": "documentation", "path": str(target_b)},
+            ]
+        )
+        diag = llm_backend.check(rule, "ignored")
+        assert diag.status is Status.UNSUPPORTED, diag.evidence[0].to_dict()
+        assert diag.evidence[0].kind == "llm_quote_fabrication"
+
+    def test_mixed_valid_and_invalid_quotes_rejected(self, monkeypatch, tmp_path):
+        """When any quote fails per-target grounding, the whole verdict is rejected."""
+        _patch_env(monkeypatch, self._ENV)
+        target_a = tmp_path / "a.md"
+        target_a.write_text("alpha text here.", encoding="utf-8")
+        target_b = tmp_path / "b.md"
+        target_b.write_text("beta text here.", encoding="utf-8")
+        response = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "OK.",
+                "supporting_evidence_quotes": [
+                    {"target_id": "alpha", "quote": "alpha text here"},  # valid
+                    # invalid: beta content claimed as alpha
+                    {"target_id": "alpha", "quote": "beta text here"},
+                ],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(llm_backend, "_call_openai", lambda *a, **k: _stub_response(response))
+        rule = _multi_target_rule(
+            [
+                {"id": "alpha", "kind": "documentation", "path": str(target_a)},
+                {"id": "beta", "kind": "documentation", "path": str(target_b)},
+            ]
+        )
+        diag = llm_backend.check(rule, "ignored")
+        assert diag.status is Status.UNSUPPORTED
+        assert diag.evidence[0].kind == "llm_quote_fabrication"
+        assert diag.evidence[0].data["fabricated_quotes"] == ["beta text here"]
+
+
+class TestResolveQuoteTargetIdsStrict:
+    """Unit tests for :func:`_resolve_quote_target_ids_strict` (#225)."""
+
+    def test_single_target_rule_returns_none(self):
+        """The strict resolver mirrors the lenient one for single-target rules."""
+        rule = _semantic_rule()  # no params.targets
+        # Simulate a parsed judgment with one plain-string quote.
+        parsed = LlmJudgment(
+            judgment="pass",
+            primary_reason="ok",
+            supporting_evidence_quotes=["some quote"],
+            suggested_action=None,
+            supporting_evidence_quote_target_ids=None,
+        )
+        result = llm_backend._resolve_quote_target_ids_strict(rule, parsed)
+        assert result is None
+
+    def test_known_target_id_preserved(self):
+        """A known target_id is passed through unchanged."""
+        rule = _multi_target_rule(
+            [
+                {"id": "src", "kind": "documentation", "path": "a.md"},
+                {"id": "dep", "kind": "documentation", "path": "b.md"},
+            ]
+        )
+        parsed = LlmJudgment(
+            judgment="pass",
+            primary_reason="ok",
+            supporting_evidence_quotes=["q1", "q2"],
+            suggested_action=None,
+            supporting_evidence_quote_target_ids=["src", "dep"],
+        )
+        result = llm_backend._resolve_quote_target_ids_strict(rule, parsed)
+        assert result == ["src", "dep"]
+
+    def test_unknown_target_id_becomes_sentinel(self):
+        """An unknown target_id is replaced by _UNKNOWN_TARGET_ID sentinel."""
+        rule = _multi_target_rule([{"id": "src", "kind": "documentation", "path": "a.md"}])
+        parsed = LlmJudgment(
+            judgment="pass",
+            primary_reason="ok",
+            supporting_evidence_quotes=["q"],
+            suggested_action=None,
+            supporting_evidence_quote_target_ids=["not_a_real_id"],
+        )
+        result = llm_backend._resolve_quote_target_ids_strict(rule, parsed)
+        assert result == [llm_backend._UNKNOWN_TARGET_ID]
+
+    def test_missing_target_id_becomes_sentinel(self):
+        """A missing target_id (None in the parallel list) becomes the sentinel."""
+        rule = _multi_target_rule([{"id": "src", "kind": "documentation", "path": "a.md"}])
+        parsed = LlmJudgment(
+            judgment="pass",
+            primary_reason="ok",
+            supporting_evidence_quotes=["q"],
+            suggested_action=None,
+            supporting_evidence_quote_target_ids=[None],
+        )
+        result = llm_backend._resolve_quote_target_ids_strict(rule, parsed)
+        assert result == [llm_backend._UNKNOWN_TARGET_ID]
+
+    def test_plain_string_form_becomes_sentinel(self):
+        """Legacy plain-string quotes (no object form) become the sentinel."""
+        rule = _multi_target_rule([{"id": "src", "kind": "documentation", "path": "a.md"}])
+        # supporting_evidence_quote_target_ids is None when all quotes were
+        # plain strings (no object form seen by parser).
+        parsed = LlmJudgment(
+            judgment="pass",
+            primary_reason="ok",
+            supporting_evidence_quotes=["plain string quote"],
+            suggested_action=None,
+            supporting_evidence_quote_target_ids=None,
+        )
+        result = llm_backend._resolve_quote_target_ids_strict(rule, parsed)
+        assert result == [llm_backend._UNKNOWN_TARGET_ID]
+
+
+class TestFindPerTargetFabricatedQuotes:
+    """Unit tests for :func:`_find_per_target_fabricated_quotes` (#225)."""
+
+    def test_valid_quotes_return_empty(self):
+        """Quotes that are substrings of their attributed artifact pass."""
+        quotes = ["alpha phrase", "beta phrase"]
+        target_ids = ["a", "b"]
+        texts = {"a": "some alpha phrase here", "b": "some beta phrase here"}
+        result = llm_backend._find_per_target_fabricated_quotes(quotes, target_ids, texts)
+        assert result == []
+
+    def test_cross_artifact_quote_detected(self):
+        """A quote present in B but claimed to be from A is fabricated."""
+        quotes = ["beta only content"]
+        target_ids = ["a"]
+        texts = {"a": "alpha only content", "b": "beta only content"}
+        result = llm_backend._find_per_target_fabricated_quotes(quotes, target_ids, texts)
+        assert result == ["beta only content"]
+
+    def test_unknown_target_id_fabricated(self):
+        """A sentinel or unknown target_id (not in texts) is fabricated."""
+        quotes = ["some quote"]
+        target_ids = [llm_backend._UNKNOWN_TARGET_ID]
+        texts = {"known": "some quote here"}
+        result = llm_backend._find_per_target_fabricated_quotes(quotes, target_ids, texts)
+        assert result == ["some quote"]
+
+    def test_empty_quote_fabricated(self):
+        """An empty quote string is fabricated regardless of target_id."""
+        quotes = [""]
+        target_ids = ["a"]
+        texts = {"a": "some content"}
+        result = llm_backend._find_per_target_fabricated_quotes(quotes, target_ids, texts)
+        assert result == [""]
+
+    def test_placeholder_excluded_from_corpus(self):
+        """A target_id absent from texts_by_id (placeholder) causes fabrication."""
+        quotes = ["any text"]
+        target_ids = ["ghost"]
+        texts = {}  # ghost was a placeholder, excluded from corpus
+        result = llm_backend._find_per_target_fabricated_quotes(quotes, target_ids, texts)
+        assert result == ["any text"]
+
+    def test_smart_quote_normalisation_tolerated(self):
+        """Smart-quote differences between quote and artifact are tolerated."""
+        quotes = ["don’t"]  # RIGHT SINGLE QUOTATION MARK
+        target_ids = ["a"]
+        texts = {"a": "please don't do this"}  # ASCII apostrophe
+        result = llm_backend._find_per_target_fabricated_quotes(quotes, target_ids, texts)
+        assert result == []


### PR DESCRIPTION
## Summary

Closes #225. Slice-2 follow-up to PR #224 (multi-target context assembly).

- **Strict per-target quote grounding**: a quote claiming `target_id=A` must now be a substring of artifact A's text specifically. The slice-1 implementation accepted any quote present in the concatenated multi-artifact prompt, allowing cross-artifact attribution to pass silently.
- **Fail-closed on unknown/missing `target_id`**: unknown ids and missing `target_id` (plain-string form on a multi-target rule) now map to an internal sentinel that is guaranteed to miss the corpus lookup, producing `llm_quote_fabrication` evidence rather than silently defaulting to the first declared target.
- **Placeholder text hardening**: placeholder ids (`"(no path declared)"`, `"(unable to read artifact at …)"`) are excluded from the quotable corpus by `_resolve_artifact_texts_for_rule`; any quote attributed to a placeholder target fails the per-target check.
- **Prompt instruction tightened**: `_MULTI_TARGET_INSTRUCTION_BLOCK` now states the `{target_id, quote}` object form is **required** (not merely preferred) for multi-target rules.

## Implementation details

New functions:
- `_find_per_target_fabricated_quotes(quotes, resolved_target_ids, texts_by_id)` — per-artifact grounding check
- `_resolve_quote_target_ids_strict(rule, parsed)` — fail-closed resolver mapping unknown/missing ids to `_UNKNOWN_TARGET_ID` sentinel
- `_UNKNOWN_TARGET_ID = "__unknown_target__"` — sentinel that always misses the corpus dict

`_run_single_strategy` updated to branch on `_parse_multi_targets(rule)`: multi-target rules use the strict path, single-target rules use the existing flat `_find_fabricated_quotes` path unchanged.

Two slice-1 tests updated to reflect the new fail-closed semantics:
- `test_multi_target_evidence_defaults_missing_target_id_to_first` → `test_multi_target_evidence_missing_target_id_fails_closed`
- `test_multi_target_evidence_unknown_target_id_remapped_to_first` → `test_multi_target_evidence_unknown_target_id_fails_closed`

16 new tests added covering:
- `TestStrictPerTargetGrounding`: end-to-end via `check()` — valid attribution, cross-artifact rejection, placeholder rejection, no-path rejection, mixed valid/invalid
- `TestResolveQuoteTargetIdsStrict`: unit tests for the strict resolver
- `TestFindPerTargetFabricatedQuotes`: unit tests for the per-target fabrication check

## Validation

```
uv run pytest tests/test_llm_rubric_backend.py  # 270 passed, 6 pre-existing failures
uv run pytest tests/  # 1326 passed, 8 pre-existing failures
uvx ruff check .  # All checks passed
uvx ruff format --check .  # 71 files already formatted
uvx pyright src/gate_keeper/backends/llm_rubric.py  # 4 pre-existing reportMissingImports only
```

## Baseline note (owner action required)

The `multi-target-01-doc-doc-consistency` fixture now surfaces a regression: the model (gpt-4o-mini) emits plain-string quotes without `target_id` on multi-target rules, which the new strict contract correctly rejects as `llm_quote_fabrication`. This reveals a model-compliance gap — the model is not following the prompt instruction to use the `{target_id, quote}` object form.

The baseline is NOT updated in this PR. Once the model-compliance gap is addressed (or the fixture is updated to reflect the actual observed behavior), the owner should run:

```bash
uv run gate-keeper bench tests/fixtures/semantic/entries/ \
  --baseline tests/fixtures/semantic/baseline.json
```

and commit the result in a follow-up.

## Out of scope (deferred)

- Manifest integration (#159), CLI multi-target flags, per-target span resolution
- `consensus` and `review` strategies: still use `_resolve_artifact_text` (single-target only); multi-target support deferred