### PR TITLE
fix: resolve DOTENV_PATH relative to user home (#245)

### DIFF
--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -108,7 +108,11 @@ class Strategy(Protocol):
     def __call__(self, request: JudgmentRequest) -> Diagnostic: ...
 
 
-DOTENV_PATH = Path(os.environ["GATE_KEEPER_DOTENV"]) if os.environ.get("GATE_KEEPER_DOTENV") else Path.home() / ".config/hermes-projects/gate-keeper.env"
+DOTENV_PATH = (
+    Path(os.environ["GATE_KEEPER_DOTENV"])
+    if os.environ.get("GATE_KEEPER_DOTENV")
+    else Path.home() / ".config/hermes-projects/gate-keeper.env"
+)
 
 ANTHROPIC_DEFAULT_MODEL = "claude-haiku-4-5"
 OPENAI_DEFAULT_MODEL = "gpt-4o-mini"

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import os
 import re
 import time
 from dataclasses import dataclass, field
@@ -107,7 +108,7 @@ class Strategy(Protocol):
     def __call__(self, request: JudgmentRequest) -> Diagnostic: ...
 
 
-DOTENV_PATH = Path("/home/vscode/.config/hermes-projects/gate-keeper.env")
+DOTENV_PATH = Path(os.environ["GATE_KEEPER_DOTENV"]) if os.environ.get("GATE_KEEPER_DOTENV") else Path.home() / ".config/hermes-projects/gate-keeper.env"
 
 ANTHROPIC_DEFAULT_MODEL = "claude-haiku-4-5"
 OPENAI_DEFAULT_MODEL = "gpt-4o-mini"

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -1935,8 +1935,14 @@ class TestPromptVersion:
 
 class TestPathConstants:
     def test_dotenv_path_matches_spec(self):
-        """Issue #51 hard-codes the host-side dotenv path; do not regress it."""
-        assert llm_backend.DOTENV_PATH == Path("/home/vscode/.config/hermes-projects/gate-keeper.env")
+        """Issue #245: DOTENV_PATH resolves relative to the running user's home."""
+        import os
+        expected = (
+            Path(os.environ["GATE_KEEPER_DOTENV"])
+            if os.environ.get("GATE_KEEPER_DOTENV")
+            else Path.home() / ".config/hermes-projects/gate-keeper.env"
+        )
+        assert llm_backend.DOTENV_PATH == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -1937,6 +1937,7 @@ class TestPathConstants:
     def test_dotenv_path_matches_spec(self):
         """Issue #245: DOTENV_PATH resolves relative to the running user's home."""
         import os
+
         expected = (
             Path(os.environ["GATE_KEEPER_DOTENV"])
             if os.environ.get("GATE_KEEPER_DOTENV")


### PR DESCRIPTION
Closes #245

## Changes

- `DOTENV_PATH` now resolves to `Path.home() / ".config/hermes-projects/gate-keeper.env"` instead of the hardcoded `/home/vscode/...` path
- Added `GATE_KEEPER_DOTENV` env-var override for the **path only** (not credentials), enabling CI/multi-project setups to point at a different file
- Updated `TestPathConstants::test_dotenv_path_matches_spec` to assert the portable value

## Validation

```
uv run pytest --ignore=tests/test_dogfooding_rules.py -x -q
1438 passed in 5.24s
```