### PR TITLE
llm-rubric: migrate OpenAI backend to Responses API (closes #248)

### DIFF
--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -133,6 +133,59 @@ Behavior:
 `gate-keeper diagnose` surfaces the resolved model and whether it came
 from an override or the default.
 
+### Restricted API key setup
+
+Provider-specific key restriction is not a single shared mechanism — each
+provider exposes a different surface, so the minimal-permission setup for
+gate-keeper must be configured per provider.
+
+**OpenAI (post-#248).** The backend calls
+`client.responses.create(...)` (the `/v1/responses` endpoint). When
+issuing a restricted API key from the OpenAI Platform UI, set only:
+
+- `Responses` (`/v1/responses`): **Request**
+- `Chat completions` (`/v1/chat/completions`): **None** — gate-keeper no
+  longer touches this endpoint after #248.
+- All other resources / capabilities: **None**.
+
+This is the minimal endpoint surface required for `_call_openai` in
+`src/gate_keeper/backends/llm_rubric.py`. Do not enable agent tools,
+file search, web search, or code interpreter — gate-keeper does not use
+any Responses API tool surface.
+
+**Anthropic.** The Anthropic Console does not currently expose the
+endpoint-by-endpoint capability matrix that OpenAI offers, so there is no
+direct equivalent of `Responses: Request, Chat completions: None`.
+Practical isolation for gate-keeper is workspace- and spend-scoped
+instead:
+
+- Create a dedicated Anthropic workspace (or at minimum a dedicated API
+  key) used only by gate-keeper.
+- Apply a low spend limit on that workspace/key so a runaway loop is
+  bounded by billing rather than by capability scoping.
+- Rotate the key independently of other Anthropic keys you hold.
+
+The gate-keeper Anthropic backend uses the Messages API via
+`client.messages.create(...)`; no further endpoint restriction is
+available in the standard Console flow.
+
+**Google AI Studio / Gemini (forward note).** gate-keeper does not
+currently support a Gemini provider. If a Gemini backend is added later,
+its restricted-key guidance will not match the OpenAI shape either — it
+will use Google Cloud's mechanisms:
+
+- Issue the key from a dedicated Google Cloud project used only by
+  gate-keeper.
+- Restrict the API key to the Generative Language API (Gemini) and deny
+  all other APIs.
+- Where applicable, add API-key application restrictions such as a fixed
+  egress IP allowlist.
+- Set low quota and billing limits on the project.
+
+Treat OpenAI endpoint permissions, Anthropic workspace/spend isolation,
+and Google Cloud API-key restrictions as three distinct mechanisms, not
+one shared provider-neutral security model.
+
 ### CI exception: GitHub Actions secret projection
 
 The host-side dotenv route is the only credential path the backend reads
@@ -375,8 +428,8 @@ detection, cost analysis, and per-rule SLA work:
 | Field | Type | Source | Semantics |
 | --- | --- | --- | --- |
 | `latency_ms` | `int` (milliseconds) | `time.perf_counter()` around the SDK call | Wall-clock duration of the provider call, integer-rounded. |
-| `tokens_in` | `int` | Anthropic `usage.input_tokens` / OpenAI `usage.prompt_tokens` | Provider-reported prompt token count. |
-| `tokens_out` | `int` | Anthropic `usage.output_tokens` / OpenAI `usage.completion_tokens` | Provider-reported completion token count. |
+| `tokens_in` | `int` | Anthropic `usage.input_tokens` / OpenAI Responses `usage.input_tokens` | Provider-reported prompt token count. |
+| `tokens_out` | `int` | Anthropic `usage.output_tokens` / OpenAI Responses `usage.output_tokens` | Provider-reported completion token count. |
 | `cost_estimate_usd` | `float \| null` | Static `_MODEL_PRICING` table (snapshot 2026-05-08) | Estimated USD cost for this call; `null` for unknown models (fail-closed). |
 
 Pricing snapshot (2026-05-08) used for `cost_estimate_usd`:

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -1179,27 +1179,33 @@ def _reasoning_effort_for(model: str) -> str | None:
 
 
 def _call_openai(api_key: str, system: str, user: str, model: str) -> tuple[str, dict[str, int]]:
-    """Call OpenAI and return ``(response_text, telemetry)``.
+    """Call OpenAI Responses API and return ``(response_text, telemetry)``.
 
     Telemetry keys (#76):
 
     - ``latency_ms``: wall-clock provider call duration, integer milliseconds.
     - ``tokens_in``: provider-reported prompt token count
-      (OpenAI ``usage.prompt_tokens``).
+      (OpenAI Responses ``usage.input_tokens``).
     - ``tokens_out``: provider-reported completion token count
-      (OpenAI ``usage.completion_tokens``).
+      (OpenAI Responses ``usage.output_tokens``).
 
     Fail-closed contract (#76 follow-up): if the provider response omits
-    ``usage.prompt_tokens`` or ``usage.completion_tokens`` (or the entire
+    ``usage.input_tokens`` or ``usage.output_tokens`` (or the entire
     ``usage`` object), raise :class:`RuntimeError`. The caller in
     :func:`check` catches this and dispatches a ``provider_error``
     diagnostic; we never synthesise a zero token count.
 
     Reasoning-class models (#233): ``gpt-5*``, ``o1*``, ``o3*`` receive a
-    model-family-specific ``reasoning_effort`` at the lowest tier
-    (``minimal`` for gpt-5, ``none`` for gpt-5.4) and a raised
-    ``max_completion_tokens`` (2000 vs 600) so the visible response is not
+    model-family-specific reasoning effort at the lowest tier
+    (``minimal`` for gpt-5, ``none`` for gpt-5.4) via the Responses API
+    ``reasoning={"effort": ...}`` parameter, and a raised
+    ``max_output_tokens`` (2000 vs 600) so the visible response is not
     starved by reasoning token consumption.
+
+    API endpoint (#248): this helper targets ``/v1/responses`` exclusively
+    via ``client.responses.create``. A restricted OpenAI key for
+    gate-keeper needs only ``Responses (/v1/responses): Request`` enabled;
+    ``Chat completions (/v1/chat/completions)`` may be set to ``None``.
     """
     from openai import OpenAI
 
@@ -1210,38 +1216,38 @@ def _call_openai(api_key: str, system: str, user: str, model: str) -> tuple[str,
 
     client = OpenAI(api_key=api_key)
     start = time.perf_counter()
-    messages = [
+    input_messages = [
         {"role": "system", "content": system},
         {"role": "user", "content": user},
     ]
     if effort is not None:
-        resp = client.chat.completions.create(
+        resp = client.responses.create(
             model=model,
-            max_completion_tokens=max_tokens,
-            messages=messages,  # type: ignore[arg-type]
-            reasoning_effort=effort,  # type: ignore[arg-type]
+            max_output_tokens=max_tokens,
+            input=input_messages,  # type: ignore[arg-type]
+            reasoning={"effort": effort},  # type: ignore[arg-type]
         )
     else:
-        resp = client.chat.completions.create(
+        resp = client.responses.create(
             model=model,
-            max_completion_tokens=max_tokens,
-            messages=messages,  # type: ignore[arg-type]
+            max_output_tokens=max_tokens,
+            input=input_messages,  # type: ignore[arg-type]
         )
     latency_ms = int(round((time.perf_counter() - start) * 1000))
-    text = resp.choices[0].message.content or ""
+    text = resp.output_text or ""
     usage = getattr(resp, "usage", None)
     if usage is None:
         raise RuntimeError("OpenAI response missing usage block; cannot record token telemetry.")
-    prompt_tokens = getattr(usage, "prompt_tokens", None)
-    completion_tokens = getattr(usage, "completion_tokens", None)
-    if prompt_tokens is None:
-        raise RuntimeError("OpenAI response missing usage.prompt_tokens; cannot record token telemetry.")
-    if completion_tokens is None:
-        raise RuntimeError("OpenAI response missing usage.completion_tokens; cannot record token telemetry.")
+    input_tokens = getattr(usage, "input_tokens", None)
+    output_tokens = getattr(usage, "output_tokens", None)
+    if input_tokens is None:
+        raise RuntimeError("OpenAI response missing usage.input_tokens; cannot record token telemetry.")
+    if output_tokens is None:
+        raise RuntimeError("OpenAI response missing usage.output_tokens; cannot record token telemetry.")
     return text, {
         "latency_ms": latency_ms,
-        "tokens_in": int(prompt_tokens),
-        "tokens_out": int(completion_tokens),
+        "tokens_in": int(input_tokens),
+        "tokens_out": int(output_tokens),
     }
 
 

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -745,30 +745,25 @@ class TestEvidenceObservability:
         assert "usage" in detail.lower() or "input_tokens" in detail.lower()
 
     def test_missing_usage_openai_maps_to_unavailable(self, monkeypatch, tmp_path):
-        """OpenAI response without usage fields must fail closed (no synthetic 0)."""
+        """OpenAI Responses API response without usage fields must fail closed (no synthetic 0)."""
         _patch_env(monkeypatch, self._OPENAI_ENV)
 
-        class _UsageMissingCompletion:
-            prompt_tokens = 250
-            # completion_tokens deliberately absent
-
-        class _Choice:
-            class message:  # noqa: N801
-                content = _VALID_PASS_JSON
+        class _UsageMissingOutput:
+            input_tokens = 250
+            # output_tokens deliberately absent
 
         class _Resp:
-            choices = [_Choice()]
-            usage = _UsageMissingCompletion()
+            output_text = _VALID_PASS_JSON
+            usage = _UsageMissingOutput()
 
         class _Client:
             def __init__(self, *_a, **_k):
                 pass
 
-            class chat:  # noqa: N801
-                class completions:  # noqa: N801
-                    @staticmethod
-                    def create(*_a, **_k):
-                        return _Resp()
+            class responses:  # noqa: N801
+                @staticmethod
+                def create(*_a, **_k):
+                    return _Resp()
 
         import sys
 
@@ -783,7 +778,7 @@ class TestEvidenceObservability:
         assert "tokens_in" not in diag.evidence[0].data
         assert "tokens_out" not in diag.evidence[0].data
         detail = diag.evidence[0].data["detail"]
-        assert "usage" in detail.lower() or "completion_tokens" in detail.lower()
+        assert "usage" in detail.lower() or "output_tokens" in detail.lower()
 
     def test_missing_usage_block_anthropic_maps_to_unavailable(self, monkeypatch, tmp_path):
         """Anthropic response with no usage object at all must fail closed."""
@@ -4591,19 +4586,24 @@ class TestFindPerTargetFabricatedQuotes:
 
 
 class TestReasoningEffortParamRouting:
-    """Verify that _call_openai passes correct reasoning_effort / max_completion_tokens
-    per model family (#233).
+    """Verify that _call_openai passes correct reasoning effort / max_output_tokens
+    per model family (#233, #248).
 
-    All tests stub OpenAI().chat.completions.create to capture kwargs so that
+    All tests stub OpenAI().responses.create to capture kwargs so that
     no real network call is made.  The disable_llm_dotenv autouse fixture
     (conftest.py) ensures no host credential file is read.
+
+    Post-#248: the helper targets the Responses API. Reasoning effort
+    travels in the ``reasoning={"effort": ...}`` dict, the token budget
+    parameter is ``max_output_tokens``, and the prompt parameter is
+    ``input`` (list of role/content dicts).
     """
 
     def _make_fake_response(self):
-        """Return a minimal fake openai ChatCompletion response object."""
+        """Return a minimal fake openai Responses-API response object."""
         import types
 
-        usage = types.SimpleNamespace(prompt_tokens=10, completion_tokens=5)
+        usage = types.SimpleNamespace(input_tokens=10, output_tokens=5)
         _content = json.dumps(
             {
                 "judgment": "pass",
@@ -4612,31 +4612,26 @@ class TestReasoningEffortParamRouting:
                 "suggested_action": None,
             }
         )
-        message = types.SimpleNamespace(content=_content)
-        choice = types.SimpleNamespace(message=message)
-        return types.SimpleNamespace(choices=[choice], usage=usage)
+        return types.SimpleNamespace(output_text=_content, usage=usage)
 
     def _patch_openai(self, monkeypatch):
-        """Patch OpenAI client so create() records kwargs and returns a fake response.
+        """Patch OpenAI client so responses.create() records kwargs and returns a fake response.
 
         Returns a list that is appended to on each create() call:
-            [{"model": ..., "max_completion_tokens": ..., "reasoning_effort": ..., ...}]
+            [{"model": ..., "max_output_tokens": ..., "reasoning": {...}, ...}]
         """
         captured: list[dict] = []
         fake_response = self._make_fake_response()
 
         import openai as _openai_module
 
-        class FakeCompletions:
+        class FakeResponses:
             def create(self, **kwargs):
                 captured.append(dict(kwargs))
                 return fake_response
 
-        class FakeChat:
-            completions = FakeCompletions()
-
         class FakeClient:
-            chat = FakeChat()
+            responses = FakeResponses()
 
         monkeypatch.setattr(_openai_module, "OpenAI", lambda **kw: FakeClient())
         return captured
@@ -4700,80 +4695,80 @@ class TestReasoningEffortParamRouting:
         captured = self._patch_openai(monkeypatch)
         llm_backend._call_openai("sk-test", "system", "user", "gpt-5")
         assert len(captured) == 1
-        assert captured[0]["reasoning_effort"] == "minimal"
+        assert captured[0]["reasoning"] == {"effort": "minimal"}
 
-    def test_gpt5_gets_max_completion_tokens_2000(self, monkeypatch):
+    def test_gpt5_gets_max_output_tokens_2000(self, monkeypatch):
         captured = self._patch_openai(monkeypatch)
         llm_backend._call_openai("sk-test", "system", "user", "gpt-5")
-        assert captured[0]["max_completion_tokens"] == 2000
+        assert captured[0]["max_output_tokens"] == 2000
 
     def test_gpt5_dot4_gets_reasoning_effort_none(self, monkeypatch):
         captured = self._patch_openai(monkeypatch)
         llm_backend._call_openai("sk-test", "system", "user", "gpt-5.4")
-        assert captured[0]["reasoning_effort"] == "none"
+        assert captured[0]["reasoning"] == {"effort": "none"}
 
-    def test_gpt5_dot4_gets_max_completion_tokens_2000(self, monkeypatch):
+    def test_gpt5_dot4_gets_max_output_tokens_2000(self, monkeypatch):
         captured = self._patch_openai(monkeypatch)
         llm_backend._call_openai("sk-test", "system", "user", "gpt-5.4")
-        assert captured[0]["max_completion_tokens"] == 2000
+        assert captured[0]["max_output_tokens"] == 2000
 
     def test_gpt5_unknown_subversion_gets_minimal(self, monkeypatch):
         """gpt-5.99 longest-prefix-matches gpt-5 → minimal."""
         captured = self._patch_openai(monkeypatch)
         llm_backend._call_openai("sk-test", "system", "user", "gpt-5.99")
-        assert captured[0]["reasoning_effort"] == "minimal"
+        assert captured[0]["reasoning"] == {"effort": "minimal"}
 
     # ------------------------------------------------------------------
     # _call_openai kwargs: non-reasoning models (unchanged behaviour)
     # ------------------------------------------------------------------
 
-    def test_gpt4o_no_reasoning_effort(self, monkeypatch):
+    def test_gpt4o_no_reasoning_kwarg(self, monkeypatch):
         captured = self._patch_openai(monkeypatch)
         llm_backend._call_openai("sk-test", "system", "user", "gpt-4o")
-        assert "reasoning_effort" not in captured[0]
+        assert "reasoning" not in captured[0]
 
-    def test_gpt4o_mini_no_reasoning_effort(self, monkeypatch):
+    def test_gpt4o_mini_no_reasoning_kwarg(self, monkeypatch):
         captured = self._patch_openai(monkeypatch)
         llm_backend._call_openai("sk-test", "system", "user", "gpt-4o-mini")
-        assert "reasoning_effort" not in captured[0]
+        assert "reasoning" not in captured[0]
 
-    def test_gpt4o_max_completion_tokens_600(self, monkeypatch):
+    def test_gpt4o_max_output_tokens_600(self, monkeypatch):
         captured = self._patch_openai(monkeypatch)
         llm_backend._call_openai("sk-test", "system", "user", "gpt-4o")
-        assert captured[0]["max_completion_tokens"] == 600
+        assert captured[0]["max_output_tokens"] == 600
 
-    def test_gpt4o_mini_max_completion_tokens_600(self, monkeypatch):
+    def test_gpt4o_mini_max_output_tokens_600(self, monkeypatch):
         captured = self._patch_openai(monkeypatch)
         llm_backend._call_openai("sk-test", "system", "user", "gpt-4o-mini")
-        assert captured[0]["max_completion_tokens"] == 600
+        assert captured[0]["max_output_tokens"] == 600
 
     # ------------------------------------------------------------------
     # _call_openai kwargs: o1*/o3* — reasoning-class without table entry
     # ------------------------------------------------------------------
     # These models match the prefix detector (so they get the raised token
     # budget) but have no entry in _REASONING_EFFORT_RAW (fail-open: no
-    # reasoning_effort kwarg passed, API default applies).  The pattern
+    # reasoning kwarg passed, API default applies).  The pattern
     # locks in the intended behaviour described in #233.
 
-    def test_o1_no_reasoning_effort_kwarg(self, monkeypatch):
+    def test_o1_no_reasoning_kwarg(self, monkeypatch):
         captured = self._patch_openai(monkeypatch)
         llm_backend._call_openai("sk-test", "system", "user", "o1")
-        assert "reasoning_effort" not in captured[0]
+        assert "reasoning" not in captured[0]
 
     def test_o1_uses_reasoning_class_token_budget(self, monkeypatch):
         captured = self._patch_openai(monkeypatch)
         llm_backend._call_openai("sk-test", "system", "user", "o1")
-        assert captured[0]["max_completion_tokens"] == 2000
+        assert captured[0]["max_output_tokens"] == 2000
 
-    def test_o3_mini_no_reasoning_effort_kwarg(self, monkeypatch):
+    def test_o3_mini_no_reasoning_kwarg(self, monkeypatch):
         captured = self._patch_openai(monkeypatch)
         llm_backend._call_openai("sk-test", "system", "user", "o3-mini")
-        assert "reasoning_effort" not in captured[0]
+        assert "reasoning" not in captured[0]
 
     def test_o3_mini_uses_reasoning_class_token_budget(self, monkeypatch):
         captured = self._patch_openai(monkeypatch)
         llm_backend._call_openai("sk-test", "system", "user", "o3-mini")
-        assert captured[0]["max_completion_tokens"] == 2000
+        assert captured[0]["max_output_tokens"] == 2000
 
     # ------------------------------------------------------------------
     # Longest-prefix sort robustness (#233 review thread 3)


### PR DESCRIPTION
## Summary

Migrates the OpenAI provider in `_call_openai()` from Chat Completions (`/v1/chat/completions`) to the Responses API (`/v1/responses`), so a restricted OpenAI key for gate-keeper needs only `Responses: Request` and may set `Chat completions: None`. Telemetry, fail-closed semantics, reasoning-class handling, and JSON parsing are preserved byte-for-byte at the `_call_openai` return boundary.

Scope is strictly the lite-spec posted on #248 (Phase A triage comment): one function rewrite, three doc updates in `docs/llm-rubric.md`, and the SDK-level test mocks in `tests/test_llm_rubric_backend.py`. No Responses-API tool features (file search, web search, code interpreter) introduced.

## Key changes

- `src/gate_keeper/backends/llm_rubric.py` `_call_openai()`:
  - `client.chat.completions.create(...)` -> `client.responses.create(...)`
  - `messages=` -> `input=` (same role/content list shape)
  - `max_completion_tokens=` -> `max_output_tokens=`
  - `reasoning_effort=<str>` -> `reasoning={"effort": <str>}` (Responses API takes a nested Reasoning typed-dict per `openai>=1.50` SDK; verified against the pinned `openai==2.33.0`)
  - `resp.choices[0].message.content` -> `resp.output_text`
  - `usage.prompt_tokens` / `usage.completion_tokens` -> `usage.input_tokens` / `usage.output_tokens`
  - `RuntimeError` messages updated; fail-closed contract for missing usage unchanged.
- `tests/test_llm_rubric_backend.py`:
  - `test_missing_usage_openai_maps_to_unavailable` SDK mock updated to expose `responses.create` returning `output_text` + `usage.{input_tokens, output_tokens}`.
  - `TestReasoningEffortParamRouting._patch_openai` / `_make_fake_response` helpers and all 12 kwarg-assertion tests retargeted at `max_output_tokens` and `reasoning={"effort": ...}`.
- `docs/llm-rubric.md`:
  - New `### Restricted API key setup` subsection. Per owner's 2026-05-23 follow-up on #248, OpenAI / Anthropic / Google are written as three distinct mechanisms — OpenAI gets endpoint-level capability scoping, Anthropic gets workspace + spend-limit isolation, and a forward Gemini note covers Google Cloud API-key restrictions. The closing paragraph states this explicitly.
  - Observability table source column updated: OpenAI token fields now reference Responses `usage.input_tokens` / `usage.output_tokens`.

`openai>=1.50` (pinned in `pyproject.toml`) supports `client.responses.create` and `resp.output_text`; no SDK bump required.

## Validation

| Command | Result |
| --- | --- |
| `uv run pytest tests/test_llm_rubric_backend.py` | 304 passed |
| `uv run pytest` | 1446 passed, 1 failed |
| `uvx ruff check .` | All checks passed |
| `uvx pyright` | 234 errors (unchanged baseline) |

The 1 full-suite failure (`tests/test_dependency_validator.py::test_validator_emit_shape`) and all pyright errors are pre-existing on `main` (verified via `git stash` round-trip on the same worktree). No new failures or skips introduced.

## Test plan

- [x] `_call_openai` exercises the Responses API end-to-end via SDK-level mock (`test_missing_usage_openai_maps_to_unavailable`).
- [x] Reasoning-class effort routing for gpt-5 / gpt-5.4 / gpt-5.99 verified against `reasoning={"effort": ...}` shape.
- [x] Non-reasoning models (gpt-4o, gpt-4o-mini) verified to omit the `reasoning` kwarg entirely.
- [x] o1 / o3-mini verified to get raised `max_output_tokens=2000` without a `reasoning` kwarg.
- [x] Fail-closed contract still raises `RuntimeError` when `usage.input_tokens` or `usage.output_tokens` is absent.

Closes #248