### PR TITLE
feat(github): add changed_file_policy rule kind for real-data intake repos (#230)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -18,7 +18,7 @@ Subcommands: [`compile`](#compile), [`explain`](#explain),
 |------|----------|---------|
 | `0`  | `EXIT_OK`   | All rules passed (or `bench` ran without a usage error). |
 | `1`  | `EXIT_FAIL` | One or more rules produced a non-passing status (`fail`, `unavailable`, `unsupported`, or `error`). |
-| `2`  | `EXIT_USAGE` | Bad arguments, unreadable input file, an unmatched `--include` glob, or a duplicate rule id across composed documents. |
+| `2`  | `EXIT_USAGE` | Bad arguments, unreadable input file, an unmatched `--include` glob, or a duplicate rule ID across composed documents. |
 
 Defined in `src/gate_keeper/diagnostics.py`.
 
@@ -64,11 +64,11 @@ globs — not both.
   point back to the originating document.
 - If any `--include` glob matches no files, the command exits `2` and prints
   the unmatched pattern.
-- Rule ids must be unique across the composed RuleSet. If two documents
-  produce the same rule id (the default scheme is `rule-<stem>-L<line>`,
+- Rule IDs must be unique across the composed RuleSet. If two documents
+  produce the same rule ID (the default scheme is `rule-<stem>-L<line>`,
   so two files with the same stem and a rule on the same line collide),
   the command exits `2` and reports both source path/line locations. Rule
-  ids are never silently renamed.
+  IDs are never silently renamed.
 
 ### Sample invocation
 
@@ -344,7 +344,7 @@ Each line: `path:line: severity: [backend/status] rule_id: message [evidence]`.
   [docs/rule-ir.md](rule-ir.md) for the full params and evidence shape.
 - The `changed_file_policy` rule kind (issue #230) is a **deterministic
   changed-file policy check, not a semantic content review**. It evaluates
-  changed files — from a GitHub PR or from a local git working tree —
+  changed files — from a GitHub PR or from a local Git working tree —
   against a repository-owned YAML manifest of forbidden path globs and
   exception entries. File contents are never inspected or uploaded.
   Required params: `manifest_path`, `changed_files_source`
@@ -437,7 +437,7 @@ flag entirely. Rules whose `target_kind` is `unspecified` are
 unaffected: they preserve the prompt-level fallback (the `llm-rubric`
 prompt still names the rule's annotated kind in the model's
 instructions for defence-in-depth, see `docs/llm-rubric.md`). Rules
-routed to non-LLM backends (filesystem, github, external) ignore this
+routed to non-LLM backends (filesystem, GitHub, external) ignore this
 flag.
 
 Sample invocations:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -342,6 +342,15 @@ Each line: `path:line: severity: [backend/status] rule_id: message [evidence]`.
   generated workbook outputs"*) to this kind; ambiguous filesystem rules
   remain on the filesystem or semantic backends. See
   [docs/rule-ir.md](rule-ir.md) for the full params and evidence shape.
+- The `changed_file_policy` rule kind (issue #230) is a **deterministic
+  changed-file policy check, not a semantic content review**. It evaluates
+  changed files — from a GitHub PR or from a local git working tree —
+  against a repository-owned YAML manifest of forbidden path globs and
+  exception entries. File contents are never inspected or uploaded.
+  Required params: `manifest_path`, `changed_files_source`
+  (`"github_pr"` or `"local_git"`); for local mode, optional
+  `local_git_mode` and `repo_root`. See [docs/rule-ir.md](rule-ir.md) for
+  the full manifest schema and failure modes.
 
 ### Multi-target evaluation
 

--- a/docs/example-rules.md
+++ b/docs/example-rules.md
@@ -173,6 +173,91 @@ rules.md:3: error: [github/fail] no-workbook-outputs: PR owner/repo#43: 1 of 9 c
 
 ---
 
+## 4b. Manifest-backed changed-file policy — `github / changed_file_policy`
+
+A **deterministic changed-file policy check, not a semantic content
+review**. Evaluates changed files from a GitHub PR *or* a local git working
+tree against a repository-owned YAML manifest (issue #230). Useful for
+real-data intake repositories such as `uda-lab/spread-applicant-ai` that
+must prevent rights-constrained or private artifacts from being committed
+to public Git history.
+
+**Rule document (compile produces the IR; params are author-supplied):**
+
+```markdown
+## Path policy
+
+- PRs must not change paths forbidden by the project policy manifest.
+```
+
+**Compiled rule (JSON — params hand-authored against
+`policy-manifests/path-rules.yaml`):**
+
+```json
+{
+  "rules": [{
+    "id": "manifest-path-policy",
+    "text": "PRs must not change paths forbidden by the project policy manifest.",
+    "kind": "changed_file_policy",
+    "severity": "error",
+    "backend_hint": "github",
+    "params": {
+      "manifest_path": "policy-manifests/path-rules.yaml",
+      "changed_files_source": "github_pr"
+    }
+  }]
+}
+```
+
+**Sample run (PR target — fail on a forbidden output):**
+
+```
+$ gate-keeper validate rules.md --target owner/repo#42
+rules.md:3: error: [github/fail] manifest-path-policy: changed_file_policy: 1 of 9 changed file(s) violate manifest policy (policy-manifests/path-rules.yaml): ['outputs/foo.xlsx'].
+  remediation: Remove or move the following files before committing:
+    'outputs/foo.xlsx': matched forbidden pattern 'outputs/**/*.xlsx' (source: docs/policy.md#3)
+```
+
+**Sample run (local preflight — staged file is forbidden):**
+
+```json
+{
+  "params": {
+    "manifest_path": "policy-manifests/path-rules.yaml",
+    "changed_files_source": "local_git",
+    "local_git_mode": "staged_and_unstaged"
+  }
+}
+```
+
+```
+$ gate-keeper validate rules.md --target .
+rules.md:3: error: [github/fail] manifest-path-policy: changed_file_policy: 1 of 3 changed file(s) violate manifest policy (...): ['source/official/call.pdf'].
+```
+
+**Notes:**
+
+- `changed_files_source` selects `"github_pr"` (uses the existing PR
+  file-list machinery, identical to `github_changed_files_absent`) or
+  `"local_git"` (collects changed paths via `git diff` /
+  `git ls-files --others`).
+- `local_git_mode` (only used with `local_git`) chooses
+  `staged | unstaged | staged_and_unstaged | untracked | all`. Default
+  is `staged_and_unstaged`.
+- Manifest schema is strict: unknown top-level keys, unknown entry kinds,
+  and unknown entry fields all fail closed with `manifest_error`
+  evidence. Arbitrary YAML tags are not evaluated (`yaml.safe_load`).
+- The diagnostic identifies the exact manifest entry per finding
+  (`matched_pattern`, `manifest_source`, `stop_condition`).
+- This rule does **not** classify file contents, decide
+  rights/publication policy, or inspect file bodies. It enforces only
+  the path-level policy that the manifest already states.
+
+See [docs/rule-ir.md](rule-ir.md#changed_file_policy--manifest-backed-changed-file-policy)
+for the full schema and failure modes.
+
+---
+
 ## 5. Semantic rubric — `llm-rubric / semantic_rubric`
 
 **Rule document:**

--- a/docs/example-rules.md
+++ b/docs/example-rules.md
@@ -176,7 +176,7 @@ rules.md:3: error: [github/fail] no-workbook-outputs: PR owner/repo#43: 1 of 9 c
 ## 4b. Manifest-backed changed-file policy — `github / changed_file_policy`
 
 A **deterministic changed-file policy check, not a semantic content
-review**. Evaluates changed files from a GitHub PR *or* a local git working
+review**. Evaluates changed files from a GitHub PR *or* a local Git working
 tree against a repository-owned YAML manifest (issue #230). Useful for
 real-data intake repositories such as `uda-lab/spread-applicant-ai` that
 must prevent rights-constrained or private artifacts from being committed

--- a/docs/rule-ir.md
+++ b/docs/rule-ir.md
@@ -109,7 +109,7 @@ backend rather than minting new `Backend` enum values; see
 `github_not_draft`, `github_labels_absent`, `github_tasks_complete`,
 `github_checks_success`, `github_threads_resolved`,
 `github_non_author_approval`, `github_changed_files_absent`,
-`semantic_rubric`, `external_check`
+`changed_file_policy`, `semantic_rubric`, `external_check`
 
 ### `Severity`
 `error`, `warning`, `advisory`
@@ -144,6 +144,7 @@ artifact.
 | `github_checks_success` | _(none)_ | — | Evaluates every entry in `statusCheckRollup` as required; only `SUCCESS` state/conclusion passes. Branch protection remains the authoritative control plane. |
 | `external_check` | `tool` | _(required)_ | String adapter ID selecting which `external` adapter handles the rule (e.g. `"textlint"`). Missing → `unavailable` / `params_error`; unregistered → `unsupported` / `adapter_unknown`. All other `params` keys are forwarded verbatim to the adapter, which owns its own per-tool keys. See [`docs/backend-external.md`](backend-external.md). |
 | `github_changed_files_absent` | `patterns`, `case_sensitive` | `case_sensitive=true` | `patterns` is required and must be a non-empty list of glob strings; missing or invalid → `unavailable` / `params_error`. `case_sensitive` is optional (default `true`). Glob semantics: `**` matches zero or more path segments, `*` matches anything except `/`, `?` matches one non-`/` char. See the dedicated section below for the data policy. |
+| `changed_file_policy` | `manifest_path`, `changed_files_source`, `local_git_mode`, `repo_root` | `local_git_mode=staged_and_unstaged`; `repo_root` defaults to the target string or cwd | `manifest_path` (required, non-empty string) points at a YAML policy manifest. `changed_files_source` (required) is `"github_pr"` or `"local_git"`. `local_git_mode` (relevant only for `local_git`) is one of `staged \| unstaged \| staged_and_unstaged \| untracked \| all`. `repo_root` overrides the directory used for `git` commands. Deterministic changed-file policy, **not** semantic content review. See the dedicated section below. |
 | `markdown_evidence_block` | `heading` | _(required)_ | Verbatim ATX heading title (case-sensitive). Backend locates the first fenced code block following this heading and stops at the next sibling/parent heading. Missing → `unavailable` / `params_error`. |
 | `markdown_evidence_block` | `format` | _(required)_ | Format of the fenced block. Currently only `"yaml"` is supported. Other values → `unsupported`. |
 | `markdown_evidence_block` | `required_keys` | _(required)_ | Non-empty list of dotted-key strings (e.g. `"policy.bundle"`). Each must resolve through nested mappings. Missing or empty → `unavailable`. |
@@ -309,6 +310,119 @@ Missing or malformed `patterns` (or non-bool `case_sensitive`) produces
 The backend never returns `pass` on a partial page set — incomplete
 pagination is treated as `unavailable` so a forbidden file added in a
 later page can never be silently skipped.
+
+## `changed_file_policy` — manifest-backed changed-file policy
+
+The `changed_file_policy` rule kind (issue #230) evaluates **only changed
+files** — from a GitHub PR or from a local git working tree — against a
+repository-owned YAML policy manifest. It is a **deterministic changed-file
+policy check, not a semantic content review**: file contents are never
+parsed, inspected, or uploaded.
+
+It is intended for real-data intake repositories such as
+`uda-lab/spread-applicant-ai`, which must prevent rights-constrained or
+private artifacts from being committed to public Git history. The manifest
+remains the project's source of truth; this rule only enforces the manifest.
+
+### Params
+
+```json
+{
+  "manifest_path": "policy-manifests/path-rules.yaml",
+  "changed_files_source": "github_pr",
+  "local_git_mode": "staged_and_unstaged",
+  "repo_root": ""
+}
+```
+
+- `manifest_path` — required, non-empty string; absolute or relative to the
+  working directory.
+- `changed_files_source` — required; one of `"github_pr"` or `"local_git"`.
+- `local_git_mode` — optional, used only when `changed_files_source ==
+  "local_git"`. One of `staged | unstaged | staged_and_unstaged |
+  untracked | all`. Defaults to `staged_and_unstaged`.
+- `repo_root` — optional. Directory used for git commands when
+  `local_git`. When absent, the target string is used if it does not look
+  like a PR reference; otherwise cwd.
+
+Missing or invalid params produce `status = unavailable` with
+`evidence.kind = params_error`.
+
+### Manifest schema
+
+The parser accepts a small explicit schema; unknown top-level keys and
+unknown entry fields are rejected (fail closed). Arbitrary YAML tags are
+**not** evaluated (`yaml.safe_load`).
+
+```yaml
+version: 1                            # required, must equal 1
+entries:                              # required, list of entries
+  - kind: forbidden_path_pattern
+    pattern: "outputs/**/*.xlsx"      # required
+    stop_condition: fail_closed_never_commit  # required
+    source: docs/policy.md#3          # required (manifest entry reference)
+    note: "..."                       # optional
+
+  - kind: known_allowed_exception
+    pattern: "outputs/sample.xlsx"    # required
+    exempts_pattern: "outputs/**/*.xlsx"  # required (the forbidden pattern exempted)
+    authorising_issue: "#42"          # required
+    source: docs/policy.md            # required
+
+  - kind: generated_output_extension
+    extension: .xlsx                  # required
+    source: docs/policy.md            # required
+    note: "..."                       # optional
+
+  - kind: authored_text_extension
+    extension: .md                    # required
+    source: docs/policy.md            # required
+```
+
+Optional informational top-level keys (`source_documents`, `allowed_kinds`,
+`allowed_stop_conditions`, `known_allowed_exceptions_note`,
+`default_unknown_extension`, `default_unknown_path`) are accepted and
+ignored.
+
+### Glob semantics
+
+Identical to `github_changed_files_absent` (`**`, `*`, `?` per the table
+above). Matching is case-sensitive.
+
+### Evidence — `changed_file_policy`
+
+| Field | Meaning |
+| ----- | ------- |
+| `total_changed_files` | Number of changed files considered. |
+| `manifest_path` | The manifest path that was evaluated. |
+| `source` | `github_pr:<owner>/<repo>#<n>` or `local_git:<mode>`. |
+| `violations` | List of `{path, matched_pattern, stop_condition, manifest_source, note}` per offending file. |
+| `forbidden_pattern_count` | Count of forbidden patterns in the manifest. |
+| `exception_count` | Count of exception entries in the manifest. |
+
+The `manifest_source` on each violation is the `source:` field of the
+matched manifest entry, so diagnostics identify the exact manifest entry
+that caused each finding (per #230 done criteria).
+
+### Failure modes
+
+| Status | Evidence kind | When |
+| ------ | ------------- | ---- |
+| `pass` | `changed_file_policy` | No changed file violates a forbidden pattern (or all violations are covered by a known-allowed exception). |
+| `fail` | `changed_file_policy` | One or more changed files violate the manifest; the `violations` list is populated and the diagnostic carries a `remediation` block listing the offending paths. |
+| `unavailable` | `params_error` | Required params missing or malformed (`manifest_path`, `changed_files_source`, `local_git_mode`, `repo_root`). |
+| `unavailable` | `manifest_error` | Manifest file missing, YAML parse error, unsupported version, unknown top-level key, unknown entry kind, missing required entry field, or unknown entry field. |
+| `unavailable` | `local_git_error` | `git` binary missing or git command failed (e.g. target is not a git repository). |
+| `unavailable` | `gh_*` | Any `gh` failure when fetching the PR file list (same surface as `github_changed_files_absent`). |
+
+### Composition
+
+This rule reuses the existing PR file-list machinery
+(`_fetch_changed_files`) so its GitHub-side behaviour matches
+`github_changed_files_absent`. The two rules can coexist; choose
+`github_changed_files_absent` for a flat list of glob patterns embedded in
+the rule itself, and `changed_file_policy` when the patterns live in a
+repository-owned YAML manifest with stop-conditions and exception entries.
 
 ## Validation policy
 

--- a/docs/rule-ir.md
+++ b/docs/rule-ir.md
@@ -314,7 +314,7 @@ later page can never be silently skipped.
 ## `changed_file_policy` — manifest-backed changed-file policy
 
 The `changed_file_policy` rule kind (issue #230) evaluates **only changed
-files** — from a GitHub PR or from a local git working tree — against a
+files** — from a GitHub PR or from a local Git working tree — against a
 repository-owned YAML policy manifest. It is a **deterministic changed-file
 policy check, not a semantic content review**: file contents are never
 parsed, inspected, or uploaded.
@@ -341,7 +341,7 @@ remains the project's source of truth; this rule only enforces the manifest.
 - `local_git_mode` — optional, used only when `changed_files_source ==
   "local_git"`. One of `staged | unstaged | staged_and_unstaged |
   untracked | all`. Defaults to `staged_and_unstaged`.
-- `repo_root` — optional. Directory used for git commands when
+- `repo_root` — optional. Directory used for Git commands when
   `local_git`. When absent, the target string is used if it does not look
   like a PR reference; otherwise cwd.
 
@@ -412,7 +412,7 @@ that caused each finding (per #230 done criteria).
 | `fail` | `changed_file_policy` | One or more changed files violate the manifest; the `violations` list is populated and the diagnostic carries a `remediation` block listing the offending paths. |
 | `unavailable` | `params_error` | Required params missing or malformed (`manifest_path`, `changed_files_source`, `local_git_mode`, `repo_root`). |
 | `unavailable` | `manifest_error` | Manifest file missing, YAML parse error, unsupported version, unknown top-level key, unknown entry kind, missing required entry field, or unknown entry field. |
-| `unavailable` | `local_git_error` | `git` binary missing or git command failed (e.g. target is not a git repository). |
+| `unavailable` | `local_git_error` | `git` binary missing or Git command failed (e.g. target is not a Git repository). |
 | `unavailable` | `gh_*` | Any `gh` failure when fetching the PR file list (same surface as `github_changed_files_absent`). |
 
 ### Composition

--- a/src/gate_keeper/backends/github.py
+++ b/src/gate_keeper/backends/github.py
@@ -1236,6 +1236,604 @@ def _check_changed_files_absent(rule: Rule, pr: PrTarget) -> Diagnostic:
 
 
 # ---------------------------------------------------------------------------
+# Changed-file policy handler (issue #230 — changed_file_policy)
+# ---------------------------------------------------------------------------
+#
+# This rule kind evaluates changed files — from a GitHub PR *or* from a local
+# git working tree — against a YAML policy manifest.  It is deterministic: no
+# LLM calls.  The manifest schema is a strict subset of the contract defined in
+# ``spread-applicant-ai/policy-manifests/path-rules.yaml``.
+#
+# Param contract (rule.params):
+#   manifest_path          str    Required. Path to the policy manifest YAML,
+#                                 relative to the working directory or absolute.
+#   changed_files_source   str    Required. One of: "github_pr" | "local_git".
+#   local_git_mode         str    Optional (only relevant when source="local_git").
+#                                 One of: "staged" | "unstaged" |
+#                                 "staged_and_unstaged" | "untracked" | "all".
+#                                 Defaults to "staged_and_unstaged".
+#   repo_root              str    Optional. Directory to run git commands in
+#                                 when source="local_git". Defaults to cwd.
+#
+# Manifest schema (strict; unknown top-level keys and unknown entry fields
+# are rejected):
+#   version: 1
+#   entries:
+#     - kind: forbidden_path_pattern
+#       pattern: <glob>
+#       stop_condition: <str>
+#       source: <str>
+#       note: <str>          # optional
+#     - kind: known_allowed_exception
+#       pattern: <glob>
+#       exempts_pattern: <glob>
+#       authorising_issue: <str>
+#       source: <str>
+#     - kind: generated_output_extension
+#       extension: <str>
+#       source: <str>
+#       note: <str>          # optional
+#     - kind: authored_text_extension
+#       extension: <str>
+#       source: <str>
+#   Optional top-level keys (informational, not evaluated):
+#     source_documents, allowed_kinds, allowed_stop_conditions,
+#     known_allowed_exceptions_note, default_unknown_extension,
+#     default_unknown_path
+#
+# Evidence kind: ``changed_file_policy``
+
+# Allowed manifest entry kinds.
+_MANIFEST_ALLOWED_KINDS = frozenset(
+    [
+        "forbidden_path_pattern",
+        "known_allowed_exception",
+        "generated_output_extension",
+        "authored_text_extension",
+    ]
+)
+
+# Required / optional fields per entry kind.
+_MANIFEST_ENTRY_SCHEMA: dict[str, tuple[frozenset[str], frozenset[str]]] = {
+    "forbidden_path_pattern": (
+        frozenset(["kind", "pattern", "stop_condition", "source"]),
+        frozenset(["note"]),
+    ),
+    "known_allowed_exception": (
+        frozenset(["kind", "pattern", "exempts_pattern", "authorising_issue", "source"]),
+        frozenset([]),
+    ),
+    "generated_output_extension": (
+        frozenset(["kind", "extension", "source"]),
+        frozenset(["note"]),
+    ),
+    "authored_text_extension": (
+        frozenset(["kind", "extension", "source"]),
+        frozenset([]),
+    ),
+}
+
+# Optional informational top-level keys (not evaluated; kept to avoid
+# rejecting well-formed consumer manifests).
+_MANIFEST_OPTIONAL_TOP_KEYS = frozenset(
+    [
+        "source_documents",
+        "allowed_kinds",
+        "allowed_stop_conditions",
+        "known_allowed_exceptions_note",
+        "default_unknown_extension",
+        "default_unknown_path",
+    ]
+)
+
+# Allowed values for local_git_mode.
+_LOCAL_GIT_MODES = frozenset(["staged", "unstaged", "staged_and_unstaged", "untracked", "all"])
+
+
+def _manifest_error_diag(rule: Rule, reason: str, **extra: object) -> Diagnostic:
+    """Build an UNAVAILABLE diagnostic with ``manifest_error`` evidence."""
+    data: dict[str, object] = {"rule_id": rule.id, "reason": reason}
+    data.update(extra)
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=Backend.GITHUB,
+        status=Status.UNAVAILABLE,
+        severity=rule.severity,
+        message=f"rule {rule.id!r}: {reason}",
+        evidence=[Evidence(kind="manifest_error", data=data)],
+    )
+
+
+def _policy_params_error_diag(rule: Rule, reason: str, **extra: object) -> Diagnostic:
+    """Build an UNAVAILABLE diagnostic with ``params_error`` evidence (policy variant)."""
+    data: dict[str, object] = {"rule_id": rule.id, "reason": reason}
+    data.update(extra)
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=Backend.GITHUB,
+        status=Status.UNAVAILABLE,
+        severity=rule.severity,
+        message=f"rule {rule.id!r} has invalid params for changed_file_policy: {reason}",
+        evidence=[Evidence(kind="params_error", data=data)],
+    )
+
+
+def _local_git_error_diag(rule: Rule, reason: str, **extra: object) -> Diagnostic:
+    """Build an UNAVAILABLE diagnostic with ``local_git_error`` evidence."""
+    data: dict[str, object] = {"rule_id": rule.id, "reason": reason}
+    data.update(extra)
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=Backend.GITHUB,
+        status=Status.UNAVAILABLE,
+        severity=rule.severity,
+        message=f"rule {rule.id!r}: {reason}",
+        evidence=[Evidence(kind="local_git_error", data=data)],
+    )
+
+
+def _parse_policy_manifest(
+    rule: Rule,
+    manifest_path: str,
+) -> "tuple[dict, Diagnostic | None]":
+    """Load and validate the policy manifest YAML at *manifest_path*.
+
+    Returns ``(manifest_dict, None)`` on success or ``({}, diag)`` on any
+    failure.  Unknown top-level keys and unknown/malformed entry fields are
+    rejected (fail-closed).
+    """
+    try:
+        import yaml  # local import — keeps PyYAML out of the import graph until needed
+    except ImportError as exc:
+        return {}, _manifest_error_diag(
+            rule,
+            f"PyYAML is required but is not importable: {exc}",
+            package="pyyaml",
+        )
+
+    path = Path(manifest_path)
+    if not path.exists():
+        return {}, _manifest_error_diag(
+            rule,
+            f"manifest file not found: {manifest_path}",
+            path=manifest_path,
+        )
+
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {}, _manifest_error_diag(
+            rule,
+            f"cannot read manifest file {manifest_path}: {exc}",
+            path=manifest_path,
+        )
+
+    try:
+        doc = yaml.safe_load(raw_text)
+    except yaml.YAMLError as exc:
+        return {}, _manifest_error_diag(
+            rule,
+            f"YAML parse error in manifest {manifest_path}: {exc}",
+            path=manifest_path,
+            error=str(exc),
+        )
+
+    if not isinstance(doc, dict):
+        return {}, _manifest_error_diag(
+            rule,
+            f"manifest {manifest_path}: expected a YAML mapping at top level",
+            path=manifest_path,
+        )
+
+    # Validate version field.
+    version = doc.get("version")
+    if version != 1:
+        return {}, _manifest_error_diag(
+            rule,
+            f"manifest {manifest_path}: unsupported or missing version (got {version!r}); expected 1",
+            path=manifest_path,
+            version=version,
+        )
+
+    # Reject unknown top-level keys (beyond version, entries, and the
+    # known informational keys).
+    allowed_top = frozenset(["version", "entries"]) | _MANIFEST_OPTIONAL_TOP_KEYS
+    unknown_top = set(doc.keys()) - allowed_top
+    if unknown_top:
+        return {}, _manifest_error_diag(
+            rule,
+            f"manifest {manifest_path}: unknown top-level keys: {sorted(unknown_top)}",
+            path=manifest_path,
+            unknown_keys=sorted(unknown_top),
+        )
+
+    # Validate entries array.
+    entries_raw = doc.get("entries")
+    if entries_raw is None:
+        return {}, _manifest_error_diag(
+            rule,
+            f"manifest {manifest_path}: missing required 'entries' key",
+            path=manifest_path,
+        )
+    if not isinstance(entries_raw, list):
+        return {}, _manifest_error_diag(
+            rule,
+            f"manifest {manifest_path}: 'entries' must be a list",
+            path=manifest_path,
+        )
+
+    for idx, entry in enumerate(entries_raw):
+        if not isinstance(entry, dict):
+            return {}, _manifest_error_diag(
+                rule,
+                f"manifest {manifest_path}: entries[{idx}] is not a mapping",
+                path=manifest_path,
+                entry_index=idx,
+            )
+        kind_val = entry.get("kind")
+        if kind_val not in _MANIFEST_ALLOWED_KINDS:
+            return {}, _manifest_error_diag(
+                rule,
+                (
+                    f"manifest {manifest_path}: entries[{idx}].kind {kind_val!r} is not valid; "
+                    f"allowed: {sorted(_MANIFEST_ALLOWED_KINDS)}"
+                ),
+                path=manifest_path,
+                entry_index=idx,
+                kind=kind_val,
+            )
+        required_fields, optional_fields = _MANIFEST_ENTRY_SCHEMA[kind_val]
+        entry_keys = set(entry.keys())
+        missing = required_fields - entry_keys
+        if missing:
+            return {}, _manifest_error_diag(
+                rule,
+                (
+                    f"manifest {manifest_path}: entries[{idx}] (kind={kind_val!r}) "
+                    f"is missing required fields: {sorted(missing)}"
+                ),
+                path=manifest_path,
+                entry_index=idx,
+                kind=kind_val,
+                missing_fields=sorted(missing),
+            )
+        unknown = entry_keys - required_fields - optional_fields
+        if unknown:
+            return {}, _manifest_error_diag(
+                rule,
+                (
+                    f"manifest {manifest_path}: entries[{idx}] (kind={kind_val!r}) "
+                    f"has unknown fields: {sorted(unknown)}"
+                ),
+                path=manifest_path,
+                entry_index=idx,
+                kind=kind_val,
+                unknown_fields=sorted(unknown),
+            )
+
+    return doc, None
+
+
+def _collect_local_git_files(
+    rule: Rule,
+    mode: str,
+    repo_root: str,
+) -> "tuple[list[str] | None, Diagnostic | None]":
+    """Collect changed file paths from the local git working tree.
+
+    Returns ``(filenames, None)`` on success or ``(None, diag)`` on failure.
+
+    Git command mapping per mode:
+    - staged:               ``git diff --cached --name-only``
+    - unstaged:             ``git diff --name-only``
+    - staged_and_unstaged:  both staged + unstaged, deduplicated
+    - untracked:            ``git ls-files --others --exclude-standard``
+    - all:                  staged + unstaged + untracked
+    """
+    import subprocess  # noqa: PLC0415 — deferred to avoid import cost when not used
+
+    root = Path(repo_root) if repo_root else Path.cwd()
+
+    def _run_git(args: list[str]) -> "tuple[str | None, str | None]":
+        """Run a git command in *root*; return (stdout, error_msg)."""
+        try:
+            result = subprocess.run(
+                ["git"] + args,
+                cwd=str(root),
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except FileNotFoundError:
+            return None, "git binary not found"
+        except subprocess.TimeoutExpired:
+            return None, "git command timed out after 30 seconds"
+        except OSError as exc:
+            return None, f"git command failed: {exc}"
+
+        if result.returncode != 0:
+            stderr_excerpt = result.stderr.strip()[:200]
+            return None, f"git exited with code {result.returncode}: {stderr_excerpt}"
+        return result.stdout, None
+
+    def _parse_names(stdout: str) -> list[str]:
+        return [line for line in stdout.splitlines() if line.strip()]
+
+    if mode == "staged":
+        out, err = _run_git(["diff", "--cached", "--name-only"])
+        if err is not None:
+            return None, _local_git_error_diag(rule, f"cannot collect staged files: {err}", mode=mode)
+        return _parse_names(out or ""), None
+
+    if mode == "unstaged":
+        out, err = _run_git(["diff", "--name-only"])
+        if err is not None:
+            return None, _local_git_error_diag(rule, f"cannot collect unstaged files: {err}", mode=mode)
+        return _parse_names(out or ""), None
+
+    if mode == "staged_and_unstaged":
+        staged_out, err = _run_git(["diff", "--cached", "--name-only"])
+        if err is not None:
+            return None, _local_git_error_diag(rule, f"cannot collect staged files: {err}", mode=mode)
+        unstaged_out, err = _run_git(["diff", "--name-only"])
+        if err is not None:
+            return None, _local_git_error_diag(rule, f"cannot collect unstaged files: {err}", mode=mode)
+        seen: set[str] = set()
+        names: list[str] = []
+        for line in (staged_out or "").splitlines() + (unstaged_out or "").splitlines():
+            name = line.strip()
+            if name and name not in seen:
+                seen.add(name)
+                names.append(name)
+        return names, None
+
+    if mode == "untracked":
+        out, err = _run_git(["ls-files", "--others", "--exclude-standard"])
+        if err is not None:
+            return None, _local_git_error_diag(rule, f"cannot collect untracked files: {err}", mode=mode)
+        return _parse_names(out or ""), None
+
+    if mode == "all":
+        staged_out, err = _run_git(["diff", "--cached", "--name-only"])
+        if err is not None:
+            return None, _local_git_error_diag(rule, f"cannot collect staged files: {err}", mode=mode)
+        unstaged_out, err = _run_git(["diff", "--name-only"])
+        if err is not None:
+            return None, _local_git_error_diag(rule, f"cannot collect unstaged files: {err}", mode=mode)
+        untracked_out, err = _run_git(["ls-files", "--others", "--exclude-standard"])
+        if err is not None:
+            return None, _local_git_error_diag(rule, f"cannot collect untracked files: {err}", mode=mode)
+        seen2: set[str] = set()
+        names2: list[str] = []
+        for line in (
+            (staged_out or "").splitlines()
+            + (unstaged_out or "").splitlines()
+            + (untracked_out or "").splitlines()
+        ):
+            name = line.strip()
+            if name and name not in seen2:
+                seen2.add(name)
+                names2.append(name)
+        return names2, None
+
+    # Unreachable if params were validated, but fail closed.
+    return None, _local_git_error_diag(rule, f"unknown local_git_mode {mode!r}", mode=mode)
+
+
+def _evaluate_manifest_policy(
+    rule: Rule,
+    filenames: list[str],
+    manifest: dict,
+    manifest_path: str,
+    source_label: str,
+) -> Diagnostic:
+    """Evaluate *filenames* against the policy manifest entries.
+
+    Returns a PASS or FAIL Diagnostic with structured evidence per finding.
+
+    Evidence kind: ``changed_file_policy``.
+
+    Logic:
+    1. Build a list of forbidden-path-pattern entries.
+    2. Build a set of known-allowed-exception entries (pattern + exempts_pattern).
+    3. For each changed file:
+       a. Check if it matches any forbidden pattern.
+       b. If yes, check if it is covered by a known-allowed exception
+          (exception.pattern must match the file AND exception.exempts_pattern
+          must match the forbidden pattern that triggered).
+       c. If not exempted → violation.
+    """
+    entries = manifest.get("entries", [])
+
+    forbidden: list[dict] = [e for e in entries if e.get("kind") == "forbidden_path_pattern"]
+    exceptions: list[dict] = [e for e in entries if e.get("kind") == "known_allowed_exception"]
+
+    violations: list[dict] = []
+
+    for filename in filenames:
+        for fp in forbidden:
+            pattern = fp["pattern"]
+            if not _match_glob(filename, pattern, case_sensitive=True):
+                continue
+            # File matches a forbidden pattern. Check for an exception.
+            exempted = False
+            for exc_entry in exceptions:
+                exc_pattern = exc_entry.get("pattern", "")
+                exempts = exc_entry.get("exempts_pattern", "")
+                if _match_glob(filename, exc_pattern, case_sensitive=True) and _match_glob(
+                    pattern, exempts, case_sensitive=True
+                ):
+                    exempted = True
+                    break
+            if not exempted:
+                violations.append(
+                    {
+                        "path": filename,
+                        "matched_pattern": pattern,
+                        "stop_condition": fp.get("stop_condition", ""),
+                        "manifest_source": fp.get("source", ""),
+                        "note": fp.get("note", ""),
+                    }
+                )
+                break  # one violation per file; record first matching pattern
+
+    evidence_data: dict = {
+        "total_changed_files": len(filenames),
+        "manifest_path": manifest_path,
+        "source": source_label,
+        "violations": violations,
+        "forbidden_pattern_count": len(forbidden),
+        "exception_count": len(exceptions),
+    }
+    evidence = [Evidence(kind="changed_file_policy", data=evidence_data)]
+
+    if not violations:
+        return _diag(
+            rule,
+            Status.PASS,
+            (
+                f"changed_file_policy: 0 of {len(filenames)} changed file(s) "
+                f"violate manifest policy ({manifest_path})."
+            ),
+            evidence,
+        )
+
+    violation_paths = [v["path"] for v in violations]
+    remediation_lines = [
+        f"  {v['path']!r}: matched forbidden pattern {v['matched_pattern']!r} "
+        f"(source: {v['manifest_source'] or 'unspecified'})"
+        for v in violations
+    ]
+    remediation = "Remove or move the following files before committing:\n" + "\n".join(remediation_lines)
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=Backend.GITHUB,
+        status=Status.FAIL,
+        severity=rule.severity,
+        message=(
+            f"changed_file_policy: {len(violations)} of {len(filenames)} changed file(s) "
+            f"violate manifest policy ({manifest_path}): {violation_paths!r}."
+        ),
+        evidence=evidence,
+        remediation=remediation,
+    )
+
+
+def _validate_changed_file_policy_params(
+    rule: Rule,
+) -> "tuple[str, str, str, str] | Diagnostic":
+    """Validate and normalise params for ``changed_file_policy``.
+
+    Returns ``(manifest_path, changed_files_source, local_git_mode, repo_root)``
+    on success, or an UNAVAILABLE Diagnostic on error.
+    """
+    params = rule.params
+
+    if "manifest_path" not in params:
+        return _policy_params_error_diag(rule, "manifest_path is required", missing="manifest_path")
+    manifest_path = params["manifest_path"]
+    if not isinstance(manifest_path, str) or not manifest_path:
+        return _policy_params_error_diag(
+            rule,
+            "manifest_path must be a non-empty string",
+            field="manifest_path",
+            actual_type=type(manifest_path).__name__,
+        )
+
+    if "changed_files_source" not in params:
+        return _policy_params_error_diag(
+            rule, "changed_files_source is required", missing="changed_files_source"
+        )
+    cfs = params["changed_files_source"]
+    if cfs not in ("github_pr", "local_git"):
+        return _policy_params_error_diag(
+            rule,
+            f"changed_files_source must be 'github_pr' or 'local_git', got {cfs!r}",
+            field="changed_files_source",
+            actual_value=cfs,
+        )
+
+    local_git_mode = params.get("local_git_mode", "staged_and_unstaged")
+    if not isinstance(local_git_mode, str) or local_git_mode not in _LOCAL_GIT_MODES:
+        return _policy_params_error_diag(
+            rule,
+            f"local_git_mode must be one of {sorted(_LOCAL_GIT_MODES)}, got {local_git_mode!r}",
+            field="local_git_mode",
+            actual_value=local_git_mode,
+        )
+
+    repo_root = params.get("repo_root", "")
+    if not isinstance(repo_root, str):
+        return _policy_params_error_diag(
+            rule,
+            "repo_root must be a string when present",
+            field="repo_root",
+            actual_type=type(repo_root).__name__,
+        )
+
+    return manifest_path, cfs, local_git_mode, repo_root
+
+
+def _check_changed_file_policy_local(rule: Rule, target_str: str) -> Diagnostic:
+    """Handle ``changed_file_policy`` with ``changed_files_source='local_git'``.
+
+    *target_str* is used as *repo_root* when ``params.repo_root`` is not set
+    and target_str looks like a directory path (not a PR reference).
+    """
+    validated = _validate_changed_file_policy_params(rule)
+    if isinstance(validated, Diagnostic):
+        return validated
+    manifest_path, _cfs, local_git_mode, repo_root = validated
+
+    # If repo_root param is absent, fall back to target_str if it looks like a
+    # filesystem path, otherwise use cwd.
+    if not repo_root:
+        from gate_keeper.backends._target import parse_target
+
+        parsed, _ = parse_target(target_str)
+        if parsed is None:
+            # Target does not look like a PR reference — treat as directory.
+            repo_root = target_str
+        # else: target looks like a PR but source is local_git — use cwd.
+
+    manifest, diag = _parse_policy_manifest(rule, manifest_path)
+    if diag is not None:
+        return diag
+
+    filenames, git_diag = _collect_local_git_files(rule, local_git_mode, repo_root)
+    if git_diag is not None:
+        return git_diag
+    assert filenames is not None
+
+    source_label = f"local_git:{local_git_mode}"
+    return _evaluate_manifest_policy(rule, filenames, manifest, manifest_path, source_label)
+
+
+def _check_changed_file_policy_pr(rule: Rule, pr: PrTarget) -> Diagnostic:
+    """Handle ``changed_file_policy`` with ``changed_files_source='github_pr'``."""
+    validated = _validate_changed_file_policy_params(rule)
+    if isinstance(validated, Diagnostic):
+        return validated
+    manifest_path, _cfs, _local_git_mode, _repo_root = validated
+
+    manifest, diag = _parse_policy_manifest(rule, manifest_path)
+    if diag is not None:
+        return diag
+
+    filenames, page_count, fetch_diag = _fetch_changed_files(pr, rule)
+    if fetch_diag is not None:
+        return fetch_diag
+    assert filenames is not None
+
+    source_label = f"github_pr:{pr.owner}/{pr.repo}#{pr.number}"
+    return _evaluate_manifest_policy(rule, filenames, manifest, manifest_path, source_label)
+
+
+# ---------------------------------------------------------------------------
 # Dispatch tables
 # ---------------------------------------------------------------------------
 
@@ -1300,10 +1898,25 @@ def check(rule: Rule, target: str | Path | TargetSpec) -> Diagnostic:
             )
         target = target.paths[0] if target.paths else ""
     target_str = str(target)
+
+    # ``changed_file_policy`` with ``changed_files_source='local_git'`` must
+    # skip PR resolution entirely — the target is a directory path (or cwd).
+    # Route it before the resolve_target() call so a non-PR target string does
+    # not produce a spurious UNAVAILABLE.
+    if rule.kind is RuleKind.CHANGED_FILE_POLICY:
+        cfs = rule.params.get("changed_files_source", "")
+        if cfs == "local_git":
+            return _check_changed_file_policy_local(rule, target_str)
+        # For ``github_pr`` source: fall through to normal PR resolution below.
+
     pr, diag = resolve_target(rule, target_str)
     if diag is not None:
         return diag
     assert pr is not None
+
+    # ``changed_file_policy`` with github_pr source.
+    if rule.kind is RuleKind.CHANGED_FILE_POLICY:
+        return _check_changed_file_policy_pr(rule, pr)
 
     # Direct handlers: make their own gh call, don't need pr-view.
     direct = _DIRECT_HANDLERS.get(rule.kind)

--- a/src/gate_keeper/backends/github.py
+++ b/src/gate_keeper/backends/github.py
@@ -1473,7 +1473,23 @@ def _parse_policy_manifest(
                 path=manifest_path,
                 entry_index=idx,
             )
+        # ``kind`` must be a string before we can membership-test it against
+        # the allowed set; an unhashable value (e.g. ``["forbidden_path_pattern"]``)
+        # would otherwise raise ``TypeError`` from the ``not in`` lookup and bypass
+        # the fail-closed contract (codex P1 / Copilot review on #232).
         kind_val = entry.get("kind")
+        if not isinstance(kind_val, str):
+            return {}, _manifest_error_diag(
+                rule,
+                (
+                    f"manifest {manifest_path}: entries[{idx}].kind must be a string, "
+                    f"got {type(kind_val).__name__}"
+                ),
+                path=manifest_path,
+                entry_index=idx,
+                field="kind",
+                actual_type=type(kind_val).__name__,
+            )
         if kind_val not in _MANIFEST_ALLOWED_KINDS:
             return {}, _manifest_error_diag(
                 rule,
@@ -1513,6 +1529,33 @@ def _parse_policy_manifest(
                 kind=kind_val,
                 unknown_fields=sorted(unknown),
             )
+
+        # Per-kind value-type validation. Every required field (and the
+        # optional ``note`` when present) must be a non-empty string;
+        # without this check a malformed manifest with the right *keys* but
+        # wrong *value types* (e.g. ``pattern: 7``) would later crash in
+        # ``_glob_to_regex`` / ``_match_glob`` rather than surfacing as a
+        # ``manifest_error`` diagnostic (codex P1 / Copilot review on
+        # #232).
+        string_fields = required_fields | (optional_fields & {"note"})
+        for field in sorted(string_fields):
+            if field not in entry:
+                continue  # already validated as required-or-present
+            value = entry[field]
+            if not isinstance(value, str) or not value:
+                return {}, _manifest_error_diag(
+                    rule,
+                    (
+                        f"manifest {manifest_path}: entries[{idx}] (kind={kind_val!r}) "
+                        f"field {field!r} must be a non-empty string, "
+                        f"got {type(value).__name__}"
+                    ),
+                    path=manifest_path,
+                    entry_index=idx,
+                    kind=kind_val,
+                    field=field,
+                    actual_type=type(value).__name__,
+                )
 
     return doc, None
 
@@ -1629,6 +1672,7 @@ def _evaluate_manifest_policy(
     manifest: dict,
     manifest_path: str,
     source_label: str,
+    pagination_metadata: dict | None = None,
 ) -> Diagnostic:
     """Evaluate *filenames* against the policy manifest entries.
 
@@ -1645,6 +1689,11 @@ def _evaluate_manifest_policy(
           (exception.pattern must match the file AND exception.exempts_pattern
           must match the forbidden pattern that triggered).
        c. If not exempted → violation.
+
+    *pagination_metadata*: when supplied, merged into the evidence payload
+    so PR-mode runs carry the same ``page_count`` / ``pagination_complete``
+    parity that ``github_changed_files_absent`` exposes (Copilot review on
+    #232).  Local-git runs pass ``None`` because no pagination occurs.
     """
     entries = manifest.get("entries", [])
 
@@ -1688,6 +1737,8 @@ def _evaluate_manifest_policy(
         "forbidden_pattern_count": len(forbidden),
         "exception_count": len(exceptions),
     }
+    if pagination_metadata is not None:
+        evidence_data.update(pagination_metadata)
     evidence = [Evidence(kind="changed_file_policy", data=evidence_data)]
 
     if not violations:
@@ -1828,9 +1879,21 @@ def _check_changed_file_policy_pr(rule: Rule, pr: PrTarget) -> Diagnostic:
     if fetch_diag is not None:
         return fetch_diag
     assert filenames is not None
+    assert page_count is not None
 
     source_label = f"github_pr:{pr.owner}/{pr.repo}#{pr.number}"
-    return _evaluate_manifest_policy(rule, filenames, manifest, manifest_path, source_label)
+    pagination_metadata = {
+        "pagination_complete": True,
+        "page_count": page_count,
+    }
+    return _evaluate_manifest_policy(
+        rule,
+        filenames,
+        manifest,
+        manifest_path,
+        source_label,
+        pagination_metadata=pagination_metadata,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1899,15 +1962,21 @@ def check(rule: Rule, target: str | Path | TargetSpec) -> Diagnostic:
         target = target.paths[0] if target.paths else ""
     target_str = str(target)
 
-    # ``changed_file_policy`` with ``changed_files_source='local_git'`` must
-    # skip PR resolution entirely — the target is a directory path (or cwd).
-    # Route it before the resolve_target() call so a non-PR target string does
-    # not produce a spurious UNAVAILABLE.
+    # ``changed_file_policy`` must validate its params *before* PR
+    # resolution.  Otherwise a missing/invalid ``changed_files_source``
+    # plus a non-PR target string (e.g. ``--target .``) would fall through
+    # to ``resolve_target()`` and surface as ``target_parse_error`` instead
+    # of the documented ``params_error`` (codex P2 / Copilot review on
+    # #232).  Validated params → dispatch by source; invalid → return the
+    # ``params_error`` diagnostic verbatim.
     if rule.kind is RuleKind.CHANGED_FILE_POLICY:
-        cfs = rule.params.get("changed_files_source", "")
+        validated = _validate_changed_file_policy_params(rule)
+        if isinstance(validated, Diagnostic):
+            return validated
+        _manifest_path, cfs, _local_git_mode, _repo_root = validated
         if cfs == "local_git":
             return _check_changed_file_policy_local(rule, target_str)
-        # For ``github_pr`` source: fall through to normal PR resolution below.
+        # ``cfs == "github_pr"`` — fall through to PR resolution below.
 
     pr, diag = resolve_target(rule, target_str)
     if diag is not None:

--- a/src/gate_keeper/models.py
+++ b/src/gate_keeper/models.py
@@ -56,6 +56,7 @@ class RuleKind(str, enum.Enum):
     GITHUB_THREADS_RESOLVED = "github_threads_resolved"
     GITHUB_NON_AUTHOR_APPROVAL = "github_non_author_approval"
     GITHUB_CHANGED_FILES_ABSENT = "github_changed_files_absent"
+    CHANGED_FILE_POLICY = "changed_file_policy"
     SEMANTIC_RUBRIC = "semantic_rubric"
     EXTERNAL_CHECK = "external_check"
 

--- a/tests/test_changed_file_policy.py
+++ b/tests/test_changed_file_policy.py
@@ -348,6 +348,176 @@ class TestManifestParser:
         assert ev.kind == "manifest_error"
         assert "bonus_field" in ev.data["unknown_fields"]
 
+    # ----- Per-kind value-type validation (codex P1 / Copilot review on #232) -----
+
+    def test_entry_kind_non_string_unavailable(self, monkeypatch, tmp_path):
+        """A list-valued ``kind`` would crash the ``not in`` membership test."""
+        p = tmp_path / "kind-not-string.yaml"
+        p.write_text(
+            dedent(
+                """\
+                version: 1
+                entries:
+                  - kind: [forbidden_path_pattern]
+                    pattern: "outputs/**"
+                    stop_condition: fail_closed_never_commit
+                    source: docs/policy.md
+                """
+            ),
+            encoding="utf-8",
+        )
+        rule = _make_rule(manifest_path=str(p))
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "manifest_error"
+        assert ev.data["field"] == "kind"
+        assert ev.data["actual_type"] == "list"
+
+    def test_entry_pattern_non_string_unavailable(self, monkeypatch, tmp_path):
+        """A non-string ``pattern`` would otherwise crash ``_match_glob``."""
+        p = tmp_path / "pattern-not-string.yaml"
+        p.write_text(
+            dedent(
+                """\
+                version: 1
+                entries:
+                  - kind: forbidden_path_pattern
+                    pattern: 7
+                    stop_condition: fail_closed_never_commit
+                    source: docs/policy.md
+                """
+            ),
+            encoding="utf-8",
+        )
+        rule = _make_rule(manifest_path=str(p))
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "manifest_error"
+        assert ev.data["field"] == "pattern"
+        assert ev.data["actual_type"] == "int"
+
+    def test_entry_pattern_empty_string_unavailable(self, monkeypatch, tmp_path):
+        """Empty string ``pattern`` would match every path; fail closed."""
+        p = tmp_path / "pattern-empty.yaml"
+        p.write_text(
+            dedent(
+                """\
+                version: 1
+                entries:
+                  - kind: forbidden_path_pattern
+                    pattern: ""
+                    stop_condition: fail_closed_never_commit
+                    source: docs/policy.md
+                """
+            ),
+            encoding="utf-8",
+        )
+        rule = _make_rule(manifest_path=str(p))
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "manifest_error"
+        assert ev.data["field"] == "pattern"
+
+    def test_extension_non_string_unavailable(self, monkeypatch, tmp_path):
+        """Per-kind type check covers ``generated_output_extension.extension``."""
+        p = tmp_path / "extension-not-string.yaml"
+        p.write_text(
+            dedent(
+                """\
+                version: 1
+                entries:
+                  - kind: generated_output_extension
+                    extension: 7
+                    source: docs/policy.md
+                """
+            ),
+            encoding="utf-8",
+        )
+        rule = _make_rule(manifest_path=str(p))
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "manifest_error"
+        assert ev.data["field"] == "extension"
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher param-precedence (codex P2 / Copilot review on #232)
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherParamPrecedence:
+    def test_missing_changed_files_source_with_directory_target_unavailable(self, tmp_path):
+        """``--target .`` with missing source must surface ``params_error``, not ``target_parse_error``."""
+        rule = _make_rule(manifest_path="any.yaml", omit_source=True)
+        diag = gh_backend.check(rule, str(tmp_path))
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        # Must be params_error, NOT target_parse_error.
+        assert ev.kind == "params_error"
+        assert ev.data["missing"] == "changed_files_source"
+
+    def test_invalid_changed_files_source_with_directory_target_unavailable(self, tmp_path):
+        rule = _make_rule(
+            manifest_path="any.yaml",
+            changed_files_source="bogus",
+        )
+        diag = gh_backend.check(rule, str(tmp_path))
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "params_error"
+        assert ev.data["field"] == "changed_files_source"
+
+
+# ---------------------------------------------------------------------------
+# Pagination metadata in PR-mode evidence (Copilot review on #232)
+# ---------------------------------------------------------------------------
+
+
+class TestPaginationMetadata:
+    def test_pr_evidence_carries_page_count_and_pagination_complete(self, monkeypatch, manifest_file):
+        """PR mode must surface ``page_count`` and ``pagination_complete``.
+
+        Parity with ``github_changed_files_absent`` (Copilot review on #232).
+        """
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [_ok(_files_response(["README.md"]))],
+        )
+        rule = _make_rule(manifest_path=str(manifest_file))
+        diag = gh_backend.check(rule, "owner/repo#42")
+        ev = diag.evidence[0]
+        assert ev.data["pagination_complete"] is True
+        assert ev.data["page_count"] == 1
+
+    def test_local_mode_evidence_omits_pagination_keys(self, tmp_path: Path):
+        """Local mode does not paginate; the keys must be absent for honesty."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_git_repo(repo)
+
+        manifest = tmp_path / "manifest.yaml"
+        manifest.write_text(_SAMPLE_MANIFEST, encoding="utf-8")
+
+        rule = _make_rule(
+            manifest_path=str(manifest),
+            changed_files_source="local_git",
+            local_git_mode="staged",
+            repo_root=str(repo),
+        )
+        diag = gh_backend.check(rule, str(repo))
+        ev = diag.evidence[0]
+        assert "page_count" not in ev.data
+        assert "pagination_complete" not in ev.data
+
 
 # ---------------------------------------------------------------------------
 # GitHub PR mode — pass and fail paths via the existing PR file-list machinery

--- a/tests/test_changed_file_policy.py
+++ b/tests/test_changed_file_policy.py
@@ -1,0 +1,732 @@
+"""Tests for the ``changed_file_policy`` rule kind (issue #230).
+
+This rule kind evaluates *only changed files* — from a GitHub PR or from a
+local git working tree — against a YAML policy manifest.  The manifest schema
+mirrors a strict subset of
+``spread-applicant-ai/policy-manifests/path-rules.yaml``.
+
+Coverage areas (per #230 done criteria):
+
+- GitHub PR mode: pass / fail on forbidden changed paths.
+- Local git modes: ``staged``, ``unstaged``, ``staged_and_unstaged``,
+  ``untracked``, ``all``.
+- Manifest exceptions: a ``known_allowed_exception`` entry must exempt a
+  matching file from a corresponding forbidden pattern.
+- Malformed manifest fails closed.
+- Fail-closed on unknown manifest fields or kinds.
+- Diagnostics identify the exact manifest entry that caused each finding.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from gate_keeper.backends import _gh, _target
+from gate_keeper.backends import github as gh_backend
+from gate_keeper.models import (
+    Backend,
+    Confidence,
+    Rule,
+    RuleKind,
+    Severity,
+    SourceLocation,
+    Status,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_RESOLVE_OK = json.dumps({"number": 42, "url": "https://github.com/owner/repo/pull/42"})
+
+
+def _ok(stdout: str) -> _gh.GhResult:
+    return _gh.GhResult(ok=True, stdout=stdout, stderr="", returncode=0, cmd=("gh",))
+
+
+def _make_run_gh_sequence(results):
+    queue = list(results)
+
+    def _fake(args, **kwargs):
+        if queue:
+            return queue.pop(0)
+        raise AssertionError(f"run_gh called more times than expected; args={args!r}")
+
+    return _fake
+
+
+def _patch_with_pages(monkeypatch, resolve_result, pages):
+    monkeypatch.setattr(_target, "run_gh", _make_run_gh_sequence([resolve_result]))
+    monkeypatch.setattr(gh_backend, "run_gh", _make_run_gh_sequence(pages))
+
+
+def _files_response(paths, *, has_next_page=False, end_cursor=None) -> str:
+    return json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "files": {
+                            "nodes": [{"path": p} for p in paths],
+                            "pageInfo": {
+                                "hasNextPage": has_next_page,
+                                "endCursor": end_cursor,
+                            },
+                        }
+                    }
+                }
+            }
+        }
+    )
+
+
+def _make_rule(
+    *,
+    manifest_path: str,
+    changed_files_source: str = "github_pr",
+    local_git_mode: str | None = None,
+    repo_root: str | None = None,
+    omit_manifest_path: bool = False,
+    omit_source: bool = False,
+) -> Rule:
+    params: dict = {}
+    if not omit_manifest_path:
+        params["manifest_path"] = manifest_path
+    if not omit_source:
+        params["changed_files_source"] = changed_files_source
+    if local_git_mode is not None:
+        params["local_git_mode"] = local_git_mode
+    if repo_root is not None:
+        params["repo_root"] = repo_root
+    return Rule(
+        id="rule-cf-policy",
+        title="Real-data intake policy",
+        source=SourceLocation(path="rules.md", line=1),
+        text="PRs must not change forbidden manifest paths.",
+        kind=RuleKind.CHANGED_FILE_POLICY,
+        severity=Severity.ERROR,
+        backend_hint=Backend.GITHUB,
+        confidence=Confidence.HIGH,
+        params=params,
+    )
+
+
+# Modeled on the spread-applicant-ai/policy-manifests/path-rules.yaml schema
+# but kept minimal and self-contained for hermetic tests.
+_SAMPLE_MANIFEST = dedent(
+    """\
+    version: 1
+    source_documents:
+      - docs/policy.md
+    allowed_kinds:
+      - forbidden_path_pattern
+      - known_allowed_exception
+      - generated_output_extension
+      - authored_text_extension
+    allowed_stop_conditions:
+      - fail_closed_never_commit
+      - refuse_and_surface
+    entries:
+      - kind: forbidden_path_pattern
+        pattern: "source/official/**/*.pdf"
+        stop_condition: fail_closed_never_commit
+        note: Generated submission PDFs must not be tracked publicly.
+        source: docs/policy.md#3
+      - kind: forbidden_path_pattern
+        pattern: "outputs/**/*.xlsx"
+        stop_condition: fail_closed_never_commit
+        source: docs/policy.md#3
+      - kind: forbidden_path_pattern
+        pattern: "context/researcher/raw/**"
+        stop_condition: fail_closed_never_commit
+        note: Raw researcher partition never tracked publicly.
+        source: docs/policy.md#5
+      - kind: forbidden_path_pattern
+        pattern: "**/.env"
+        stop_condition: fail_closed_never_commit
+        source: docs/policy.md#2.5
+      - kind: generated_output_extension
+        extension: .xlsx
+        source: docs/policy.md
+      - kind: authored_text_extension
+        extension: .md
+        source: docs/policy.md
+    known_allowed_exceptions_note: >-
+      No cross-layer exceptions are approved at issuance.
+    default_unknown_extension:
+      treatment: fail_closed_private
+      source: docs/policy.md#6
+    default_unknown_path:
+      stop_condition: fail_closed_never_commit
+      source: docs/policy.md#6
+    """
+)
+
+
+@pytest.fixture
+def manifest_file(tmp_path: Path) -> Path:
+    """Write the sample manifest to a temp file and return its path."""
+    p = tmp_path / "path-rules.yaml"
+    p.write_text(_SAMPLE_MANIFEST, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Params validation
+# ---------------------------------------------------------------------------
+
+
+class TestParamsValidation:
+    def test_missing_manifest_path_unavailable(self, monkeypatch):
+        rule = _make_rule(manifest_path="x", omit_manifest_path=True)
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "params_error"
+        assert diag.evidence[0].data["missing"] == "manifest_path"
+
+    def test_missing_source_unavailable(self, monkeypatch):
+        rule = _make_rule(manifest_path="x", omit_source=True)
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "params_error"
+        assert diag.evidence[0].data["missing"] == "changed_files_source"
+
+    def test_invalid_source_unavailable(self, monkeypatch, manifest_file):
+        rule = _make_rule(
+            manifest_path=str(manifest_file),
+            changed_files_source="invalid",
+        )
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "params_error"
+        assert diag.evidence[0].data["field"] == "changed_files_source"
+
+    def test_invalid_local_git_mode_unavailable(self, tmp_path):
+        rule = _make_rule(
+            manifest_path="x",
+            changed_files_source="local_git",
+            local_git_mode="bogus",
+            repo_root=str(tmp_path),
+        )
+        diag = gh_backend.check(rule, str(tmp_path))
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "params_error"
+        assert diag.evidence[0].data["field"] == "local_git_mode"
+
+
+# ---------------------------------------------------------------------------
+# Manifest parser — fail-closed on malformed or unknown content
+# ---------------------------------------------------------------------------
+
+
+class TestManifestParser:
+    def test_missing_manifest_file_unavailable(self, monkeypatch, tmp_path):
+        bogus = tmp_path / "does-not-exist.yaml"
+        rule = _make_rule(manifest_path=str(bogus))
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "manifest_error"
+        assert "not found" in diag.evidence[0].data["reason"]
+
+    def test_malformed_yaml_unavailable(self, monkeypatch, tmp_path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("entries: [unterminated\n", encoding="utf-8")
+        rule = _make_rule(manifest_path=str(bad))
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "manifest_error"
+        assert "YAML parse error" in diag.evidence[0].data["reason"]
+
+    def test_unsupported_version_unavailable(self, monkeypatch, tmp_path):
+        p = tmp_path / "wrong-version.yaml"
+        p.write_text("version: 2\nentries: []\n", encoding="utf-8")
+        rule = _make_rule(manifest_path=str(p))
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "manifest_error"
+        assert diag.evidence[0].data["version"] == 2
+
+    def test_missing_entries_unavailable(self, monkeypatch, tmp_path):
+        p = tmp_path / "no-entries.yaml"
+        p.write_text("version: 1\n", encoding="utf-8")
+        rule = _make_rule(manifest_path=str(p))
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "manifest_error"
+        assert "entries" in diag.evidence[0].data["reason"]
+
+    def test_unknown_top_level_key_unavailable(self, monkeypatch, tmp_path):
+        p = tmp_path / "unknown-top.yaml"
+        p.write_text(
+            "version: 1\nentries: []\nmysterious_key: 7\n",
+            encoding="utf-8",
+        )
+        rule = _make_rule(manifest_path=str(p))
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "manifest_error"
+        assert "mysterious_key" in diag.evidence[0].data["unknown_keys"]
+
+    def test_unknown_entry_kind_unavailable(self, monkeypatch, tmp_path):
+        p = tmp_path / "bad-kind.yaml"
+        p.write_text(
+            dedent(
+                """\
+                version: 1
+                entries:
+                  - kind: invented_kind
+                    pattern: "x/**"
+                """
+            ),
+            encoding="utf-8",
+        )
+        rule = _make_rule(manifest_path=str(p))
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "manifest_error"
+        assert diag.evidence[0].data["kind"] == "invented_kind"
+
+    def test_entry_missing_required_field_unavailable(self, monkeypatch, tmp_path):
+        p = tmp_path / "missing-fields.yaml"
+        p.write_text(
+            dedent(
+                """\
+                version: 1
+                entries:
+                  - kind: forbidden_path_pattern
+                    pattern: "outputs/**"
+                """
+            ),
+            encoding="utf-8",
+        )
+        rule = _make_rule(manifest_path=str(p))
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "manifest_error"
+        # stop_condition and source are required for forbidden_path_pattern.
+        missing = ev.data["missing_fields"]
+        assert "stop_condition" in missing
+        assert "source" in missing
+
+    def test_entry_unknown_field_unavailable(self, monkeypatch, tmp_path):
+        p = tmp_path / "extra-field.yaml"
+        p.write_text(
+            dedent(
+                """\
+                version: 1
+                entries:
+                  - kind: forbidden_path_pattern
+                    pattern: "outputs/**"
+                    stop_condition: fail_closed_never_commit
+                    source: docs/policy.md
+                    bonus_field: 7
+                """
+            ),
+            encoding="utf-8",
+        )
+        rule = _make_rule(manifest_path=str(p))
+        _patch_with_pages(monkeypatch, _ok(_RESOLVE_OK), [])
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.UNAVAILABLE
+        ev = diag.evidence[0]
+        assert ev.kind == "manifest_error"
+        assert "bonus_field" in ev.data["unknown_fields"]
+
+
+# ---------------------------------------------------------------------------
+# GitHub PR mode — pass and fail paths via the existing PR file-list machinery
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubPrMode:
+    def test_pass_when_no_changed_files_match(self, monkeypatch, manifest_file):
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [_ok(_files_response(["source/official/source-index.yaml", "README.md"]))],
+        )
+        rule = _make_rule(manifest_path=str(manifest_file))
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.PASS
+        ev = diag.evidence[0]
+        assert ev.kind == "changed_file_policy"
+        assert ev.data["total_changed_files"] == 2
+        assert ev.data["violations"] == []
+        assert ev.data["source"].startswith("github_pr:")
+
+    def test_fail_on_forbidden_pdf(self, monkeypatch, manifest_file):
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [_ok(_files_response(["source/official/call.pdf", "README.md"]))],
+        )
+        rule = _make_rule(manifest_path=str(manifest_file))
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        ev = diag.evidence[0]
+        violations = ev.data["violations"]
+        assert len(violations) == 1
+        v = violations[0]
+        assert v["path"] == "source/official/call.pdf"
+        assert v["matched_pattern"] == "source/official/**/*.pdf"
+        assert v["stop_condition"] == "fail_closed_never_commit"
+        assert v["manifest_source"] == "docs/policy.md#3"
+        # Diagnostic carries remediation text identifying the file.
+        assert diag.remediation is not None
+        assert "source/official/call.pdf" in diag.remediation
+
+    def test_fail_on_forbidden_xlsx(self, monkeypatch, manifest_file):
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [_ok(_files_response(["outputs/foo.xlsx"]))],
+        )
+        rule = _make_rule(manifest_path=str(manifest_file))
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        v = diag.evidence[0].data["violations"][0]
+        assert v["path"] == "outputs/foo.xlsx"
+        assert v["matched_pattern"] == "outputs/**/*.xlsx"
+
+    def test_fail_on_researcher_raw(self, monkeypatch, manifest_file):
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [_ok(_files_response(["context/researcher/raw/interview.md"]))],
+        )
+        rule = _make_rule(manifest_path=str(manifest_file))
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        v = diag.evidence[0].data["violations"][0]
+        assert v["path"] == "context/researcher/raw/interview.md"
+        assert v["matched_pattern"] == "context/researcher/raw/**"
+
+    def test_fail_on_dotenv(self, monkeypatch, manifest_file):
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [_ok(_files_response([".env"]))],
+        )
+        rule = _make_rule(manifest_path=str(manifest_file))
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        v = diag.evidence[0].data["violations"][0]
+        assert v["path"] == ".env"
+        assert v["matched_pattern"] == "**/.env"
+
+    def test_multiple_violations_collected(self, monkeypatch, manifest_file):
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [
+                _ok(
+                    _files_response(
+                        [
+                            "source/official/call.pdf",
+                            "outputs/foo.xlsx",
+                            "README.md",
+                        ]
+                    )
+                )
+            ],
+        )
+        rule = _make_rule(manifest_path=str(manifest_file))
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        paths = {v["path"] for v in diag.evidence[0].data["violations"]}
+        assert paths == {"source/official/call.pdf", "outputs/foo.xlsx"}
+
+
+# ---------------------------------------------------------------------------
+# Manifest exceptions — known_allowed_exception entries exempt matching files
+# ---------------------------------------------------------------------------
+
+
+class TestExceptions:
+    def test_exception_exempts_matching_file(self, monkeypatch, tmp_path):
+        manifest = tmp_path / "with-exception.yaml"
+        manifest.write_text(
+            dedent(
+                """\
+                version: 1
+                entries:
+                  - kind: forbidden_path_pattern
+                    pattern: "outputs/**/*.xlsx"
+                    stop_condition: fail_closed_never_commit
+                    source: docs/policy.md
+                  - kind: known_allowed_exception
+                    pattern: "outputs/sample.xlsx"
+                    exempts_pattern: "outputs/**/*.xlsx"
+                    authorising_issue: "#42"
+                    source: docs/policy.md
+                """
+            ),
+            encoding="utf-8",
+        )
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [_ok(_files_response(["outputs/sample.xlsx", "outputs/other.xlsx"]))],
+        )
+        rule = _make_rule(manifest_path=str(manifest))
+        diag = gh_backend.check(rule, "owner/repo#42")
+        assert diag.status is Status.FAIL
+        # ``outputs/sample.xlsx`` must NOT appear in violations (exempted).
+        # ``outputs/other.xlsx`` must.
+        paths = {v["path"] for v in diag.evidence[0].data["violations"]}
+        assert paths == {"outputs/other.xlsx"}
+
+
+# ---------------------------------------------------------------------------
+# Local git mode — staged, unstaged, untracked, all
+# ---------------------------------------------------------------------------
+
+
+def _init_git_repo(repo: Path) -> None:
+    """Initialise a hermetic local git repo at *repo* with a baseline commit."""
+    subprocess.run(["git", "init", "--initial-branch=main", str(repo)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "test@example.com"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.name", "Test"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "commit.gpgsign", "false"],
+        check=True,
+        capture_output=True,
+    )
+    # Baseline file so subsequent diffs are well-defined.
+    (repo / "README.md").write_text("init\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "init"],
+        check=True,
+        capture_output=True,
+    )
+
+
+class TestLocalGitMode:
+    def test_local_staged_fail_on_forbidden(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_git_repo(repo)
+        # Stage a forbidden output.
+        (repo / "outputs").mkdir()
+        forbidden = repo / "outputs" / "foo.xlsx"
+        forbidden.write_text("garbage", encoding="utf-8")
+        subprocess.run(["git", "-C", str(repo), "add", "outputs/foo.xlsx"], check=True, capture_output=True)
+
+        manifest = tmp_path / "manifest.yaml"
+        manifest.write_text(_SAMPLE_MANIFEST, encoding="utf-8")
+
+        rule = _make_rule(
+            manifest_path=str(manifest),
+            changed_files_source="local_git",
+            local_git_mode="staged",
+            repo_root=str(repo),
+        )
+        diag = gh_backend.check(rule, str(repo))
+        assert diag.status is Status.FAIL
+        paths = {v["path"] for v in diag.evidence[0].data["violations"]}
+        assert "outputs/foo.xlsx" in paths
+        assert diag.evidence[0].data["source"] == "local_git:staged"
+
+    def test_local_staged_pass_on_clean(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_git_repo(repo)
+        # Stage an allowed file.
+        allowed = repo / "source"
+        allowed.mkdir()
+        (allowed / "official").mkdir()
+        (allowed / "official" / "source-index.yaml").write_text("x: 1\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "source/official/source-index.yaml"],
+            check=True,
+            capture_output=True,
+        )
+
+        manifest = tmp_path / "manifest.yaml"
+        manifest.write_text(_SAMPLE_MANIFEST, encoding="utf-8")
+
+        rule = _make_rule(
+            manifest_path=str(manifest),
+            changed_files_source="local_git",
+            local_git_mode="staged",
+            repo_root=str(repo),
+        )
+        diag = gh_backend.check(rule, str(repo))
+        assert diag.status is Status.PASS
+        assert diag.evidence[0].data["violations"] == []
+
+    def test_local_untracked_fail_on_forbidden(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_git_repo(repo)
+        # Create an untracked .env file (not staged).
+        (repo / ".env").write_text("SECRET=1\n", encoding="utf-8")
+
+        manifest = tmp_path / "manifest.yaml"
+        manifest.write_text(_SAMPLE_MANIFEST, encoding="utf-8")
+
+        rule = _make_rule(
+            manifest_path=str(manifest),
+            changed_files_source="local_git",
+            local_git_mode="untracked",
+            repo_root=str(repo),
+        )
+        diag = gh_backend.check(rule, str(repo))
+        assert diag.status is Status.FAIL
+        paths = {v["path"] for v in diag.evidence[0].data["violations"]}
+        assert ".env" in paths
+
+    def test_local_staged_and_unstaged_picks_up_both(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_git_repo(repo)
+        # Staged: outputs/a.xlsx ; Unstaged: edit README.md
+        (repo / "outputs").mkdir()
+        (repo / "outputs" / "a.xlsx").write_text("g", encoding="utf-8")
+        subprocess.run(["git", "-C", str(repo), "add", "outputs/a.xlsx"], check=True, capture_output=True)
+        # Modify README (unstaged).
+        (repo / "README.md").write_text("changed\n", encoding="utf-8")
+
+        manifest = tmp_path / "manifest.yaml"
+        manifest.write_text(_SAMPLE_MANIFEST, encoding="utf-8")
+
+        rule = _make_rule(
+            manifest_path=str(manifest),
+            changed_files_source="local_git",
+            local_git_mode="staged_and_unstaged",
+            repo_root=str(repo),
+        )
+        diag = gh_backend.check(rule, str(repo))
+        assert diag.status is Status.FAIL
+        # README.md unmodified by policy; outputs/a.xlsx is forbidden.
+        paths = {v["path"] for v in diag.evidence[0].data["violations"]}
+        assert paths == {"outputs/a.xlsx"}
+        assert diag.evidence[0].data["total_changed_files"] == 2
+
+    def test_local_all_includes_untracked(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_git_repo(repo)
+        # Untracked forbidden file.
+        (repo / "context").mkdir()
+        (repo / "context" / "researcher").mkdir()
+        (repo / "context" / "researcher" / "raw").mkdir()
+        (repo / "context" / "researcher" / "raw" / "interview.md").write_text("notes", encoding="utf-8")
+
+        manifest = tmp_path / "manifest.yaml"
+        manifest.write_text(_SAMPLE_MANIFEST, encoding="utf-8")
+
+        rule = _make_rule(
+            manifest_path=str(manifest),
+            changed_files_source="local_git",
+            local_git_mode="all",
+            repo_root=str(repo),
+        )
+        diag = gh_backend.check(rule, str(repo))
+        assert diag.status is Status.FAIL
+        paths = {v["path"] for v in diag.evidence[0].data["violations"]}
+        assert "context/researcher/raw/interview.md" in paths
+
+    def test_local_git_uses_target_as_repo_root_when_param_absent(self, tmp_path: Path):
+        """When ``repo_root`` param is absent the target string is used."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_git_repo(repo)
+        (repo / "outputs").mkdir()
+        (repo / "outputs" / "b.xlsx").write_text("g", encoding="utf-8")
+        subprocess.run(["git", "-C", str(repo), "add", "outputs/b.xlsx"], check=True, capture_output=True)
+
+        manifest = tmp_path / "manifest.yaml"
+        manifest.write_text(_SAMPLE_MANIFEST, encoding="utf-8")
+
+        rule = _make_rule(
+            manifest_path=str(manifest),
+            changed_files_source="local_git",
+            local_git_mode="staged",
+        )
+        diag = gh_backend.check(rule, str(repo))
+        assert diag.status is Status.FAIL
+        paths = {v["path"] for v in diag.evidence[0].data["violations"]}
+        assert "outputs/b.xlsx" in paths
+
+    def test_local_git_failure_unavailable(self, tmp_path: Path):
+        """A non-git directory must surface as UNAVAILABLE, not crash."""
+        not_a_repo = tmp_path / "plain"
+        not_a_repo.mkdir()
+
+        manifest = tmp_path / "manifest.yaml"
+        manifest.write_text(_SAMPLE_MANIFEST, encoding="utf-8")
+
+        rule = _make_rule(
+            manifest_path=str(manifest),
+            changed_files_source="local_git",
+            local_git_mode="staged",
+            repo_root=str(not_a_repo),
+        )
+        diag = gh_backend.check(rule, str(not_a_repo))
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "local_git_error"
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic shape — round-trip, evidence keys
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticShape:
+    def test_evidence_carries_manifest_metadata(self, monkeypatch, manifest_file):
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [_ok(_files_response(["source/official/call.pdf"]))],
+        )
+        rule = _make_rule(manifest_path=str(manifest_file))
+        diag = gh_backend.check(rule, "owner/repo#42")
+        ev = diag.evidence[0]
+        assert ev.kind == "changed_file_policy"
+        assert ev.data["manifest_path"] == str(manifest_file)
+        assert ev.data["forbidden_pattern_count"] >= 1
+        assert "violations" in ev.data
+        v = ev.data["violations"][0]
+        # The diagnostic must identify the exact manifest entry.
+        assert {"path", "matched_pattern", "stop_condition", "manifest_source", "note"} <= set(v.keys())
+
+    def test_diagnostic_round_trip(self, monkeypatch, manifest_file):
+        from gate_keeper.models import Diagnostic
+
+        _patch_with_pages(
+            monkeypatch,
+            _ok(_RESOLVE_OK),
+            [_ok(_files_response(["outputs/foo.xlsx"]))],
+        )
+        rule = _make_rule(manifest_path=str(manifest_file))
+        diag = gh_backend.check(rule, "owner/repo#42")
+        rt = Diagnostic.from_dict(diag.to_dict())
+        assert rt.status is Status.FAIL
+        assert rt.evidence[0].kind == "changed_file_policy"
+        assert rt.evidence[0].data["violations"][0]["path"] == "outputs/foo.xlsx"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -63,6 +63,7 @@ def test_rule_kind_members():
         "github_threads_resolved",
         "github_non_author_approval",
         "github_changed_files_absent",
+        "changed_file_policy",
         "semantic_rubric",
         "external_check",
     }


### PR DESCRIPTION
## Summary

Adds a deterministic, manifest-backed changed-file policy check that evaluates **only changed files** — from a GitHub PR or a local git working tree — against a repository-owned YAML manifest. No LLM calls. Designed for real-data intake repositories such as `uda-lab/spread-applicant-ai` to prevent rights-constrained or private artifacts from being committed to public Git history.

Closes #230

## Design

- New `RuleKind.CHANGED_FILE_POLICY` (`backend_hint = github`).
- Params:
  - `manifest_path` (required) — path to the YAML policy manifest.
  - `changed_files_source` (required) — `"github_pr"` or `"local_git"`.
  - `local_git_mode` — `staged | unstaged | staged_and_unstaged | untracked | all` (default `staged_and_unstaged`).
  - `repo_root` — directory used for git commands (defaults to target string / cwd).
- PR-side path **reuses the existing `_fetch_changed_files` pagination** from `github_changed_files_absent`, so the two compose cleanly rather than forking a parallel policy engine.
- Local-git path collects changed paths via `git diff` / `git ls-files --others --exclude-standard` in a subprocess (30 s timeout, no shell).
- Manifest schema is a strict subset of the [`spread-applicant-ai/policy-manifests/path-rules.yaml`](https://github.com/uda-lab/spread-applicant-ai/blob/main/policy-manifests/path-rules.yaml) contract:
  - Entry kinds: `forbidden_path_pattern`, `known_allowed_exception`, `generated_output_extension`, `authored_text_extension`.
  - Unknown top-level keys, unknown entry kinds, and unknown entry fields all fail closed with `manifest_error` evidence.
  - Arbitrary YAML tags are never evaluated (`yaml.safe_load`).
- Diagnostics identify the exact manifest entry per finding (`matched_pattern`, `stop_condition`, `manifest_source`). A `remediation` block lists the offending paths with their manifest sources.

## Tests

`tests/test_changed_file_policy.py` — 28 tests covering:

- params validation (missing / invalid `manifest_path`, `changed_files_source`, `local_git_mode`);
- manifest parser fail-closed paths (missing file, malformed YAML, unsupported version, missing/extra top-level keys, unknown entry kind, missing / unknown entry fields);
- GitHub PR mode: pass and fail on the issue's fixture set (`source/official/source-index.yaml` allowed; `source/official/call.pdf`, `outputs/foo.xlsx`, `context/researcher/raw/interview.md`, `.env` forbidden);
- multiple violations collected;
- `known_allowed_exception` correctly exempts matching files;
- local-git modes: `staged`, `staged_and_unstaged`, `untracked`, `all`, fallback to target as `repo_root`, non-git directory surfacing as `unavailable`;
- diagnostic round-trip via `Diagnostic.from_dict(diag.to_dict())`.

## Docs

- `docs/rule-ir.md` — new section `changed_file_policy — manifest-backed changed-file policy` with params, manifest schema, evidence shape, and failure-mode table; rule-kind enum updated.
- `docs/example-rules.md` — new section `4b. Manifest-backed changed-file policy` with both PR and local-git invocation examples.
- `docs/cli-reference.md` — new note explicitly stating this is **deterministic changed-file policy, not semantic content review**.

## Validation

- `uv run pytest` — **1386 passed**, including 28 new tests for this rule kind.
- `uvx ruff check .` — clean.
- `uvx ruff format --check .` — 73 files already formatted.
- `uvx pyright` — no new errors; the one new warning is the same `Import "yaml" could not be resolved from source` stub-missing warning that already exists for `src/gate_keeper/backends/filesystem.py`, `src/gate_keeper/matrix.py`, and the dependency-gates scripts.

## Test plan

- [x] `uv run pytest` clean
- [x] `uvx ruff check .` clean
- [x] `uvx ruff format --check .` clean
- [x] `uvx pyright` no new errors (one consistent `yaml` stub warning matching pre-existing pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)