### PR TITLE
feat(testing): make llm-rubric tests hermetic by default

### DIFF
--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -398,6 +398,60 @@ verdict is rejected as ungrounded).  Failure modes recorded in
 
 There is no retry. Investigate the failure mode, then rerun.
 
+## Contributor testing: hermetic vs live-provider tests
+
+### Default behaviour
+
+`uv run pytest` is **always hermetic**.  A pytest autouse fixture in
+`tests/conftest.py` monkeypatches `_load_env_file` to return `{}` for every
+ordinary test, so no host credential file (e.g.
+`/home/vscode/.config/hermes-projects/gate-keeper.env`) is ever read.
+
+Tests that expect `provider_unconfigured` behaviour are therefore stable both
+in CI (which has no dotenv) and on a developer machine that has a real provider
+configured.
+
+### Live-provider tests
+
+Tests that exercise a real LLM provider must be decorated with
+`@pytest.mark.live_llm`.  They are skipped automatically unless **both**
+conditions are met at collection time:
+
+1. `GATE_KEEPER_RUN_LIVE_LLM_TESTS=1` is set in the environment.
+2. The project dotenv file contains a supported provider and the corresponding
+   API key (same check as `_is_configured()`).
+
+Run them explicitly:
+
+```sh
+GATE_KEEPER_RUN_LIVE_LLM_TESTS=1 uv run pytest -m live_llm
+```
+
+### Adding a new test that needs the real dotenv
+
+Mark it `@pytest.mark.live_llm` and add a skip guard inside the test body if
+it requires keys beyond what `_is_configured()` checks:
+
+```python
+import pytest
+
+@pytest.mark.live_llm
+def test_real_provider_smoke():
+    ...
+```
+
+The conftest autouse fixture detects the marker and skips patching, so the
+real `_load_env_file` runs and the test sees the actual dotenv contents.
+
+### Do not monkeypatch `_load_env_file` in ordinary tests
+
+Before this isolation was centralised, individual tests called
+`monkeypatch.setattr(llm_backend, "_load_env_file", lambda *a, **k: {...})`.
+That pattern still works (the central fixture is applied first; a second
+`monkeypatch.setattr` on the same attribute overrides it within that test), but
+new tests should rely on the autouse stub and only patch when they need a
+specific non-empty env dict.
+
 ## Extending to additional providers
 
 Currently `anthropic` and `openai` are wired. To add another provider:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ extraPaths = ["scripts"]
 [tool.pytest.ini_options]
 markers = [
     "integration: tests that require local tooling (e.g. npx, textlint); skipped automatically when those binaries are missing",
+    "live_llm: live-provider integration test; skipped unless GATE_KEEPER_RUN_LIVE_LLM_TESTS=1 and provider dotenv is configured",
+    "dotenv_loader: tests that directly exercise the _load_env_file implementation; bypasses the hermetic dotenv stub",
 ]
 
 [build-system]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,94 @@
