### PR TITLE
Reduce dogfooding PR comment noise: skip fallback and upsert bot comment

### DIFF
--- a/.github/workflows/dogfooding.yml
+++ b/.github/workflows/dogfooding.yml
@@ -24,7 +24,6 @@
 #     directory mode is `700`.
 #
 # Out of scope (per #131):
-#   - Sticky / edited comments — each run posts a fresh comment.
 #   - Promotion to required check — promotion path is owned by #79.
 
 name: dogfooding
@@ -134,15 +133,43 @@ jobs:
           cat /tmp/dogfood-comment.md
           echo "::endgroup::"
 
-      - name: Post advisory comment
+      - name: Guard low-signal advisory output
         if: steps.secret_guard.outputs.secret_present == 'true' && steps.format.outcome == 'success'
+        id: comment_guard
+        run: |
+          set +x
+          if rg -q "Advisory evaluation could not be produced for this PR" /tmp/dogfood-comment.md; then
+            echo "post_comment=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping PR comment because advisory output is fallback/noisy."
+          else
+            echo "post_comment=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upsert advisory comment
+        if: steps.secret_guard.outputs.secret_present == 'true' && steps.format.outcome == 'success' && steps.comment_guard.outputs.post_comment == 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set +x
-          gh pr comment "$PR_NUMBER" --body-file /tmp/dogfood-comment.md
+          marker='<!-- gate-keeper-dogfooding-comment -->'
+          existing_comment_id="$({
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --paginate \
+              --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- gate-keeper-dogfooding-comment -->")) | .id' \
+              | tail -n 1
+          } || true)"
+
+          if [ -n "${existing_comment_id:-}" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_comment_id}" \
+              -F "body=@/tmp/dogfood-comment.md"
+          else
+            gh pr comment "$PR_NUMBER" --body-file /tmp/dogfood-comment.md
+          fi
 
       - name: Scrub provisioned credentials
         if: always() && steps.secret_guard.outputs.secret_present == 'true'

--- a/.github/workflows/dogfooding.yml
+++ b/.github/workflows/dogfooding.yml
@@ -138,7 +138,7 @@ jobs:
         id: comment_guard
         run: |
           set +x
-          if rg -q "Advisory evaluation could not be produced for this PR" /tmp/dogfood-comment.md; then
+          if rg -q "<!-- gate-keeper-dogfooding-comment:fallback -->" /tmp/dogfood-comment.md; then
             echo "post_comment=false" >> "$GITHUB_OUTPUT"
             echo "Skipping PR comment because advisory output is fallback/noisy."
           else
@@ -153,12 +153,11 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set +x
-          marker='<!-- gate-keeper-dogfooding-comment -->'
           existing_comment_id="$({
             gh api \
               "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
               --paginate \
-              --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- gate-keeper-dogfooding-comment -->")) | .id' \
+              --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- gate-keeper-dogfooding-comment:")) | .id' \
               | tail -n 1
           } || true)"
 

--- a/.github/workflows/format_dogfooding_comment.py
+++ b/.github/workflows/format_dogfooding_comment.py
@@ -33,6 +33,7 @@ import sys
 from typing import Any
 
 _FALLBACK_HEADER = "## gate-keeper dogfooding (advisory)"
+_MARKER = "<!-- gate-keeper-dogfooding-comment -->"
 _FALLBACK_BODY = (
     "Advisory evaluation could not be produced for this PR.\n\n"
     "The validate step exited without a usable JSON report. This does not "
@@ -45,6 +46,8 @@ _TRAILER = (
 
 
 def _emit_fallback() -> None:
+    print(_MARKER)
+    print()
     print(_FALLBACK_HEADER)
     print()
     print(_FALLBACK_BODY)
@@ -162,6 +165,8 @@ def main(argv: list[str]) -> int:
         _emit_fallback()
         return 0
 
+    print(_MARKER)
+    print()
     print(_FALLBACK_HEADER)
     print()
     print("| rule | status | judgment | primary_reason |")

--- a/.github/workflows/format_dogfooding_comment.py
+++ b/.github/workflows/format_dogfooding_comment.py
@@ -33,7 +33,9 @@ import sys
 from typing import Any
 
 _FALLBACK_HEADER = "## gate-keeper dogfooding (advisory)"
-_MARKER = "<!-- gate-keeper-dogfooding-comment -->"
+_MARKER_BASE = "gate-keeper-dogfooding-comment"
+_MARKER_FALLBACK = f"<!-- {_MARKER_BASE}:fallback -->"
+_MARKER_REPORT = f"<!-- {_MARKER_BASE}:report -->"
 _FALLBACK_BODY = (
     "Advisory evaluation could not be produced for this PR.\n\n"
     "The validate step exited without a usable JSON report. This does not "
@@ -46,7 +48,7 @@ _TRAILER = (
 
 
 def _emit_fallback() -> None:
-    print(_MARKER)
+    print(_MARKER_FALLBACK)
     print()
     print(_FALLBACK_HEADER)
     print()
@@ -165,7 +167,7 @@ def main(argv: list[str]) -> int:
         _emit_fallback()
         return 0
 
-    print(_MARKER)
+    print(_MARKER_REPORT)
     print()
     print(_FALLBACK_HEADER)
     print()


### PR DESCRIPTION
### Motivation
- Prevent low-signal "advisory" comments from polluting PR discussions when the validator produces only a fallback/no-op result. 
- Stop creating a fresh advisory comment on every run to avoid comment spam on repeated workflow executions. 
- Make the advisory comment reliably identifiable so the workflow can update (upsert) the existing bot comment instead of posting duplicates.

### Description
- Add a hidden stable marker (`<!-- gate-keeper-dogfooding-comment -->`) to the formatted advisory output in `.github/workflows/format_dogfooding_comment.py` so comments can be located and de-duplicated. 
- Add a guard step `Guard low-signal advisory output` to `.github/workflows/dogfooding.yml` that skips posting when the formatter produced the fallback "Advisory evaluation could not be produced for this PR" body. 
- Replace the always-new `gh pr comment` behavior with an upsert flow in `.github/workflows/dogfooding.yml` that finds an existing `github-actions[bot]` comment containing the marker and `PATCH`es it, or creates a new comment if none exists. 
- Preserve advisory semantics (non-blocking); this only changes comment hygiene and signal filtering.

### Testing
- Ran `python3 -m py_compile .github/workflows/format_dogfooding_comment.py` which completed successfully. 
- Executed `python3 .github/workflows/format_dogfooding_comment.py /tmp/does-not-exist.json >/tmp/out.md` and confirmed the fallback comment (including the marker) was produced as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02dc2c8d688323958cdf86d4f77a23)