### PR TITLE
Filter structural-skip UNSUPPORTED from advisory comment (#240)

### DIFF
--- a/.github/workflows/format_dogfooding_comment.py
+++ b/.github/workflows/format_dogfooding_comment.py
@@ -24,6 +24,12 @@ Output shape (matches issue #131 acceptance criteria):
 
   <small>This comment is advisory and does not gate merge. See
   docs/dogfooding.md.</small>
+
+Structural skips (#240): UNSUPPORTED diagnostics whose primary evidence
+kind is ``target_kind_mismatch`` (deterministic precheck, #178) or
+``llm_quote_fabrication`` (parser-side reject, #172) are not
+author-actionable per PR. They are filtered out of the main table and
+collapsed into a ``<details>`` summary at the end.
 """
 
 from __future__ import annotations
@@ -44,6 +50,17 @@ _FALLBACK_BODY = (
 _TRAILER = (
     "<sub>This comment is advisory and does not gate merge. "
     "See [`docs/dogfooding.md`](docs/dogfooding.md) for the promotion path.</sub>"
+)
+
+# UNSUPPORTED diagnostics whose primary evidence falls in this set are
+# "structural skips": the system correctly short-circuited or self-defended
+# (deterministic target-kind precheck #178, parser-side quote-fabrication
+# reject #172). They are not author-actionable per PR, so they are collapsed
+# into a <details> block instead of polluting the main table. See #240.
+_STRUCTURAL_SKIP_KINDS = frozenset({"target_kind_mismatch", "llm_quote_fabrication"})
+_NO_ACTIONABLE_BODY = (
+    "No author-actionable findings. All evaluated rules either passed or "
+    "were structurally skipped (see below)."
 )
 
 
@@ -94,6 +111,58 @@ def _primary_reason(diag: dict[str, Any]) -> str:
         if isinstance(data, dict) and data.get("primary_reason"):
             return _safe_truncate(str(data["primary_reason"]), 200)
     return "-"
+
+
+def _structural_skip_kind(diag: dict[str, Any]) -> str | None:
+    """Return the structural-skip evidence kind for ``diag``, or ``None``.
+
+    A diagnostic is classified as a structural skip when status is
+    ``unsupported`` AND the first evidence entry's ``kind`` falls in
+    :data:`_STRUCTURAL_SKIP_KINDS`. See module docstring / #240.
+    """
+    status = str(diag.get("status", "")).lower()
+    if status != "unsupported":
+        return None
+    evidence = diag.get("evidence") or []
+    if not isinstance(evidence, list) or not evidence:
+        return None
+    first = evidence[0]
+    if not isinstance(first, dict):
+        return None
+    kind = first.get("kind")
+    if isinstance(kind, str) and kind in _STRUCTURAL_SKIP_KINDS:
+        return kind
+    return None
+
+
+def _structural_skip_summary(skips: list[tuple[dict[str, Any], str]]) -> str:
+    """Render the collapsed ``<details>`` block for structurally-skipped rules."""
+    counts: dict[str, int] = {}
+    for _, kind in skips:
+        counts[kind] = counts.get(kind, 0) + 1
+    breakdown = ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+    lines: list[str] = []
+    lines.append("<details>")
+    lines.append(
+        f"<summary>{len(skips)} rule(s) structurally skipped "
+        f"(no author action required): {breakdown}</summary>"
+    )
+    lines.append("")
+    lines.append("| rule | status | evidence.kind | primary_reason |")
+    lines.append("| --- | --- | --- | --- |")
+    for diag, kind in skips:
+        label = _rule_label(diag)
+        status = str(diag.get("status", "-")).upper()
+        reason = _primary_reason(diag)
+        lines.append(f"| {label} | {status} | {kind} | {reason} |")
+    lines.append("")
+    lines.append(
+        "These are non-actionable: deterministic precheck (#178) or "
+        "parser-side quote-fabrication reject (#172) — the system "
+        "correctly defended. See `docs/dogfooding.md`."
+    )
+    lines.append("</details>")
+    return "\n".join(lines)
 
 
 def _telemetry_summary(diagnostics: list[dict[str, Any]]) -> str | None:
@@ -167,21 +236,37 @@ def main(argv: list[str]) -> int:
         _emit_fallback()
         return 0
 
+    actionable: list[dict[str, Any]] = []
+    structural_skips: list[tuple[dict[str, Any], str]] = []
+    for diag in diagnostics:
+        if not isinstance(diag, dict):
+            continue
+        kind = _structural_skip_kind(diag)
+        if kind is not None:
+            structural_skips.append((diag, kind))
+        else:
+            actionable.append(diag)
+
     print(_MARKER_REPORT)
     print()
     print(_FALLBACK_HEADER)
     print()
-    print("| rule | status | judgment | primary_reason |")
-    print("| --- | --- | --- | --- |")
-    for diag in diagnostics:
-        if not isinstance(diag, dict):
-            continue
-        label = _rule_label(diag)
-        status = str(diag.get("status", "-")).upper()
-        judgment = _judgment_for(diag)
-        reason = _primary_reason(diag)
-        print(f"| {label} | {status} | {judgment} | {reason} |")
+    if actionable:
+        print("| rule | status | judgment | primary_reason |")
+        print("| --- | --- | --- | --- |")
+        for diag in actionable:
+            label = _rule_label(diag)
+            status = str(diag.get("status", "-")).upper()
+            judgment = _judgment_for(diag)
+            reason = _primary_reason(diag)
+            print(f"| {label} | {status} | {judgment} | {reason} |")
+    else:
+        print(_NO_ACTIONABLE_BODY)
     print()
+
+    if structural_skips:
+        print(_structural_skip_summary(structural_skips))
+        print()
 
     telemetry = _telemetry_summary(diagnostics)
     if telemetry:

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -56,6 +56,22 @@ annotated rules participate in the deterministic dispatch. See
 (#178)](cli-reference.md#deterministic-target_kind-mismatch-178) for
 the evidence shape and full vocabulary.
 
+### Advisory-comment filtering (structural skips, #240)
+
+The advisory PR comment filters two non-actionable UNSUPPORTED rows out
+of its main table and collapses them into a `<details>` summary at the
+end:
+
+- `evidence.kind=target_kind_mismatch` — deterministic precheck (#178)
+  correctly short-circuited a rule that does not apply to the artifact.
+- `evidence.kind=llm_quote_fabrication` — parser-side reject (#172)
+  correctly defended against a model-fabricated supporting quote.
+
+These represent the system defending itself, not author-actionable
+findings, so surfacing them per-PR is noise. Other UNSUPPORTED kinds
+(e.g. `provider_unconfigured`, `provider_error`) remain in the main
+table.
+
 ## Issue hygiene
 
 Every false positive, false negative, or unclear failure observed during

--- a/tests/test_format_dogfooding_comment.py
+++ b/tests/test_format_dogfooding_comment.py
@@ -1,0 +1,197 @@
+"""Tests for the dogfooding advisory-comment formatter (#240).
+
+The formatter lives outside ``src/`` (it is workflow glue, not a public
+package surface), so we load it via ``importlib`` from the repo-relative
+path. The tests pin:
+
+1. Structural-skip diagnostics (``target_kind_mismatch`` / ``llm_quote_fabrication``)
+   are filtered out of the main table and surfaced in a ``<details>`` block.
+2. Actionable-only inputs render a plain table with no ``<details>`` block.
+3. Structural-skip-only inputs render the "no author-actionable findings"
+   placeholder plus the ``<details>`` block.
+4. Mixed inputs render only the actionable rows in the main table, with the
+   skipped rows under the ``<details>`` block.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
+from typing import Any
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent
+    / ".github"
+    / "workflows"
+    / "format_dogfooding_comment.py"
+)
+
+
+def _load_formatter():
+    spec = importlib.util.spec_from_file_location(
+        "format_dogfooding_comment", _SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(tmp_path: Path, payload: dict[str, Any]) -> str:
+    formatter = _load_formatter()
+    json_path = tmp_path / "report.json"
+    json_path.write_text(json.dumps(payload), encoding="utf-8")
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = formatter.main(["format_dogfooding_comment.py", str(json_path)])
+    assert rc == 0
+    return buf.getvalue()
+
+
+def _diag_actionable_fail() -> dict[str, Any]:
+    return {
+        "rule_id": "rule-dogfooding-rules-L23",
+        "status": "fail",
+        "message": (
+            "The PR description does not name the user-visible change in "
+            "the first sentence."
+        ),
+        "evidence": [
+            {
+                "kind": "llm_judgment",
+                "data": {
+                    "judgment": "fail",
+                    "primary_reason": "missing user-visible change",
+                    "tokens_in": 100,
+                    "tokens_out": 50,
+                    "latency_ms": 1234,
+                    "model": "gpt-4o-mini",
+                    "prompt_version": "v6",
+                },
+            }
+        ],
+    }
+
+
+def _diag_structural_target_kind() -> dict[str, Any]:
+    return {
+        "rule_id": "rule-dogfooding-rules-L25",
+        "status": "unsupported",
+        "message": (
+            "Rule annotated `target_kind: commit_message` does not apply to "
+            "artifact of kind `pr_description`; skipping without invoking "
+            "the LLM."
+        ),
+        "evidence": [
+            {
+                "kind": "target_kind_mismatch",
+                "data": {
+                    "rule_target_kind": "commit_message",
+                    "artifact_kind": "pr_description",
+                    "dispatch": "deterministic_precheck",
+                    "llm_called": False,
+                },
+            }
+        ],
+    }
+
+
+def _diag_structural_quote_fabrication() -> dict[str, Any]:
+    return {
+        "rule_id": "rule-dogfooding-rules-L24",
+        "status": "unsupported",
+        "message": (
+            "LLM rubric verdict rejected: the model returned 2 of 2 "
+            "supporting quotes that are not substrings of the artifact "
+            "(quote fabrication)."
+        ),
+        "evidence": [
+            {
+                "kind": "llm_quote_fabrication",
+                "data": {"fabricated_quotes": 2, "total_quotes": 2},
+            }
+        ],
+    }
+
+
+def test_actionable_only_no_details(tmp_path: Path) -> None:
+    """A FAIL-only input renders the main table and no <details> block."""
+    out = _run(tmp_path, {"diagnostics": [_diag_actionable_fail()]})
+    assert "rule-dogfooding-rules-L23" in out
+    assert "<details>" not in out
+    assert "structurally skipped" not in out
+    # The main table is present, not the placeholder body.
+    assert "| rule | status | judgment | primary_reason |" in out
+    assert "No author-actionable findings" not in out
+
+
+def test_structural_skip_only_collapses_into_details(tmp_path: Path) -> None:
+    """When only structural skips are present the main table is replaced by the
+    placeholder body and the <details> block lists the two skipped rules."""
+    out = _run(
+        tmp_path,
+        {
+            "diagnostics": [
+                _diag_structural_target_kind(),
+                _diag_structural_quote_fabrication(),
+            ]
+        },
+    )
+    assert "No author-actionable findings" in out
+    assert "<details>" in out
+    assert "</details>" in out
+    # Both kinds appear in the breakdown summary.
+    assert "target_kind_mismatch=1" in out
+    assert "llm_quote_fabrication=1" in out
+    # Both rule IDs appear inside the collapsed table, not the main one.
+    assert "rule-dogfooding-rules-L24" in out
+    assert "rule-dogfooding-rules-L25" in out
+    # The main "| rule | status | judgment | primary_reason |" header should NOT
+    # appear because there are no actionable rows.
+    assert "| rule | status | judgment | primary_reason |" not in out
+
+
+def test_mixed_input_keeps_only_actionable_in_main_table(tmp_path: Path) -> None:
+    """The PR #238 example: FAIL + two structural skips → table shows only FAIL,
+    skips go under <details>."""
+    out = _run(
+        tmp_path,
+        {
+            "diagnostics": [
+                _diag_actionable_fail(),
+                _diag_structural_quote_fabrication(),
+                _diag_structural_target_kind(),
+            ]
+        },
+    )
+    # Main table present with the FAIL row.
+    assert "| rule | status | judgment | primary_reason |" in out
+    main_table_idx = out.index("| rule | status | judgment | primary_reason |")
+    details_idx = out.index("<details>")
+    assert main_table_idx < details_idx
+    # FAIL row appears before <details>.
+    fail_idx = out.index("rule-dogfooding-rules-L23")
+    assert fail_idx < details_idx
+    # Skipped rule IDs appear after <details>.
+    assert out.index("rule-dogfooding-rules-L24") > details_idx
+    assert out.index("rule-dogfooding-rules-L25") > details_idx
+    # Placeholder body should not appear since we have an actionable row.
+    assert "No author-actionable findings" not in out
+
+
+def test_non_structural_unsupported_is_not_filtered(tmp_path: Path) -> None:
+    """An UNSUPPORTED diag with a non-structural evidence kind (e.g.
+    ``provider_unconfigured``) stays in the main table — only the minimum
+    set defined in #240 is filtered."""
+    diag = {
+        "rule_id": "rule-some-unavailable",
+        "status": "unsupported",
+        "message": "Provider not configured.",
+        "evidence": [{"kind": "provider_unconfigured", "data": {}}],
+    }
+    out = _run(tmp_path, {"diagnostics": [diag]})
+    assert "rule-some-unavailable" in out
+    assert "<details>" not in out

--- a/tests/test_format_dogfooding_comment.py
+++ b/tests/test_format_dogfooding_comment.py
@@ -23,17 +23,12 @@ from pathlib import Path
 from typing import Any
 
 _SCRIPT_PATH = (
-    Path(__file__).resolve().parent.parent
-    / ".github"
-    / "workflows"
-    / "format_dogfooding_comment.py"
+    Path(__file__).resolve().parent.parent / ".github" / "workflows" / "format_dogfooding_comment.py"
 )
 
 
 def _load_formatter():
-    spec = importlib.util.spec_from_file_location(
-        "format_dogfooding_comment", _SCRIPT_PATH
-    )
+    spec = importlib.util.spec_from_file_location("format_dogfooding_comment", _SCRIPT_PATH)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -55,10 +50,7 @@ def _diag_actionable_fail() -> dict[str, Any]:
     return {
         "rule_id": "rule-dogfooding-rules-L23",
         "status": "fail",
-        "message": (
-            "The PR description does not name the user-visible change in "
-            "the first sentence."
-        ),
+        "message": ("The PR description does not name the user-visible change in the first sentence."),
         "evidence": [
             {
                 "kind": "llm_judgment",


### PR DESCRIPTION
Closes #240.

## Summary

- Advisory PR comments were listing structurally-skipped UNSUPPORTED rules in the main table alongside genuine findings, inflating the apparent failure count (e.g. PR #238 surfaced 3 rows where only 1 was author-actionable).
- Filter UNSUPPORTED diagnostics whose first `evidence.kind` is `target_kind_mismatch` (deterministic precheck, #178) or `llm_quote_fabrication` (parser-side reject, #172) out of the main table and collapse them into a `<details>` summary with a per-kind breakdown.
- When every diagnostic is a structural skip, the main table is replaced with a one-line "no author-actionable findings" placeholder so the comment still reads cleanly.

## Output shape (matching the issue's PR #238 example)

```
| rule | status | judgment | primary_reason |
| --- | --- | --- | --- |
| rule-dogfooding-rules-L23 | FAIL | fail | ... |

<details>
<summary>2 rule(s) structurally skipped (no author action required): llm_quote_fabrication=1, target_kind_mismatch=1</summary>
...
</details>
```

## Scope

- `format_dogfooding_comment.py` only. No IR/backend changes — #178 and #172 are already merged; this just stops showing their successful defences as per-PR noise.
- Other UNSUPPORTED kinds (`provider_unconfigured`, `provider_error`, etc.) stay in the main table — pinned by a regression test.
- Promotion path (`docs/dogfooding.md`) unchanged; one explanatory paragraph added.

## Test plan

- [x] `uv run pytest tests/test_format_dogfooding_comment.py` — 4 new tests (actionable-only, structural-skip-only, mixed, non-structural UNSUPPORTED retained).
- [x] `uv run pytest` — full suite 1447 passed.
- [x] `uvx ruff check` + `uvx pyright` — clean.
- [x] Smoke-test with PR #238-shaped fixture matches expected layout.

Refs: parent umbrella #63 (semantic rubric quality); prior workflow tightening in PR #239 (sticky upsert + fallback guard); closed traces #169 / #172 / #175 / #178 / #186 / #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)