### PR TITLE
dogfooding-rules v2: reword L23/L24, drop L25 (closes #253, #242)

### DIFF
--- a/docs/dogfooding-rules.md
+++ b/docs/dogfooding-rules.md
@@ -15,30 +15,41 @@ carrying `provider_unconfigured` evidence. See
 [`llm-rubric.md`](llm-rubric.md) for the contract details.
 
 Promotion criteria live in [`dogfooding.md`](dogfooding.md). At time of
-authoring, the three rules below are advisory only and do not meet the
+authoring, the two rules below are advisory only and do not meet the
 trailing-10-PR criteria.
 
 ## Semantic advisory rules
 
-- The PR description should name the user-visible change in the first sentence. [target_kind: pr_description]
-- The PR description should state how the change was tested. [target_kind: pr_description]
-- The commit message should explain why the change was made, not only what was changed. [target_kind: commit_message]
+- The PR description body should describe the user-visible change introduced by this PR. The description may appear anywhere in the body — for example, in a `## Summary` section, a `## What changed` bullet, or the opening sentence. Leading metadata (`Closes #N`, `Fixes #N`, `Refs #N`, badge images) is not the description. [target_kind: pr_description]
+- The PR description should describe how the change was verified — for example, an explicit `## Test plan` or `## Validation` section, the test commands run, or an affirmation that the change does not require new tests with a brief reason. [target_kind: pr_description]
+
+The pool intentionally omits a commit-message rule: the dogfood workflow
+([`.github/workflows/dogfooding.yml`](../.github/workflows/dogfooding.yml))
+only dispatches `--artifact-kind pr_description`, so a `commit_message`
+rule would short-circuit to `Status.UNSUPPORTED` on every run (see #242
+for the dispatch-shape decision; the deferred commit-message dogfood
+tracker lives under umbrella #63).
 
 ## Rationale per rule
 
-The three rules above adapt the vetted "good" worked examples in
-[`semantic-rules.md`](semantic-rules.md) §3.1, §3.2, and §3.6. They
-cover three dimensions of the benchmark fixture (#65):
+The two rules above adapt the vetted "good" worked examples in
+[`semantic-rules.md`](semantic-rules.md) §3.1 and §3.2. They cover two
+dimensions of the benchmark fixture (#65):
 
 | Rule | Dimension | Source |
 |---|---|---|
-| First-sentence user-visible change | Clarity | `semantic-rules.md §3.1` |
-| Testing method stated | Completeness | `semantic-rules.md §3.2` |
-| Why-not-only-what in commit message | Justification | `semantic-rules.md §3.6` |
+| PR-body describes the user-visible change (anywhere in the body) | Clarity | `semantic-rules.md §3.1` |
+| PR-body describes how the change was verified | Completeness | `semantic-rules.md §3.2` |
 
 Each rule is target-grounded (`semantic-rules.md §1`): the model
 evaluates a single observable predicate against a concrete piece of
 text rather than an abstract quality such as "clear" or "good".
+
+The v2 wording (#253) matches the real PR conventions both this repo
+and `uda-lab/hermes-engineering` follow — `Closes #N` + `## Summary` +
+`## Validation` template — so the predicate is satisfied by conforming
+PRs instead of failing ~90% of them on the prior `first sentence` /
+`how the change was tested` phrasing.
 
 ## What this document does NOT settle
 

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -82,9 +82,18 @@ phase is worthless if findings are not captured.
 ## Initial advisory rule pool
 
 The seed pool of semantic self-gating rules lives in
-[`dogfooding-rules.md`](dogfooding-rules.md). All three rules in that
-document are advisory only at the time of authoring; none meets the
-promotion criteria in this document yet.
+[`dogfooding-rules.md`](dogfooding-rules.md). The two rules in that
+document are advisory only and do not meet the promotion criteria in
+this document yet.
+
+The pool intentionally ships **no commit-message rule**: the dogfood
+workflow only dispatches `--artifact-kind pr_description`, so any rule
+annotated `target_kind: commit_message` would short-circuit to
+`Status.UNSUPPORTED` (`evidence.kind=target_kind_mismatch`) on every PR
+by construction. The deferred "commit-message dogfood" tracker is #242
+under umbrella #63; reintroduce a commit-message rule once the workflow
+also dispatches the head commit's `%B` with `--artifact-kind
+commit_message`.
 
 ## Dependency-gate dogfood (umbrella #159)
 

--- a/tests/test_dogfooding_rules.py
+++ b/tests/test_dogfooding_rules.py
@@ -1,16 +1,21 @@
-"""Tests for the semantic self-gating advisory rule pool (#72).
+"""Tests for the semantic self-gating advisory rule pool (#72, #253, #242).
 
 These tests pin four contracts:
 
-1. ``docs/dogfooding-rules.md`` extracts to exactly three semantic rules.
-2. The classifier routes all three to ``semantic_rubric`` / ``llm-rubric``
+1. ``docs/dogfooding-rules.md`` extracts to exactly two semantic rules.
+   The v2 pool (#253) keeps the two PR-description rules and drops the
+   former L25 commit-message rule per #242 Option C — the dogfood
+   workflow only dispatches ``--artifact-kind pr_description`` so a
+   ``commit_message`` rule would short-circuit to ``UNSUPPORTED`` on
+   every run.
+2. The classifier routes both to ``semantic_rubric`` / ``llm-rubric``
    (no deterministic-backend mis-routing).
 3. With no LLM provider configured, ``llm_rubric.check`` returns
    ``Status.UNAVAILABLE`` with ``provider_unconfigured`` evidence — the
    fail-closed advisory contract documented in ``docs/llm-rubric.md``.
 4. (#169) Each rule carries the expected ``target_kind`` annotation
-   (PR-description rules vs commit-message rules) so the rubric backend
-   can recognise the target-kind-mismatch case.
+   (``pr_description``) so the rubric backend can recognise the
+   target-kind-mismatch case.
 
 The DOTENV_PATH used by the llm_rubric backend is monkeypatched to a
 non-existent tmpdir so the test does not depend on the developer's local
@@ -37,22 +42,30 @@ class TestParserExtraction:
     def test_dogfooding_rules_doc_exists(self):
         assert _RULES_DOC.is_file(), f"missing rules doc: {_RULES_DOC}"
 
-    def test_extracts_exactly_three_rules(self):
+    def test_extracts_exactly_two_rules(self):
         ruleset = _ruleset()
-        assert len(ruleset.rules) == 3, [r.text for r in ruleset.rules]
+        assert len(ruleset.rules) == 2, [r.text for r in ruleset.rules]
 
     def test_rule_texts_match_authored_phrasings(self):
-        # The phrasings adapt docs/semantic-rules.md §3.1 / §3.2 / §3.6 with
-        # a `should` prefix so the bullets are picked up by the parser as
-        # candidates. Filesystem-style verbs (`contain` / `include`) are
-        # avoided so the classifier does not mis-route to FILESYSTEM.
+        # The phrasings adapt docs/semantic-rules.md §3.1 and §3.2. The v2
+        # wording (#253) describes the user-visible change and the
+        # verification method anywhere in the body, matching the real
+        # `Closes #N` + `## Summary` + `## Validation` template both this
+        # repo and uda-lab/hermes-engineering follow. Filesystem-style
+        # verbs (`contain` / `include`) are avoided so the classifier does
+        # not mis-route to FILESYSTEM. L25 (commit-message rule) was
+        # dropped per #242 Option C.
         ruleset = _ruleset()
         texts = [r.text for r in ruleset.rules]
-        assert "The PR description should name the user-visible change in the first sentence." in texts
-        assert "The PR description should state how the change was tested." in texts
-        assert (
-            "The commit message should explain why the change was made, not only what was changed." in texts
-        )
+        # Identify each rule by a substring rather than exact match — v2
+        # wording carries embedded examples and the long form changes
+        # whenever rationale grows.
+        _l23_prefix = "The PR description body should describe the user-visible change introduced by this PR."
+        _l24_prefix = "The PR description should describe how the change was verified"
+        assert any(t.startswith(_l23_prefix) for t in texts), texts
+        assert any(t.startswith(_l24_prefix) for t in texts), texts
+        # No commit-message rule must remain in the pool.
+        assert not any(t.lower().startswith("the commit message") for t in texts), texts
 
 
 class TestClassifierRouting:
@@ -72,29 +85,30 @@ class TestClassifierRouting:
 class TestTargetKindAnnotations:
     """#169 — every rule in dogfooding-rules.md must carry an explicit target_kind.
 
-    The orchestrator runs the rule doc against multiple artifact kinds (PR
-    bodies and commit messages); the annotation is what lets the rubric
-    backend recognise the target-kind-mismatch case rather than parroting
-    a PR-description rule's wording onto a commit message.
+    After the v2 rewrite (#253) and #242 Option C, the pool is exclusively
+    PR-description rules; the former commit-message rule (L25) was dropped
+    because the dogfood workflow only dispatches ``--artifact-kind
+    pr_description``. The target_kind annotation still exists so the
+    rubric backend can recognise a target-kind-mismatch case if a
+    `commit_message` rule is reintroduced in the future.
     """
 
-    def test_pr_description_rules_carry_pr_description_kind(self):
+    def test_all_rules_carry_pr_description_kind(self):
         ruleset = _ruleset()
-        pr_rules = [r for r in ruleset.rules if r.text.startswith("The PR description should")]
-        assert pr_rules, "expected at least one PR-description rule"
-        for rule in pr_rules:
+        assert ruleset.rules, "expected at least one rule"
+        for rule in ruleset.rules:
             assert rule.target_kind is TargetKind.PR_DESCRIPTION, (
                 f"{rule.text!r} carries {rule.target_kind.value} (expected pr_description)"
             )
 
-    def test_commit_message_rule_carries_commit_message_kind(self):
+    def test_no_commit_message_rule_in_pool(self):
+        """#242 Option C — L25 (commit-message rule) is dropped until the
+        dogfood workflow grows a ``commit_message`` dispatch."""
         ruleset = _ruleset()
-        commit_rules = [r for r in ruleset.rules if r.text.startswith("The commit message should")]
-        assert commit_rules, "expected at least one commit-message rule"
-        for rule in commit_rules:
-            assert rule.target_kind is TargetKind.COMMIT_MESSAGE, (
-                f"{rule.text!r} carries {rule.target_kind.value} (expected commit_message)"
-            )
+        commit_rules = [r for r in ruleset.rules if r.target_kind is TargetKind.COMMIT_MESSAGE]
+        assert not commit_rules, (
+            f"unexpected commit-message rule(s) in dogfood pool: {[r.text for r in commit_rules]}"
+        )
 
     def test_no_rule_has_target_kind_parse_warning(self):
         """Annotations in the doc must use known values (no typo recovery)."""


### PR DESCRIPTION
Closes #253
Closes #242

Joint dispatch under umbrella #255 — owner ratified in both children's 2026-05-23 comments (`#253` is the consolidation hub for dogfood semantic-pool cleanup; `#242` is the L25-drop subset). Absorbs the L25/structural-skip discussion from #251 / #252 / #243 (linked via #253 body's before/after data).

## Summary

The v1 dogfood rule pool was the initial seed and its wording had not been revisited since. Re-running the 80-target dataset from #251 confirmed a systemic ~10% pass rate — not because the artifacts are bad, but because the predicates ("first sentence", "how the change was tested") do not match the `Closes #N` + `## Summary` + `## Validation` template both this repo and `uda-lab/hermes-engineering` actually follow. An advisory rule that fails ~90% of conforming PRs has lost signal.

This PR:

- **Rewords L23 / L24** in `docs/dogfooding-rules.md` to v2 — accepts the user-visible change anywhere in the body (`## Summary` / `## What changed` / opening sentence) and accepts an explicit `## Test plan` / `## Validation` section, raw test commands, or an opt-out affirmation with a brief reason. Aggregate pass-rate on the 80-target dataset moves from ~10% to ~60% with no model or backend change.
- **Drops L25** (commit-message rule) per #242 Option C. The dogfood workflow only dispatches `--artifact-kind pr_description`, so any rule annotated `target_kind: commit_message` short-circuits to `Status.UNSUPPORTED` on every PR by construction. The deferred commit-message dogfood tracker (workflow extension) lives under umbrella #63.
- **Updates `tests/test_dogfooding_rules.py`** to expect exactly 2 semantic rules and replaces the commit-message-specific assertion with a negative assertion that no commit-message rule remains in the pool. All target-kind annotations are now `pr_description`.
- **Cross-references #242 in `docs/dogfooding.md`** as the deferred commit-message dogfood tracker, explaining why the pool intentionally ships no commit-message rule.

## Validation

```sh
uv run pytest tests/test_dogfooding_rules.py -v
# 9 passed in 0.05s — all three target_kind / extraction / fail-closed contracts hold

uv run gate-keeper compile docs/dogfooding-rules.md
# Two rules emitted, both target_kind=pr_description, both backend=llm-rubric

uvx ruff check . && uvx ruff format --check .
# All checks passed; 76 files already formatted

uv run pyright tests/test_dogfooding_rules.py
# 0 errors, 0 warnings
```

Light fixture sanity check: `tests/fixtures/semantic/entries/clarity-01-pr-description-named-change.json` and `completeness-03-pr-tests-mentioned.json` carry their own inline `rule_text` (not pulled from `dogfooding-rules.md`), so the bench fixtures are unaffected by the rewording. The full repo test suite has one pre-existing failure on `main` (`tests/test_dependency_validator.py::test_validator_emit_shape`) that is unrelated to this change — verified by re-running with the diff stashed.

## Heads-up for #246

Next-up #246 (semantic rule forbidding hardcoded user-specific paths) will add a 3rd rule to `docs/dogfooding-rules.md`. Rebase coordination may apply — the file structure is intentionally simple (`## Semantic advisory rules` bullets with trailing `[target_kind: …]` annotations) so the merge should be a clean append.

## Out of scope (intentionally)

- Quote-fabrication recovery (#254 — model-level concern, tracked separately)
- Strategy choice changes (#183–#186 — orthogonal `consensus` / `review` work)
- Rule expansion beyond rewording L23 / L24 (subject to the promotion process in `docs/dogfooding.md`)
- Workflow YAML changes — #242 Option A (extending `dogfooding.yml` with a second `--artifact-kind commit_message` invocation) was rejected by owner; commit-message dispatch is deferred per the cross-reference in `docs/dogfooding.md`.

## Test plan

- [x] `uv run pytest tests/test_dogfooding_rules.py -v` (all 9 pass)
- [x] `uv run gate-keeper compile docs/dogfooding-rules.md` (two rules, both `pr_description`)
- [x] `uvx ruff check .` + `uvx ruff format --check .` (clean)
- [x] `uv run pyright tests/test_dogfooding_rules.py` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)