+"""Root conftest for gate-keeper's test suite.
+
+Hermetic LLM isolation
+----------------------
+By default every test runs with the llm_rubric dotenv loader stubbed out so
+that a developer's local credential file (``DOTENV_PATH``) is never read.
+This makes ``uv run pytest`` deterministic regardless of host configuration.
+
+Tests that intentionally exercise a real LLM provider must be decorated with
+``@pytest.mark.live_llm``.  They are skipped automatically unless both
+conditions are met:
+
+1. The environment variable ``GATE_KEEPER_RUN_LIVE_LLM_TESTS=1`` is set.
+2. The required provider keys are present in the project dotenv file.
+
+Run live tests explicitly::
+
+    GATE_KEEPER_RUN_LIVE_LLM_TESTS=1 uv run pytest -m live_llm
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from gate_keeper.backends import llm_rubric as _llm_backend
+
+# ---------------------------------------------------------------------------
+# Hermetic dotenv fixture (autouse — applies to every non-live_llm test)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def disable_llm_dotenv(request, monkeypatch):
+    """Stub the llm_rubric dotenv loader to return {} by default.
+
+    Tests marked ``live_llm`` or ``dotenv_loader`` skip this fixture so they
+    get the real ``_load_env_file`` implementation.  Any other test has the
+    function patched to return an empty dict, ensuring no host credential file
+    can bleed into the test run.
+    """
+    if request.node.get_closest_marker("live_llm"):
+        # Live tests: do not patch — let the real loader run.
+        return
+    if request.node.get_closest_marker("dotenv_loader"):
+        # Tests that exercise the loader implementation itself: do not patch.
+        return
+    monkeypatch.setattr(_llm_backend, "_load_env_file", lambda *a, **kw: {})
+
+
+# ---------------------------------------------------------------------------
+# live_llm marker: skip unless opt-in flag + dotenv keys are present
+# ---------------------------------------------------------------------------
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "live_llm: mark test as a live-provider integration test; "
+        "skipped unless GATE_KEEPER_RUN_LIVE_LLM_TESTS=1 and required dotenv keys are present",
+    )
+    config.addinivalue_line(
+        "markers",
+        "dotenv_loader: mark test as directly exercising the _load_env_file implementation; "
+        "bypasses the default hermetic dotenv stub",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip live_llm tests unless the opt-in flag is set and credentials exist."""
+    run_live = os.environ.get("GATE_KEEPER_RUN_LIVE_LLM_TESTS", "").strip() == "1"
+
+    if not run_live:
+        skip_no_flag = pytest.mark.skip(
+            reason="live LLM tests disabled; set GATE_KEEPER_RUN_LIVE_LLM_TESTS=1 and run with -m live_llm"
+        )
+        for item in items:
+            if item.get_closest_marker("live_llm"):
+                item.add_marker(skip_no_flag)
+        return
+
+    # Flag is set — still skip if required dotenv keys are absent.
+    env = _llm_backend._load_env_file()
+    if not _llm_backend._is_configured(env):
+        skip_no_creds = pytest.mark.skip(
+            reason=(
+                "live LLM tests skipped: GATE_KEEPER_RUN_LIVE_LLM_TESTS=1 "
+                "but provider not configured in dotenv"
+            )
+        )
+        for item in items:
+            if item.get_closest_marker("live_llm"):
+                item.add_marker(skip_no_creds)

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -195,6 +195,7 @@ class TestLlmRubricBackendStub:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.dotenv_loader
 class TestDotenvLoader:
     def test_returns_empty_when_file_absent(self, tmp_path):
         missing = tmp_path / "no-such.env"


### PR DESCRIPTION
## Summary

Closes #180

- Adds `tests/conftest.py` with an autouse fixture `disable_llm_dotenv` that stubs `_load_env_file` to return `{}` for all ordinary tests. `uv run pytest` is now deterministic regardless of local dotenv configuration.
- Registers `live_llm` marker for opt-in live-provider integration tests. Live tests are skipped unless `GATE_KEEPER_RUN_LIVE_LLM_TESTS=1` is set **and** provider credentials are present in the dotenv.
- Registers `dotenv_loader` marker for tests that directly exercise `_load_env_file` itself (`TestDotenvLoader`), bypassing the hermetic stub. Applied to the existing `TestDotenvLoader` class.
- Adds `live_llm`, `dotenv_loader` entries to `pyproject.toml` `[tool.pytest.ini_options]` markers list.
- Documents the hermetic vs live-provider split in `docs/llm-rubric.md` under a new "Contributor testing" section.

## Migration notes for existing tests

All existing ad-hoc `monkeypatch.setattr(llm_backend, "_load_env_file", ...)` calls continue to work — the central autouse stub is applied first and a second `monkeypatch.setattr` within a test overrides it for that test's scope. No existing test was rewritten beyond adding `@pytest.mark.dotenv_loader` to `TestDotenvLoader`.

## Validation

```
uv run pytest -q
# 1358 passed in 5.62s

uvx ruff check .
# All checks passed!
```

Live tests run:

```sh
GATE_KEEPER_RUN_LIVE_LLM_TESTS=1 uv run pytest -m live_llm
# (no live_llm-marked tests exist yet; collection succeeds, 0 selected)
```