### PR TITLE
feat(llm-rubric): model-class-aware reasoning_effort defaults for gpt-5* (#233)

### DIFF
--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -1120,7 +1120,7 @@ def _call_anthropic(api_key: str, system: str, user: str, model: str) -> tuple[s
 # Reasoning-class model support (#233)
 # ---------------------------------------------------------------------------
 
-# Longest-prefix lookup table for reasoning_effort defaults.
+# Raw reasoning_effort defaults — declaration order does not matter.
 #
 # Empirical evidence (issue #226, 2026-05-12):
 #   gpt-5   (enum: minimal/low/medium/high)  → minimal is the only passing tier
@@ -1129,14 +1129,20 @@ def _call_anthropic(api_key: str, system: str, user: str, model: str) -> tuple[s
 # o1* / o3* are out of scope for this account (models not accessible); they
 # are omitted from the table intentionally.  If they become available, add
 # entries here following the same pattern.
-#
-# Entries MUST be sorted longest-first so that iteration delivers the
-# most-specific match first (e.g. "gpt-5.4" beats "gpt-5").
-_REASONING_EFFORT_TABLE: list[tuple[str, str]] = [
-    ("gpt-5.4", "none"),
-    ("gpt-5", "minimal"),
+_REASONING_EFFORT_RAW: dict[str, str] = {
+    "gpt-5": "minimal",
+    "gpt-5.4": "none",
     # o1 / o3 entries would go here when accessible
-]
+}
+
+# Programmatically sorted longest-prefix-first list, derived from
+# _REASONING_EFFORT_RAW at module import time.  Sorting at init prevents
+# append-out-of-order regressions in _reasoning_effort_for() — declaration
+# order in _REASONING_EFFORT_RAW is intentionally not load-bearing.
+_REASONING_EFFORT_TABLE: list[tuple[str, str]] = sorted(
+    _REASONING_EFFORT_RAW.items(),
+    key=lambda kv: -len(kv[0]),
+)
 
 # Models whose names start with one of these prefixes are treated as
 # reasoning-class.  Keep in sync with _REASONING_EFFORT_TABLE prefixes.

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -1116,6 +1116,57 @@ def _call_anthropic(api_key: str, system: str, user: str, model: str) -> tuple[s
     }
 
 
+# ---------------------------------------------------------------------------
+# Reasoning-class model support (#233)
+# ---------------------------------------------------------------------------
+
+# Longest-prefix lookup table for reasoning_effort defaults.
+#
+# Empirical evidence (issue #226, 2026-05-12):
+#   gpt-5   (enum: minimal/low/medium/high)  → minimal is the only passing tier
+#   gpt-5.4 (enum: none/low/medium/high/xhigh) → none is the only passing tier
+#
+# o1* / o3* are out of scope for this account (models not accessible); they
+# are omitted from the table intentionally.  If they become available, add
+# entries here following the same pattern.
+#
+# Entries MUST be sorted longest-first so that iteration delivers the
+# most-specific match first (e.g. "gpt-5.4" beats "gpt-5").
+_REASONING_EFFORT_TABLE: list[tuple[str, str]] = [
+    ("gpt-5.4", "none"),
+    ("gpt-5", "minimal"),
+    # o1 / o3 entries would go here when accessible
+]
+
+# Models whose names start with one of these prefixes are treated as
+# reasoning-class.  Keep in sync with _REASONING_EFFORT_TABLE prefixes.
+_REASONING_CLASS_PREFIXES: tuple[str, ...] = ("gpt-5", "o1", "o3")
+
+# Token budget for reasoning-class models.  600 starves them (most tokens
+# are consumed internally for reasoning; too few remain for the visible
+# response).  2000 is empirically sufficient (#226 sweep: tokens_out ≈ 250).
+_REASONING_MAX_COMPLETION_TOKENS: int = 2000
+_DEFAULT_MAX_COMPLETION_TOKENS: int = 600
+
+
+def _is_reasoning_class(model: str) -> bool:
+    """Return True if *model* is a reasoning-class model (gpt-5*, o1*, o3*)."""
+    return model.startswith(_REASONING_CLASS_PREFIXES)
+
+
+def _reasoning_effort_for(model: str) -> str | None:
+    """Return the ``reasoning_effort`` value for *model*, or ``None``.
+
+    Uses a longest-prefix match against :data:`_REASONING_EFFORT_TABLE`.
+    Returns ``None`` when the model is reasoning-class but no entry covers it
+    (fail-open: let the API default apply).
+    """
+    for prefix, effort in _REASONING_EFFORT_TABLE:
+        if model.startswith(prefix):
+            return effort
+    return None
+
+
 def _call_openai(api_key: str, system: str, user: str, model: str) -> tuple[str, dict[str, int]]:
     """Call OpenAI and return ``(response_text, telemetry)``.
 
@@ -1132,19 +1183,39 @@ def _call_openai(api_key: str, system: str, user: str, model: str) -> tuple[str,
     ``usage`` object), raise :class:`RuntimeError`. The caller in
     :func:`check` catches this and dispatches a ``provider_error``
     diagnostic; we never synthesise a zero token count.
+
+    Reasoning-class models (#233): ``gpt-5*``, ``o1*``, ``o3*`` receive a
+    model-family-specific ``reasoning_effort`` at the lowest tier
+    (``minimal`` for gpt-5, ``none`` for gpt-5.4) and a raised
+    ``max_completion_tokens`` (2000 vs 600) so the visible response is not
+    starved by reasoning token consumption.
     """
     from openai import OpenAI
 
+    reasoning = _is_reasoning_class(model)
+    max_tokens = _REASONING_MAX_COMPLETION_TOKENS if reasoning else _DEFAULT_MAX_COMPLETION_TOKENS
+
+    effort: str | None = _reasoning_effort_for(model) if reasoning else None
+
     client = OpenAI(api_key=api_key)
     start = time.perf_counter()
-    resp = client.chat.completions.create(
-        model=model,
-        max_completion_tokens=600,
-        messages=[
-            {"role": "system", "content": system},
-            {"role": "user", "content": user},
-        ],
-    )
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+    if effort is not None:
+        resp = client.chat.completions.create(
+            model=model,
+            max_completion_tokens=max_tokens,
+            messages=messages,  # type: ignore[arg-type]
+            reasoning_effort=effort,  # type: ignore[arg-type]
+        )
+    else:
+        resp = client.chat.completions.create(
+            model=model,
+            max_completion_tokens=max_tokens,
+            messages=messages,  # type: ignore[arg-type]
+        )
     latency_ms = int(round((time.perf_counter() - start) * 1000))
     text = resp.choices[0].message.content or ""
     usage = getattr(resp, "usage", None)

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -4573,7 +4573,7 @@ class TestFindPerTargetFabricatedQuotes:
         """Smart-quote differences between quote and artifact are tolerated."""
         quotes = ["don’t"]  # RIGHT SINGLE QUOTATION MARK
         target_ids = ["a"]
-        texts = {"a": "please don’t do this"}  # ASCII apostrophe
+        texts = {"a": "please don't do this"}  # ASCII apostrophe
         result = llm_backend._find_per_target_fabricated_quotes(quotes, target_ids, texts)
         assert result == []
 
@@ -4739,3 +4739,62 @@ class TestReasoningEffortParamRouting:
         captured = self._patch_openai(monkeypatch)
         llm_backend._call_openai("sk-test", "system", "user", "gpt-4o-mini")
         assert captured[0]["max_completion_tokens"] == 600
+
+    # ------------------------------------------------------------------
+    # _call_openai kwargs: o1*/o3* — reasoning-class without table entry
+    # ------------------------------------------------------------------
+    # These models match the prefix detector (so they get the raised token
+    # budget) but have no entry in _REASONING_EFFORT_RAW (fail-open: no
+    # reasoning_effort kwarg passed, API default applies).  The pattern
+    # locks in the intended behaviour described in #233.
+
+    def test_o1_no_reasoning_effort_kwarg(self, monkeypatch):
+        captured = self._patch_openai(monkeypatch)
+        llm_backend._call_openai("sk-test", "system", "user", "o1")
+        assert "reasoning_effort" not in captured[0]
+
+    def test_o1_uses_reasoning_class_token_budget(self, monkeypatch):
+        captured = self._patch_openai(monkeypatch)
+        llm_backend._call_openai("sk-test", "system", "user", "o1")
+        assert captured[0]["max_completion_tokens"] == 2000
+
+    def test_o3_mini_no_reasoning_effort_kwarg(self, monkeypatch):
+        captured = self._patch_openai(monkeypatch)
+        llm_backend._call_openai("sk-test", "system", "user", "o3-mini")
+        assert "reasoning_effort" not in captured[0]
+
+    def test_o3_mini_uses_reasoning_class_token_budget(self, monkeypatch):
+        captured = self._patch_openai(monkeypatch)
+        llm_backend._call_openai("sk-test", "system", "user", "o3-mini")
+        assert captured[0]["max_completion_tokens"] == 2000
+
+    # ------------------------------------------------------------------
+    # Longest-prefix sort robustness (#233 review thread 3)
+    # ------------------------------------------------------------------
+
+    def test_longest_prefix_table_is_sorted_descending(self):
+        """_REASONING_EFFORT_TABLE must be sorted longest-prefix-first.
+
+        Programmatic sort at module init prevents append-out-of-order
+        regressions in _reasoning_effort_for().
+        """
+        lengths = [len(prefix) for prefix, _ in llm_backend._REASONING_EFFORT_TABLE]
+        assert lengths == sorted(lengths, reverse=True)
+
+    def test_longest_prefix_survives_raw_table_disorder(self, monkeypatch):
+        """Even if _REASONING_EFFORT_RAW is patched with reversed order,
+        the sorted table _REASONING_EFFORT_TABLE keeps longest-prefix
+        semantics. We simulate this by patching the table directly with a
+        bad-order list and confirming the dedicated longest-match helper
+        below (or a re-sort) preserves correctness.
+
+        This test serialises the contract: longest-prefix wins regardless
+        of how entries are declared in the raw dict.
+        """
+        # Bad-order list: shorter prefix declared first.
+        bad_order = [("gpt-5", "minimal"), ("gpt-5.4", "none")]
+        # Sorting it the same way the module does at init yields longest-first.
+        sorted_table = sorted(bad_order, key=lambda kv: -len(kv[0]))
+        monkeypatch.setattr(llm_backend, "_REASONING_EFFORT_TABLE", sorted_table)
+        assert llm_backend._reasoning_effort_for("gpt-5.4") == "none"
+        assert llm_backend._reasoning_effort_for("gpt-5") == "minimal"

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -4573,6 +4573,169 @@ class TestFindPerTargetFabricatedQuotes:
         """Smart-quote differences between quote and artifact are tolerated."""
         quotes = ["don’t"]  # RIGHT SINGLE QUOTATION MARK
         target_ids = ["a"]
-        texts = {"a": "please don't do this"}  # ASCII apostrophe
+        texts = {"a": "please don’t do this"}  # ASCII apostrophe
         result = llm_backend._find_per_target_fabricated_quotes(quotes, target_ids, texts)
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Reasoning-class model param routing (#233)
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningEffortParamRouting:
+    """Verify that _call_openai passes correct reasoning_effort / max_completion_tokens
+    per model family (#233).
+
+    All tests stub OpenAI().chat.completions.create to capture kwargs so that
+    no real network call is made.  The disable_llm_dotenv autouse fixture
+    (conftest.py) ensures no host credential file is read.
+    """
+
+    def _make_fake_response(self):
+        """Return a minimal fake openai ChatCompletion response object."""
+        import types
+
+        usage = types.SimpleNamespace(prompt_tokens=10, completion_tokens=5)
+        _content = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "ok",
+                "supporting_evidence_quotes": [],
+                "suggested_action": None,
+            }
+        )
+        message = types.SimpleNamespace(content=_content)
+        choice = types.SimpleNamespace(message=message)
+        return types.SimpleNamespace(choices=[choice], usage=usage)
+
+    def _patch_openai(self, monkeypatch):
+        """Patch OpenAI client so create() records kwargs and returns a fake response.
+
+        Returns a list that is appended to on each create() call:
+            [{"model": ..., "max_completion_tokens": ..., "reasoning_effort": ..., ...}]
+        """
+        captured: list[dict] = []
+        fake_response = self._make_fake_response()
+
+        import openai as _openai_module
+
+        class FakeCompletions:
+            def create(self, **kwargs):
+                captured.append(dict(kwargs))
+                return fake_response
+
+        class FakeChat:
+            completions = FakeCompletions()
+
+        class FakeClient:
+            chat = FakeChat()
+
+        monkeypatch.setattr(_openai_module, "OpenAI", lambda **kw: FakeClient())
+        return captured
+
+    # ------------------------------------------------------------------
+    # _is_reasoning_class
+    # ------------------------------------------------------------------
+
+    def test_is_reasoning_class_gpt5(self):
+        assert llm_backend._is_reasoning_class("gpt-5") is True
+
+    def test_is_reasoning_class_gpt5_dot4(self):
+        assert llm_backend._is_reasoning_class("gpt-5.4") is True
+
+    def test_is_reasoning_class_gpt5_suffix(self):
+        assert llm_backend._is_reasoning_class("gpt-5.99") is True
+
+    def test_is_reasoning_class_o1(self):
+        assert llm_backend._is_reasoning_class("o1") is True
+
+    def test_is_reasoning_class_o3(self):
+        assert llm_backend._is_reasoning_class("o3-mini") is True
+
+    def test_is_reasoning_class_gpt4o_false(self):
+        assert llm_backend._is_reasoning_class("gpt-4o") is False
+
+    def test_is_reasoning_class_gpt4o_mini_false(self):
+        assert llm_backend._is_reasoning_class("gpt-4o-mini") is False
+
+    def test_is_reasoning_class_claude_false(self):
+        assert llm_backend._is_reasoning_class("claude-sonnet-4-6") is False
+
+    # ------------------------------------------------------------------
+    # _reasoning_effort_for
+    # ------------------------------------------------------------------
+
+    def test_effort_gpt5_minimal(self):
+        assert llm_backend._reasoning_effort_for("gpt-5") == "minimal"
+
+    def test_effort_gpt5_dot4_none(self):
+        assert llm_backend._reasoning_effort_for("gpt-5.4") == "none"
+
+    def test_effort_gpt5_dot4_longest_prefix(self):
+        """gpt-5.4 must match before gpt-5 (longest-prefix wins)."""
+        effort = llm_backend._reasoning_effort_for("gpt-5.4")
+        assert effort == "none"
+
+    def test_effort_gpt5_unknown_subversion_falls_back_to_gpt5(self):
+        """gpt-5.99 → no dedicated entry → matches gpt-5 → minimal."""
+        assert llm_backend._reasoning_effort_for("gpt-5.99") == "minimal"
+
+    def test_effort_gpt4o_none(self):
+        """Non-reasoning models return None (no effort param)."""
+        assert llm_backend._reasoning_effort_for("gpt-4o") is None
+
+    # ------------------------------------------------------------------
+    # _call_openai kwargs: reasoning-class models
+    # ------------------------------------------------------------------
+
+    def test_gpt5_gets_reasoning_effort_minimal(self, monkeypatch):
+        captured = self._patch_openai(monkeypatch)
+        llm_backend._call_openai("sk-test", "system", "user", "gpt-5")
+        assert len(captured) == 1
+        assert captured[0]["reasoning_effort"] == "minimal"
+
+    def test_gpt5_gets_max_completion_tokens_2000(self, monkeypatch):
+        captured = self._patch_openai(monkeypatch)
+        llm_backend._call_openai("sk-test", "system", "user", "gpt-5")
+        assert captured[0]["max_completion_tokens"] == 2000
+
+    def test_gpt5_dot4_gets_reasoning_effort_none(self, monkeypatch):
+        captured = self._patch_openai(monkeypatch)
+        llm_backend._call_openai("sk-test", "system", "user", "gpt-5.4")
+        assert captured[0]["reasoning_effort"] == "none"
+
+    def test_gpt5_dot4_gets_max_completion_tokens_2000(self, monkeypatch):
+        captured = self._patch_openai(monkeypatch)
+        llm_backend._call_openai("sk-test", "system", "user", "gpt-5.4")
+        assert captured[0]["max_completion_tokens"] == 2000
+
+    def test_gpt5_unknown_subversion_gets_minimal(self, monkeypatch):
+        """gpt-5.99 longest-prefix-matches gpt-5 → minimal."""
+        captured = self._patch_openai(monkeypatch)
+        llm_backend._call_openai("sk-test", "system", "user", "gpt-5.99")
+        assert captured[0]["reasoning_effort"] == "minimal"
+
+    # ------------------------------------------------------------------
+    # _call_openai kwargs: non-reasoning models (unchanged behaviour)
+    # ------------------------------------------------------------------
+
+    def test_gpt4o_no_reasoning_effort(self, monkeypatch):
+        captured = self._patch_openai(monkeypatch)
+        llm_backend._call_openai("sk-test", "system", "user", "gpt-4o")
+        assert "reasoning_effort" not in captured[0]
+
+    def test_gpt4o_mini_no_reasoning_effort(self, monkeypatch):
+        captured = self._patch_openai(monkeypatch)
+        llm_backend._call_openai("sk-test", "system", "user", "gpt-4o-mini")
+        assert "reasoning_effort" not in captured[0]
+
+    def test_gpt4o_max_completion_tokens_600(self, monkeypatch):
+        captured = self._patch_openai(monkeypatch)
+        llm_backend._call_openai("sk-test", "system", "user", "gpt-4o")
+        assert captured[0]["max_completion_tokens"] == 600
+
+    def test_gpt4o_mini_max_completion_tokens_600(self, monkeypatch):
+        captured = self._patch_openai(monkeypatch)
+        llm_backend._call_openai("sk-test", "system", "user", "gpt-4o-mini")
+        assert captured[0]["max_completion_tokens"] == 600


### PR DESCRIPTION
## Summary

Reasoning-class OpenAI models (`gpt-5*`, `o1*`, `o3*`) overthink themselves into wrong verdicts at the API-default reasoning tier (medium). Per #226 empirical sweeps:

| model | passing tier | enum |
|---|---|---|
| `gpt-5`   | **`minimal`** | `minimal / low / medium / high` |
| `gpt-5.4` | **`none`**    | `none / low / medium / high / xhigh` |

Without an explicit setting, `gpt-5*` in the regular bench produces `unparseable_response` / `unsupported` / `fail` instead of the correct PASS.

This PR wires a model-class-aware default in `_call_openai`:

- Detect reasoning-class models by prefix (`gpt-5`, `o1`, `o3`).
- Select `reasoning_effort` via a longest-prefix lookup table so `gpt-5.4` beats `gpt-5` and future `gpt-5.x` variants fall back to the family default.
- Raise `max_completion_tokens` 600 → 2000 for reasoning-class models so the visible response is not starved by internal reasoning consumption.
- Leave non-reasoning models (`gpt-4o`, `gpt-4o-mini`, anthropic) unchanged.

`o1*` / `o3*` are kept in the prefix detector but omitted from the lookup table (fail-open to API default) — verified inaccessible on this account (`404 model_not_found`). Add entries when they become available.

## Bench validation (real provider, no monkey-patching)

`scripts/llm_rubric_model_matrix.py --models <m> --entries-dir /tmp/bench-c1-staging/entries --reproducibility 3`:

| label          | accuracy | tokens_in | tokens_out | latency_ms |
|----------------|----------|-----------|------------|------------|
| `openai:gpt-5`   | **1.0** | 3066 | 204 | 7773 |
| `openai:gpt-5.4` | **1.0** | 3066 | 287 | 5698 |

Both now produce PASS on clarity-01 — the failure mode #226 documented is gone.

## Validation summary

- `uv run pytest` — **1416 passed**
  - includes 22 new hermetic tests in `TestReasoningEffortParamRouting` covering: `_is_reasoning_class`, `_reasoning_effort_for` (incl. longest-prefix-match), and `_call_openai` kwargs routing for `gpt-5`, `gpt-5.4`, `gpt-5.99` (unknown subversion → minimal), `gpt-4o`, `gpt-4o-mini`.
- `uvx ruff check .` — All checks passed.
- `uv run pyright src/gate_keeper/backends/llm_rubric.py` — 0 errors.

## Notes

- Tests stub `OpenAI().chat.completions.create` to capture kwargs under the `disable_llm_dotenv` autouse fixture (#180) — no network, no host credentials.
- `o1`/`o3` enum probe returned `404 model_not_found` on this account, so they are intentionally left out of the lookup table per #233 spec ("fail-open to API default if no entry matches").

Closes #233

Refs: #164 (umbrella), #226 (empirical evidence), #180 (hermetic-test fixture).