### PR TITLE
feat(scripts): one-off classifier-feedback sampler — gpt-5 routing audit (#235)

### DIFF
--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -26,6 +26,23 @@ considering that:
 
 Use `severity=advisory` or `severity=warning` for semantic rules.
 
+### Ad-hoc routing audit (`scripts/classify_semantic_candidates.py`)
+
+A one-off utility script asks `gpt-5` (minimal reasoning) whether each
+`semantic_rubric`-fallback rule in a rules file could be evaluated
+deterministically by `filesystem`, `github`, or `external+textlint`, and
+emits a JSON report for human triage. It does **not** change classifier
+behavior; the report is read-only triage input. Not wired into bench or CI.
+
+```sh
+uv run python scripts/classify_semantic_candidates.py \
+    --rules docs/dogfooding-rules.md \
+    [--model openai:gpt-5] \
+    [--out report.json]
+```
+
+Refs: issue #235, #75 (classifier feedback loop, slice 1).
+
 ## Default behavior (no provider configured)
 
 If no provider is configured (the host-side dotenv file is absent or

--- a/scripts/classify_semantic_candidates.py
+++ b/scripts/classify_semantic_candidates.py
@@ -123,6 +123,26 @@ def _audit_rule(rule: Any, api_key: str, model: str, dry_run: bool) -> dict[str,
         proposed_pattern = None
         rationale = response_text.strip()
 
+    # Normalise inconsistent payloads (copilot review feedback on #236):
+    # - If the model says ``can_be_deterministic=false``, force the bucket to
+    #   ``"none"`` and drop any suggested pattern regardless of what the model
+    #   wrote for ``proposed_backend``.
+    # - If the model says ``can_be_deterministic=true`` but proposed_backend is
+    #   ``"none"`` / null / not one of the three deterministic buckets, treat
+    #   the payload as inconsistent and fail-closed to ``"none"`` (with a
+    #   prefixed rationale so the inconsistency is visible in the report).
+    _DETERMINISTIC_BACKENDS = ("filesystem", "github", "external+textlint")
+    if not can_be_det:
+        proposed_backend = "none"
+        proposed_pattern = None
+    elif proposed_backend not in _DETERMINISTIC_BACKENDS:
+        rationale = (
+            f"[inconsistent payload: can_be_deterministic=true but "
+            f"proposed_backend={proposed_backend!r}] {rationale}"
+        )
+        proposed_backend = "none"
+        proposed_pattern = None
+
     result: dict[str, Any] = {
         "rule_id": rule.id,
         "rule_text": rule.text,
@@ -209,8 +229,26 @@ def run_audit(
     Returns the JSON report dict. In dry-run mode the API is not called and
     the report contains ``"dry_run": true`` and an empty ``candidates_by_backend``.
 
-    Raises ``RuntimeError`` if the provider is not configured (unless dry_run).
+    Raises ``RuntimeError`` if the provider is not configured (unless dry_run),
+    or ``ValueError`` if *model* declares a non-openai provider prefix (this
+    slice is openai-only; see copilot review feedback on #236).
     """
+    # Enforce openai-only provider for this slice (copilot review feedback on
+    # #236). The slice's routing-auditor prompt is calibrated for gpt-5 minimal
+    # reasoning; honouring an ``anthropic:`` prefix here would silently call
+    # ``_call_openai`` with a non-openai model name and a missing API key. The
+    # cleanest fix is to validate the prefix at the boundary and fail-closed.
+    if ":" in model:
+        provider, raw_model = model.split(":", 1)
+        if provider != "openai":
+            raise ValueError(
+                f"--model {model!r}: this script is openai-only for slice 1; "
+                f"got provider {provider!r}. Use an 'openai:<model>' identifier "
+                "(e.g. 'openai:gpt-5')."
+            )
+    else:
+        raw_model = model
+
     # Parse + classify the rules file.
     ruleset = parse_file(rules_path)
     classified = classify(ruleset)
@@ -220,18 +258,11 @@ def run_audit(
         env = _llm._load_env_file()
         if not env.get("OPENAI_API_KEY"):
             raise RuntimeError(
-                "OPENAI_API_KEY not found in dotenv. "
-                "Configure it in /home/vscode/.config/hermes-projects/gate-keeper.env "
-                "or use --dry-run."
+                f"OPENAI_API_KEY not found in dotenv. Configure it in {_llm.DOTENV_PATH} or use --dry-run."
             )
         api_key = env["OPENAI_API_KEY"]
     else:
         api_key = ""
-
-    # Strip "provider:" prefix to pass bare model name to _call_openai.
-    raw_model = model
-    if ":" in model:
-        _, raw_model = model.split(":", 1)
 
     results: list[dict[str, Any]] = []
     for rule in fallback_rules:

--- a/scripts/classify_semantic_candidates.py
+++ b/scripts/classify_semantic_candidates.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""One-off routing-audit script for llm-rubric fallback rules (#235, #75 slice 1).
+
+Asks gpt-5 (minimal reasoning) whether each ``semantic_rubric``-fallback rule
+could be evaluated deterministically by ``filesystem``, ``github``, or
+``external+textlint``, and emits a JSON report for human triage.
+
+This is a **read-only utility** — no classifier behavior is changed.
+
+Usage::
+
+    uv run python scripts/classify_semantic_candidates.py \\
+        --rules docs/dogfooding-rules.md \\
+        [--model openai:gpt-5] \\
+        [--out /tmp/report.json]
+
+    # dry-run: print prompts without calling the API
+    uv run python scripts/classify_semantic_candidates.py \\
+        --rules docs/dogfooding-rules.md \\
+        --dry-run
+
+Refs: issue #235, #75, umbrella #164.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Allow running as ``python scripts/classify_semantic_candidates.py`` without a
+# prior ``uv pip install -e .`` by inserting the in-tree ``src/`` onto sys.path
+# when the package is not already importable.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from gate_keeper.backends import llm_rubric as _llm  # noqa: E402
+from gate_keeper.classifier import classify  # noqa: E402
+from gate_keeper.models import Backend, RuleKind  # noqa: E402
+from gate_keeper.parser import parse_file  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Routing-auditor prompt
+# ---------------------------------------------------------------------------
+
+_SYSTEM_PROMPT = """\
+You are a routing classifier auditor for the gate-keeper tool.
+The tool routes rule texts to one of four backends:
+  - filesystem: file/path/existence predicates (e.g. "README.md must exist", \
+"must not contain text X")
+  - github: PR/check/label/review-state predicates via `gh` (e.g. "PR must \
+not be a draft")
+  - external+textlint: mechanical prose patterns — keyword/terminology/style \
+(e.g. "must not use passive voice")
+  - llm-rubric: judgment-level quality checks that require reading prose and \
+forming an opinion
+
+Could this rule's verdict be determined WITHOUT LLM judgment?
+Respond as JSON with exactly these keys:
+  "can_be_deterministic": true or false
+  "proposed_backend": one of "filesystem", "github", "external+textlint", or null
+  "proposed_pattern": a regex or short description, or null
+  "rationale": one sentence explaining your decision
+
+Return only the JSON object, no surrounding text.\
+"""
+
+_USER_TEMPLATE = 'Rule text: "{rule_text}"'
+
+# ---------------------------------------------------------------------------
+# Filter: identify semantic_rubric fallback rules
+# ---------------------------------------------------------------------------
+
+
+def _is_semantic_fallback(rule: Any) -> bool:
+    """Return True iff *rule* landed in the semantic_rubric fallback bucket.
+
+    A rule is a semantic-rubric fallback when:
+    - backend_hint == Backend.LLM_RUBRIC, AND
+    - kind == RuleKind.SEMANTIC_RUBRIC.
+
+    Rules explicitly authored as ``external_check`` (kind == EXTERNAL_CHECK)
+    or classified deterministic (backend != LLM_RUBRIC) are excluded.
+    """
+    return rule.backend_hint == Backend.LLM_RUBRIC and rule.kind == RuleKind.SEMANTIC_RUBRIC
+
+
+# ---------------------------------------------------------------------------
+# Per-rule audit call
+# ---------------------------------------------------------------------------
+
+
+def _audit_rule(rule: Any, api_key: str, model: str, dry_run: bool) -> dict[str, Any]:
+    """Call the routing-auditor prompt for one rule and return a result dict."""
+    user_msg = _USER_TEMPLATE.format(rule_text=rule.text)
+
+    if dry_run:
+        print(f"[dry-run] rule_id={rule.id}")
+        print(f"  SYSTEM: {_SYSTEM_PROMPT[:120]}...")
+        print(f"  USER:   {user_msg}")
+        return {
+            "rule_id": rule.id,
+            "rule_text": rule.text,
+            "dry_run": True,
+        }
+
+    response_text, telemetry = _llm._call_openai(api_key, _SYSTEM_PROMPT, user_msg, model)
+
+    # Parse JSON response; fall back to a raw record on parse error.
+    try:
+        parsed = json.loads(response_text)
+        can_be_det = bool(parsed.get("can_be_deterministic", False))
+        proposed_backend = parsed.get("proposed_backend") or "none"
+        proposed_pattern = parsed.get("proposed_pattern")
+        rationale = str(parsed.get("rationale", ""))
+    except (json.JSONDecodeError, ValueError):
+        can_be_det = False
+        proposed_backend = "none"
+        proposed_pattern = None
+        rationale = response_text.strip()
+
+    result: dict[str, Any] = {
+        "rule_id": rule.id,
+        "rule_text": rule.text,
+        "can_be_deterministic": can_be_det,
+        "proposed_backend": proposed_backend,
+        "rationale": rationale,
+    }
+    if proposed_pattern is not None:
+        result["suggested_pattern"] = proposed_pattern
+    result["_telemetry"] = telemetry
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Report aggregation
+# ---------------------------------------------------------------------------
+
+
+def _build_report(results: list[dict[str, Any]], model: str) -> dict[str, Any]:
+    """Aggregate per-rule results into the final JSON report shape."""
+    candidates_by_backend: dict[str, list[dict[str, Any]]] = {
+        "filesystem": [],
+        "github": [],
+        "external+textlint": [],
+        "none": [],
+    }
+
+    total_tokens_in = 0
+    total_tokens_out = 0
+    has_unknown_cost = False
+
+    for r in results:
+        if r.get("dry_run"):
+            continue
+        backend_key = r.get("proposed_backend", "none")
+        if backend_key not in candidates_by_backend:
+            backend_key = "none"
+
+        entry: dict[str, Any] = {
+            "rule_id": r["rule_id"],
+            "rationale": r.get("rationale", ""),
+        }
+        if backend_key != "none" and "suggested_pattern" in r:
+            entry["suggested_pattern"] = r["suggested_pattern"]
+
+        candidates_by_backend[backend_key].append(entry)
+
+        tel = r.get("_telemetry", {})
+        total_tokens_in += tel.get("tokens_in", 0)
+        total_tokens_out += tel.get("tokens_out", 0)
+        if not tel:
+            has_unknown_cost = True
+
+    # Derive model name from "provider:model" or plain model string.
+    raw_model = model
+    if ":" in model:
+        _, raw_model = model.split(":", 1)
+
+    cost: float | None = _llm._estimate_cost(raw_model, total_tokens_in, total_tokens_out)
+    if has_unknown_cost:
+        cost = None
+
+    report: dict[str, Any] = {
+        "model": model,
+        "rules_evaluated": len([r for r in results if not r.get("dry_run")]),
+        "candidates_by_backend": candidates_by_backend,
+        "total_cost_estimate_usd": cost,
+    }
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Core run function (importable for tests)
+# ---------------------------------------------------------------------------
+
+
+def run_audit(
+    rules_path: str | Path,
+    model: str = "openai:gpt-5",
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Parse *rules_path*, filter to semantic-rubric fallback rules, audit each.
+
+    Returns the JSON report dict. In dry-run mode the API is not called and
+    the report contains ``"dry_run": true`` and an empty ``candidates_by_backend``.
+
+    Raises ``RuntimeError`` if the provider is not configured (unless dry_run).
+    """
+    # Parse + classify the rules file.
+    ruleset = parse_file(rules_path)
+    classified = classify(ruleset)
+    fallback_rules = [r for r in classified.rules if _is_semantic_fallback(r)]
+
+    if not dry_run:
+        env = _llm._load_env_file()
+        if not env.get("OPENAI_API_KEY"):
+            raise RuntimeError(
+                "OPENAI_API_KEY not found in dotenv. "
+                "Configure it in /home/vscode/.config/hermes-projects/gate-keeper.env "
+                "or use --dry-run."
+            )
+        api_key = env["OPENAI_API_KEY"]
+    else:
+        api_key = ""
+
+    # Strip "provider:" prefix to pass bare model name to _call_openai.
+    raw_model = model
+    if ":" in model:
+        _, raw_model = model.split(":", 1)
+
+    results: list[dict[str, Any]] = []
+    for rule in fallback_rules:
+        result = _audit_rule(rule, api_key, raw_model, dry_run)
+        results.append(result)
+
+    if dry_run:
+        return {
+            "model": model,
+            "rules_evaluated": 0,
+            "dry_run": True,
+            "fallback_rules_found": len(fallback_rules),
+            "candidates_by_backend": {
+                "filesystem": [],
+                "github": [],
+                "external+textlint": [],
+                "none": [],
+            },
+            "total_cost_estimate_usd": None,
+        }
+
+    return _build_report(results, model)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Routing-audit script: ask gpt-5 whether llm-rubric fallback "
+        "rules could be deterministic. Emits a JSON report."
+    )
+    parser.add_argument(
+        "--rules",
+        required=True,
+        metavar="PATH",
+        help="Path to a Markdown rules file (e.g. docs/dogfooding-rules.md).",
+    )
+    parser.add_argument(
+        "--model",
+        default="openai:gpt-5",
+        metavar="PROVIDER:MODEL",
+        help="Model to use for routing audit (default: openai:gpt-5).",
+    )
+    parser.add_argument(
+        "--out",
+        metavar="PATH",
+        help="Write JSON report to this file (stdout if omitted).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print prompts without calling the API.",
+    )
+
+    args = parser.parse_args(argv)
+    rules_path = Path(args.rules)
+
+    if not rules_path.exists():
+        print(f"error: rules file not found: {rules_path}", file=sys.stderr)
+        return 1
+
+    try:
+        report = run_audit(rules_path, model=args.model, dry_run=args.dry_run)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    report_json = json.dumps(report, indent=2)
+
+    if args.out:
+        out_path = Path(args.out)
+        out_path.write_text(report_json, encoding="utf-8")
+        print(f"Report written to {out_path}", file=sys.stderr)
+    else:
+        print(report_json)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_classify_semantic_candidates.py
+++ b/tests/test_classify_semantic_candidates.py
@@ -1,0 +1,457 @@
+"""Hermetic tests for ``scripts/classify_semantic_candidates.py`` (#235).
+
+Tests cover:
+- Filter logic: only semantic_rubric-fallback rules are evaluated.
+- Report shape: JSON output matches the documented schema.
+- Routing per stubbed response: canned _call_openai responses map correctly.
+- Dry-run mode: no API call, expected dry_run flag in report.
+
+The ``disable_llm_dotenv`` autouse fixture (conftest.py) ensures no host
+credential file bleeds into the test run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from gate_keeper.backends import llm_rubric as _llm
+from gate_keeper.models import Backend, Confidence, Rule, RuleKind, RuleSet, SourceLocation
+
+# ---------------------------------------------------------------------------
+# Module loader (script lives outside the importable package tree)
+# ---------------------------------------------------------------------------
+
+
+def _load_script_module():
+    """Import ``scripts/classify_semantic_candidates.py`` by file path."""
+    repo_root = Path(__file__).resolve().parent.parent
+    script_path = repo_root / "scripts" / "classify_semantic_candidates.py"
+    spec = importlib.util.spec_from_file_location("classify_semantic_candidates", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["classify_semantic_candidates"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+script = _load_script_module()
+
+# ---------------------------------------------------------------------------
+# Helpers to construct minimal Rule objects
+# ---------------------------------------------------------------------------
+
+
+def _make_rule(
+    text: str,
+    rule_id: str = "test-rule-001",
+    kind: RuleKind = RuleKind.SEMANTIC_RUBRIC,
+    backend: Backend = Backend.LLM_RUBRIC,
+) -> Rule:
+    """Build a minimal Rule for testing."""
+    from gate_keeper.models import Severity
+
+    source = SourceLocation(path="test-rules.md", line=1, heading="Test section")
+    return Rule(
+        id=rule_id,
+        title=text[:80],
+        text=text,
+        kind=kind,
+        backend_hint=backend,
+        confidence=Confidence.LOW,
+        severity=Severity.WARNING,
+        source=source,
+        params={},
+    )
+
+
+def _make_ruleset(rules: list[Rule]) -> RuleSet:
+    return RuleSet(rules=rules)
+
+
+# ---------------------------------------------------------------------------
+# Test: _is_semantic_fallback filter logic
+# ---------------------------------------------------------------------------
+
+
+class TestIsSemanticFallback:
+    def test_llm_rubric_semantic_rubric_is_fallback(self):
+        rule = _make_rule("The PR description should be clear.")
+        assert script._is_semantic_fallback(rule) is True
+
+    def test_filesystem_backend_is_not_fallback(self):
+        rule = _make_rule(
+            "README.md must exist.",
+            kind=RuleKind.FILE_EXISTS,
+            backend=Backend.FILESYSTEM,
+        )
+        assert script._is_semantic_fallback(rule) is False
+
+    def test_github_backend_is_not_fallback(self):
+        rule = _make_rule(
+            "PR must not be a draft.",
+            kind=RuleKind.GITHUB_NOT_DRAFT,
+            backend=Backend.GITHUB,
+        )
+        assert script._is_semantic_fallback(rule) is False
+
+    def test_external_check_kind_is_not_fallback(self):
+        rule = _make_rule(
+            "Must not use passive voice.",
+            kind=RuleKind.EXTERNAL_CHECK,
+            backend=Backend.LLM_RUBRIC,
+        )
+        assert script._is_semantic_fallback(rule) is False
+
+    def test_external_backend_is_not_fallback(self):
+        rule = _make_rule(
+            "Must not use passive voice.",
+            kind=RuleKind.EXTERNAL_CHECK,
+            backend=Backend.EXTERNAL,
+        )
+        assert script._is_semantic_fallback(rule) is False
+
+
+# ---------------------------------------------------------------------------
+# Stub helpers
+# ---------------------------------------------------------------------------
+
+
+def _stub_response_filesystem() -> tuple[str, dict[str, int]]:
+    body = json.dumps(
+        {
+            "can_be_deterministic": True,
+            "proposed_backend": "filesystem",
+            "proposed_pattern": r"README\.md",
+            "rationale": "This is a file-existence check.",
+        }
+    )
+    return body, {"latency_ms": 10, "tokens_in": 40, "tokens_out": 20}
+
+
+def _stub_response_github() -> tuple[str, dict[str, int]]:
+    body = json.dumps(
+        {
+            "can_be_deterministic": True,
+            "proposed_backend": "github",
+            "proposed_pattern": "gh pr view --json isDraft",
+            "rationale": "PR draft state is a deterministic GitHub API field.",
+        }
+    )
+    return body, {"latency_ms": 12, "tokens_in": 45, "tokens_out": 22}
+
+
+def _stub_response_none() -> tuple[str, dict[str, int]]:
+    body = json.dumps(
+        {
+            "can_be_deterministic": False,
+            "proposed_backend": None,
+            "proposed_pattern": None,
+            "rationale": "Requires judgment-level reading of the description.",
+        }
+    )
+    return body, {"latency_ms": 8, "tokens_in": 38, "tokens_out": 18}
+
+
+def _stub_response_textlint() -> tuple[str, dict[str, int]]:
+    body = json.dumps(
+        {
+            "can_be_deterministic": True,
+            "proposed_backend": "external+textlint",
+            "proposed_pattern": "textlint-rule-no-passive-voice",
+            "rationale": "Passive voice is a mechanical prose style pattern.",
+        }
+    )
+    return body, {"latency_ms": 9, "tokens_in": 42, "tokens_out": 21}
+
+
+# ---------------------------------------------------------------------------
+# Test: report shape from stubbed responses
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReport:
+    def test_report_shape_from_four_results(self):
+        """_build_report aggregates four rule results into the documented schema."""
+        results = [
+            {
+                "rule_id": "r1",
+                "rule_text": "File must exist.",
+                "can_be_deterministic": True,
+                "proposed_backend": "filesystem",
+                "rationale": "file-existence predicate",
+                "suggested_pattern": r"file\.txt",
+                "_telemetry": {"latency_ms": 10, "tokens_in": 40, "tokens_out": 20},
+            },
+            {
+                "rule_id": "r2",
+                "rule_text": "PR must not be draft.",
+                "can_be_deterministic": True,
+                "proposed_backend": "github",
+                "rationale": "GitHub API field",
+                "suggested_pattern": "isDraft field",
+                "_telemetry": {"latency_ms": 12, "tokens_in": 45, "tokens_out": 22},
+            },
+            {
+                "rule_id": "r3",
+                "rule_text": "Must not use passive voice.",
+                "can_be_deterministic": True,
+                "proposed_backend": "external+textlint",
+                "rationale": "prose style pattern",
+                "suggested_pattern": "no-passive-voice",
+                "_telemetry": {"latency_ms": 9, "tokens_in": 42, "tokens_out": 21},
+            },
+            {
+                "rule_id": "r4",
+                "rule_text": "PR description should be clear.",
+                "can_be_deterministic": False,
+                "proposed_backend": "none",
+                "rationale": "judgment-level check",
+                "_telemetry": {"latency_ms": 8, "tokens_in": 38, "tokens_out": 18},
+            },
+        ]
+
+        report = script._build_report(results, "openai:gpt-5")
+
+        assert report["model"] == "openai:gpt-5"
+        assert report["rules_evaluated"] == 4
+        assert "candidates_by_backend" in report
+        assert "total_cost_estimate_usd" in report
+
+        cbb = report["candidates_by_backend"]
+        assert set(cbb.keys()) == {"filesystem", "github", "external+textlint", "none"}
+        assert len(cbb["filesystem"]) == 1
+        assert cbb["filesystem"][0]["rule_id"] == "r1"
+        assert len(cbb["github"]) == 1
+        assert cbb["github"][0]["rule_id"] == "r2"
+        assert len(cbb["external+textlint"]) == 1
+        assert cbb["external+textlint"][0]["rule_id"] == "r3"
+        assert len(cbb["none"]) == 1
+        assert cbb["none"][0]["rule_id"] == "r4"
+
+    def test_suggested_pattern_included_for_deterministic_rules(self):
+        results = [
+            {
+                "rule_id": "r1",
+                "rule_text": "README.md must exist.",
+                "can_be_deterministic": True,
+                "proposed_backend": "filesystem",
+                "rationale": "existence check",
+                "suggested_pattern": r"README\.md",
+                "_telemetry": {"latency_ms": 10, "tokens_in": 40, "tokens_out": 20},
+            }
+        ]
+        report = script._build_report(results, "openai:gpt-5")
+        assert report["candidates_by_backend"]["filesystem"][0]["suggested_pattern"] == r"README\.md"
+
+    def test_none_backend_has_no_suggested_pattern(self):
+        results = [
+            {
+                "rule_id": "r1",
+                "rule_text": "PR should read clearly.",
+                "can_be_deterministic": False,
+                "proposed_backend": "none",
+                "rationale": "judgment-level",
+                "_telemetry": {"latency_ms": 8, "tokens_in": 30, "tokens_out": 15},
+            }
+        ]
+        report = script._build_report(results, "openai:gpt-5")
+        entry = report["candidates_by_backend"]["none"][0]
+        assert "suggested_pattern" not in entry
+
+
+# ---------------------------------------------------------------------------
+# Test: run_audit with monkeypatched _call_openai
+# ---------------------------------------------------------------------------
+
+
+_BASE_ENV = {
+    "GATE_KEEPER_LLM_PROVIDER": "openai",
+    "OPENAI_API_KEY": "sk-test-stub-not-real",
+}
+
+
+class TestRunAudit:
+    def _write_semantic_rules(self, tmp_path: Path) -> Path:
+        """Write a rules file with one semantic fallback rule."""
+        rules_md = tmp_path / "rules.md"
+        rules_md.write_text(
+            "# Test rules\n\n"
+            "- The PR description should name the user-visible change in the first sentence.\n",
+            encoding="utf-8",
+        )
+        return rules_md
+
+    def _write_mixed_rules(self, tmp_path: Path) -> Path:
+        """Write a rules file with semantic + deterministic rules."""
+        rules_md = tmp_path / "mixed.md"
+        rules_md.write_text(
+            "# Test rules\n\n"
+            "## GitHub gates\n\n"
+            "- PR must not be a draft.\n"
+            "- CI checks must pass.\n\n"
+            "## Filesystem gates\n\n"
+            "- README.md must exist.\n\n"
+            "## Semantic rules\n\n"
+            "- The commit message should explain why the change was made.\n",
+            encoding="utf-8",
+        )
+        return rules_md
+
+    def test_filters_only_semantic_fallback_rules(self, monkeypatch, tmp_path):
+        """Filter logic: only semantic_rubric rules are evaluated; deterministic rules are excluded."""
+        call_count = 0
+
+        def _stub_call(*_args, **_kwargs) -> tuple[str, dict[str, int]]:
+            nonlocal call_count
+            call_count += 1
+            return _stub_response_none()
+
+        monkeypatch.setattr(_llm, "_load_env_file", lambda *a, **k: dict(_BASE_ENV))
+        monkeypatch.setattr(_llm, "_call_openai", _stub_call)
+
+        rules_path = self._write_mixed_rules(tmp_path)
+        report = script.run_audit(rules_path, model="openai:gpt-5")
+
+        # The mixed file has 3 deterministic + 1 semantic rule.
+        # Only the semantic rule should be audited.
+        assert call_count == 1
+        assert report["rules_evaluated"] == 1
+
+    def test_report_shape_and_routing(self, monkeypatch, tmp_path):
+        """run_audit returns report with correct shape when stub returns 'none'."""
+        stub_calls: list[str] = []
+
+        def _stub_call(api_key, system, user, model) -> tuple[str, dict[str, int]]:
+            stub_calls.append(user)
+            return _stub_response_none()
+
+        monkeypatch.setattr(_llm, "_load_env_file", lambda *a, **k: dict(_BASE_ENV))
+        monkeypatch.setattr(_llm, "_call_openai", _stub_call)
+
+        rules_path = self._write_semantic_rules(tmp_path)
+        report = script.run_audit(rules_path, model="openai:gpt-5")
+
+        assert report["model"] == "openai:gpt-5"
+        assert report["rules_evaluated"] == 1
+        assert set(report["candidates_by_backend"].keys()) == {
+            "filesystem",
+            "github",
+            "external+textlint",
+            "none",
+        }
+        assert len(report["candidates_by_backend"]["none"]) == 1
+        assert len(stub_calls) == 1
+
+    def test_filesystem_stub_routes_to_filesystem(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(_llm, "_load_env_file", lambda *a, **k: dict(_BASE_ENV))
+        monkeypatch.setattr(_llm, "_call_openai", lambda *a, **k: _stub_response_filesystem())
+
+        rules_path = self._write_semantic_rules(tmp_path)
+        report = script.run_audit(rules_path, model="openai:gpt-5")
+
+        assert len(report["candidates_by_backend"]["filesystem"]) == 1
+        assert len(report["candidates_by_backend"]["none"]) == 0
+
+    def test_raises_without_api_key(self, monkeypatch, tmp_path):
+        """run_audit raises RuntimeError when OPENAI_API_KEY is absent."""
+        monkeypatch.setattr(
+            _llm,
+            "_load_env_file",
+            lambda *a, **k: {"GATE_KEEPER_LLM_PROVIDER": "openai"},
+        )
+
+        rules_path = self._write_semantic_rules(tmp_path)
+        with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+            script.run_audit(rules_path, model="openai:gpt-5")
+
+    def test_dry_run_no_api_call(self, monkeypatch, tmp_path):
+        """In dry-run mode, _call_openai is never called."""
+        call_count = 0
+
+        def _stub_call(*_args, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            return _stub_response_none()
+
+        monkeypatch.setattr(_llm, "_load_env_file", lambda *a, **k: dict(_BASE_ENV))
+        monkeypatch.setattr(_llm, "_call_openai", _stub_call)
+
+        rules_path = self._write_semantic_rules(tmp_path)
+        report = script.run_audit(rules_path, model="openai:gpt-5", dry_run=True)
+
+        assert call_count == 0
+        assert report.get("dry_run") is True
+        assert report["rules_evaluated"] == 0
+
+    def test_empty_file_no_calls(self, monkeypatch, tmp_path):
+        """An empty rules file produces zero evaluated rules."""
+        call_count = 0
+
+        def _stub_call(*_args, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            return _stub_response_none()
+
+        monkeypatch.setattr(_llm, "_load_env_file", lambda *a, **k: dict(_BASE_ENV))
+        monkeypatch.setattr(_llm, "_call_openai", _stub_call)
+
+        rules_path = tmp_path / "empty.md"
+        rules_path.write_text("# No rules here\n\n", encoding="utf-8")
+        report = script.run_audit(rules_path, model="openai:gpt-5")
+
+        assert call_count == 0
+        assert report["rules_evaluated"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Test: main() CLI entry point
+# ---------------------------------------------------------------------------
+
+
+class TestMainCli:
+    def test_main_writes_report_to_out(self, monkeypatch, tmp_path):
+        rules_md = tmp_path / "rules.md"
+        rules_md.write_text(
+            "# Rules\n\n- The commit message should explain why the change was made.\n",
+            encoding="utf-8",
+        )
+        out_path = tmp_path / "report.json"
+
+        monkeypatch.setattr(_llm, "_load_env_file", lambda *a, **k: dict(_BASE_ENV))
+        monkeypatch.setattr(_llm, "_call_openai", lambda *a, **k: _stub_response_none())
+
+        rc = script.main(
+            [
+                "--rules",
+                str(rules_md),
+                "--model",
+                "openai:gpt-5",
+                "--out",
+                str(out_path),
+            ]
+        )
+        assert rc == 0
+        assert out_path.is_file()
+        report = json.loads(out_path.read_text(encoding="utf-8"))
+        assert report["rules_evaluated"] == 1
+        assert "candidates_by_backend" in report
+
+    def test_main_dry_run_exits_zero(self, monkeypatch, tmp_path):
+        rules_md = tmp_path / "rules.md"
+        rules_md.write_text(
+            "# Rules\n\n- The PR description should be clear.\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(_llm, "_load_env_file", lambda *a, **k: dict(_BASE_ENV))
+
+        rc = script.main(["--rules", str(rules_md), "--dry-run"])
+        assert rc == 0
+
+    def test_main_missing_rules_file_exits_one(self, monkeypatch, tmp_path):
+        rc = script.main(["--rules", str(tmp_path / "nonexistent.md")])
+        assert rc == 1

--- a/tests/test_classify_semantic_candidates.py
+++ b/tests/test_classify_semantic_candidates.py
@@ -455,3 +455,113 @@ class TestMainCli:
     def test_main_missing_rules_file_exits_one(self, monkeypatch, tmp_path):
         rc = script.main(["--rules", str(tmp_path / "nonexistent.md")])
         assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for copilot review feedback (#236)
+# ---------------------------------------------------------------------------
+
+
+class TestReviewRegressions:
+    """Cover the three copilot review threads on PR #236."""
+
+    def _write_semantic_rules(self, tmp_path: Path) -> Path:
+        rules_md = tmp_path / "rules.md"
+        rules_md.write_text(
+            "# Rules\n\n- The PR description should be clear.\n",
+            encoding="utf-8",
+        )
+        return rules_md
+
+    def test_inconsistent_payload_normalised_to_none(self, monkeypatch, tmp_path):
+        """can_be_deterministic=false + proposed_backend='github' is normalised to 'none'.
+
+        Copilot thread 3223291517: trust-the-model bug — without this guard,
+        an inconsistent payload would bucket the rule under a deterministic
+        backend even though the model itself said it was not deterministic.
+        """
+
+        def _bad_stub(*_args, **_kwargs) -> tuple[str, dict[str, int]]:
+            body = json.dumps(
+                {
+                    "can_be_deterministic": False,
+                    "proposed_backend": "github",
+                    "proposed_pattern": "gh pr view",
+                    "rationale": "model self-contradicts",
+                }
+            )
+            return body, {"latency_ms": 10, "tokens_in": 30, "tokens_out": 15}
+
+        monkeypatch.setattr(_llm, "_load_env_file", lambda *a, **k: dict(_BASE_ENV))
+        monkeypatch.setattr(_llm, "_call_openai", _bad_stub)
+
+        rules_path = self._write_semantic_rules(tmp_path)
+        report = script.run_audit(rules_path, model="openai:gpt-5")
+
+        # The inconsistent payload must be bucketed under "none", not "github".
+        assert len(report["candidates_by_backend"]["github"]) == 0
+        assert len(report["candidates_by_backend"]["none"]) == 1
+        # The suggested_pattern must be dropped (deterministic-only field).
+        none_entry = report["candidates_by_backend"]["none"][0]
+        assert "suggested_pattern" not in none_entry
+
+    def test_inconsistent_deterministic_true_but_none_backend(self, monkeypatch, tmp_path):
+        """can_be_deterministic=true + proposed_backend=null is flagged in rationale.
+
+        Copilot thread 3223291517: the other direction of the inconsistency
+        — the model claims the rule is deterministic but does not name a
+        deterministic backend. We fail-closed to 'none' and prefix the
+        rationale with an [inconsistent payload] marker.
+        """
+
+        def _bad_stub(*_args, **_kwargs) -> tuple[str, dict[str, int]]:
+            body = json.dumps(
+                {
+                    "can_be_deterministic": True,
+                    "proposed_backend": None,
+                    "proposed_pattern": None,
+                    "rationale": "deterministic but unsure how",
+                }
+            )
+            return body, {"latency_ms": 10, "tokens_in": 30, "tokens_out": 15}
+
+        monkeypatch.setattr(_llm, "_load_env_file", lambda *a, **k: dict(_BASE_ENV))
+        monkeypatch.setattr(_llm, "_call_openai", _bad_stub)
+
+        rules_path = self._write_semantic_rules(tmp_path)
+        report = script.run_audit(rules_path, model="openai:gpt-5")
+
+        assert len(report["candidates_by_backend"]["none"]) == 1
+        rationale = report["candidates_by_backend"]["none"][0]["rationale"]
+        assert "inconsistent payload" in rationale
+
+    def test_non_openai_provider_rejected(self, monkeypatch, tmp_path):
+        """--model anthropic:* raises a clear ValueError; no OpenAI call attempted.
+
+        Copilot thread 3223291536: the slice is openai-only. Honouring an
+        ``anthropic:`` prefix would silently invoke ``_call_openai`` with a
+        non-openai model name. Validate at the boundary instead.
+        """
+        rules_path = self._write_semantic_rules(tmp_path)
+
+        # Even without an API key, the provider check must fire first.
+        monkeypatch.setattr(_llm, "_load_env_file", lambda *a, **k: dict(_BASE_ENV))
+
+        with pytest.raises(ValueError, match="openai-only"):
+            script.run_audit(rules_path, model="anthropic:claude-haiku-4-5")
+
+    def test_dotenv_path_in_error_uses_module_constant(self, monkeypatch, tmp_path):
+        """RuntimeError for missing OPENAI_API_KEY references _llm.DOTENV_PATH.
+
+        Copilot thread 3223291543: hard-coded path string risks drift.
+        Use the module-level constant so the message stays in sync.
+        """
+        monkeypatch.setattr(
+            _llm,
+            "_load_env_file",
+            lambda *a, **k: {"GATE_KEEPER_LLM_PROVIDER": "openai"},
+        )
+
+        rules_path = self._write_semantic_rules(tmp_path)
+        with pytest.raises(RuntimeError, match=str(_llm.DOTENV_PATH)):
+            script.run_audit(rules_path, model="openai:gpt-5")


### PR DESCRIPTION
## Summary

Implements the first slice of #75 (Classifier feedback loop) per the [research-75 recommendation](https://github.com/t-uda/gate-keeper/issues/75#issuecomment-4426730004): a read-only utility script that asks `gpt-5` (minimal reasoning) whether each `semantic_rubric`-fallback rule could be evaluated deterministically by `filesystem`, `github`, or `external+textlint`, and emits a JSON report for human triage.

This is **utility + report**, not a behavior change to the classifier.

## What changed

- `scripts/classify_semantic_candidates.py` — argparse CLI (`--rules`, `--model`, `--out`, `--dry-run`). Reuses `gate_keeper.parser.parse_file` + `classifier.classify` for the front-end, reuses `llm_rubric._call_openai` (which already routes gpt-5 to `reasoning_effort=minimal` per #233 / #234). Filters strictly to `semantic_rubric + LLM_RUBRIC` fallback rules; excludes explicit `external_check` rules and deterministic-routed rules.
- `tests/test_classify_semantic_candidates.py` — 17 hermetic tests under the `disable_llm_dotenv` autouse fixture (#180). Cover filter logic, `_build_report` shape, `run_audit` end-to-end with monkeypatched `_call_openai`, and `main()` CLI.
- `docs/llm-rubric.md` — brief usage note under Advisory status, framing the script as ad-hoc routing audit (not part of bench/CI).

## Sample report (end-to-end evidence)

Ran the script against `docs/dogfooding-rules.md`:

```sh
uv run python scripts/classify_semantic_candidates.py \
  --rules docs/dogfooding-rules.md \
  --model openai:gpt-5 \
  --out /tmp/audit-report.json
```

Output:

```json
{
  "model": "openai:gpt-5",
  "rules_evaluated": 3,
  "candidates_by_backend": {
    "filesystem": [],
    "github": [],
    "external+textlint": [],
    "none": [
      {
        "rule_id": "rule-dogfooding-rules-L23",
        "rationale": "Identifying whether the first sentence names the user-visible change requires semantic judgment about intent and clarity, not a simple mechanical pattern."
      },
      {
        "rule_id": "rule-dogfooding-rules-L24",
        "rationale": "Determining whether the PR description truly states how the change was tested requires interpreting free-form prose and judging adequacy, which is subjective and not reliably captured by simple patterns."
      },
      {
        "rule_id": "rule-dogfooding-rules-L25",
        "rationale": "Assessing whether a commit message explains the rationale (why) rather than merely the changes (what) requires subjective interpretation of prose and context."
      }
    ]
  },
  "total_cost_estimate_usd": null
}
```

All 3 known-correct `llm-rubric` rules correctly classified as `none` (no false reclassification). `total_cost_estimate_usd` is `null` because `gpt-5` is not in the static `_MODEL_PRICING` snapshot (which only carries `gpt-4o-mini` and `claude-haiku-4-5`); fail-closed by design — unknown cost is not guessed.

## Validation

- `uv run pytest` — 1439 passed (17 new tests included).
- `uvx ruff check .` — All checks passed.
- `uvx pyright scripts/classify_semantic_candidates.py tests/test_classify_semantic_candidates.py` — same pre-existing pattern as `scripts/llm_rubric_model_matrix.py` (sys.path injection at runtime; pyright doesn't resolve the in-tree package without the venv on its path).
- End-to-end run on `docs/dogfooding-rules.md` succeeded (report above).

## Out of scope

- Behavior change to `classifier.py` (report is for human triage).
- CI wiring.
- New dependencies.
- Multi-model matrix (gpt-5 only for this slice).
- Closing #75 (parent design issue stays open).

## Test plan

- [x] Filter logic test: only `semantic_rubric`-fallback rules audited
- [x] Report shape test: JSON matches the documented schema
- [x] Routing-per-stub test: canned `_call_openai` responses route correctly
- [x] Dry-run test: no API call
- [x] End-to-end run on `docs/dogfooding-rules.md`

Refs: #75 (parent), #226, #234, #227, umbrella #164.

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)