### PR TITLE
dogfood: add semantic rule forbidding hardcoded user-specific paths (closes #246)

### DIFF
--- a/docs/dogfooding-rules.md
+++ b/docs/dogfooding-rules.md
@@ -15,13 +15,14 @@ carrying `provider_unconfigured` evidence. See
 [`llm-rubric.md`](llm-rubric.md) for the contract details.
 
 Promotion criteria live in [`dogfooding.md`](dogfooding.md). At time of
-authoring, the two rules below are advisory only and do not meet the
+authoring, the three rules below are advisory only and do not meet the
 trailing-10-PR criteria.
 
 ## Semantic advisory rules
 
 - The PR description body should describe the user-visible change introduced by this PR. The description may appear anywhere in the body — for example, in a `## Summary` section, a `## What changed` bullet, or the opening sentence. Leading metadata (`Closes #N`, `Fixes #N`, `Refs #N`, badge images) is not the description. [target_kind: pr_description]
 - The PR description should describe how the change was verified — for example, an explicit `## Test plan` or `## Validation` section, the test commands run, or an affirmation that the change does not require new tests with a brief reason. [target_kind: pr_description]
+- Product code must not hardcode absolute filesystem locations that assume a specific user account, devcontainer user, host username, or workspace root layout. Acceptable spellings include `~`, `$HOME`, `${HOME}`, `home()` from pathlib, `platformdirs`, documented placeholders, and CI-only locations explicitly scoped to a workflow step. Test fixtures that exercise location handling are exempt when the test scope makes the intent obvious. [target_kind: pr_description]
 
 The pool intentionally omits a commit-message rule: the dogfood workflow
 ([`.github/workflows/dogfooding.yml`](../.github/workflows/dogfooding.yml))
@@ -32,14 +33,19 @@ tracker lives under umbrella #63).
 
 ## Rationale per rule
 
-The two rules above adapt the vetted "good" worked examples in
+The first two rules adapt the vetted "good" worked examples in
 [`semantic-rules.md`](semantic-rules.md) §3.1 and §3.2. They cover two
-dimensions of the benchmark fixture (#65):
+dimensions of the benchmark fixture (#65). The third rule (env-safety)
+addresses a regression class the prior pool did not cover: PRs that
+land hardcoded user/container-layout paths in product code (anchor case
+[#245](https://github.com/t-uda/gate-keeper/issues/245), tracking issue
+[#246](https://github.com/t-uda/gate-keeper/issues/246)).
 
 | Rule | Dimension | Source |
 |---|---|---|
 | PR-body describes the user-visible change (anywhere in the body) | Clarity | `semantic-rules.md §3.1` |
 | PR-body describes how the change was verified | Completeness | `semantic-rules.md §3.2` |
+| Product code avoids hardcoded user-specific / container-layout paths | Env-safety | #245 anchor / #246 tracking |
 
 Each rule is target-grounded (`semantic-rules.md §1`): the model
 evaluates a single observable predicate against a concrete piece of

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -82,7 +82,7 @@ phase is worthless if findings are not captured.
 ## Initial advisory rule pool
 
 The seed pool of semantic self-gating rules lives in
-[`dogfooding-rules.md`](dogfooding-rules.md). The two rules in that
+[`dogfooding-rules.md`](dogfooding-rules.md). The three rules in that
 document are advisory only and do not meet the promotion criteria in
 this document yet.
 

--- a/tests/fixtures/semantic/entries/env-safety-01-hardcoded-vscode-path.json
+++ b/tests/fixtures/semantic/entries/env-safety-01-hardcoded-vscode-path.json
@@ -1,0 +1,13 @@
+{
+  "rule_text": "Product code must not hardcode absolute filesystem locations that assume a specific user account, devcontainer user, host username, or workspace root layout. Acceptable spellings include `~`, `$HOME`, `${HOME}`, `home()` from pathlib, `platformdirs`, documented placeholders, and CI-only locations explicitly scoped to a workflow step. Test fixtures that exercise location handling are exempt when the test scope makes the intent obvious.",
+  "rule_target_kind": "pr_description",
+  "target": {
+    "kind": "path",
+    "value": "pr_description_hardcoded_path.md"
+  },
+  "expected_judgment": "fail",
+  "expected_rationale_keywords": ["/home/vscode", "hardcoded", "devcontainer", "home()"],
+  "category": "consistency",
+  "intended_backend": "llm-rubric",
+  "notes": "Anchor case for #246 (originally observed in #245). The PR description plainly states that the change introduces `Path(\"/home/vscode/.config/gate-keeper/.env\")` as a module-level constant in src/, which is exactly the spelling the env-safety rule forbids."
+}

--- a/tests/fixtures/semantic/entries/env-safety-02-portable-home.json
+++ b/tests/fixtures/semantic/entries/env-safety-02-portable-home.json
@@ -1,0 +1,13 @@
+{
+  "rule_text": "Product code must not hardcode absolute filesystem locations that assume a specific user account, devcontainer user, host username, or workspace root layout. Acceptable spellings include `~`, `$HOME`, `${HOME}`, `home()` from pathlib, `platformdirs`, documented placeholders, and CI-only locations explicitly scoped to a workflow step. Test fixtures that exercise location handling are exempt when the test scope makes the intent obvious.",
+  "rule_target_kind": "pr_description",
+  "target": {
+    "kind": "path",
+    "value": "pr_description_portable_home.md"
+  },
+  "expected_judgment": "pass",
+  "expected_rationale_keywords": ["home()", "portable", "user"],
+  "category": "consistency",
+  "intended_backend": "llm-rubric",
+  "notes": "Negative counterpart to env-safety-01. The PR description describes resolving the location via `Path.home() / \".config/gate-keeper/.env\"` — `home()` from pathlib is one of the explicitly acceptable spellings called out in the rule text — so the rubric should pass."
+}

--- a/tests/fixtures/semantic/targets/pr_description_hardcoded_path.md
+++ b/tests/fixtures/semantic/targets/pr_description_hardcoded_path.md
@@ -1,0 +1,20 @@
+# Resolve DOTENV_PATH from a fixed devcontainer location
+
+## Summary
+
+Switch `llm_rubric.DOTENV_PATH` to a hardcoded module-level constant so
+the backend always reads provider credentials from the same place on
+this devcontainer.
+
+## What changed
+
+- In `src/gate_keeper/backends/llm_rubric.py`, set
+  `DOTENV_PATH = Path("/home/vscode/.config/gate-keeper/.env")` at
+  module load time.
+- Drop the previous `Path.home() / ".config/gate-keeper/.env"`
+  resolution.
+
+## Validation
+
+- `uv run pytest tests/test_llm_rubric_backend.py` passes locally on
+  the devcontainer.

--- a/tests/fixtures/semantic/targets/pr_description_portable_home.md
+++ b/tests/fixtures/semantic/targets/pr_description_portable_home.md
@@ -1,0 +1,20 @@
+# Resolve DOTENV_PATH relative to the user's home directory
+
+## Summary
+
+Make `llm_rubric.DOTENV_PATH` portable across host accounts and
+devcontainer layouts by resolving it from the current user's home
+directory instead of a hardcoded `/home/vscode/...` literal.
+
+## What changed
+
+- In `src/gate_keeper/backends/llm_rubric.py`, define
+  `DOTENV_PATH = Path.home() / ".config/gate-keeper/.env"` so the
+  backend works for any user account.
+- Document the resolution rule in `docs/llm-rubric.md`.
+
+## Validation
+
+- `uv run pytest tests/test_llm_rubric_backend.py` passes on the
+  devcontainer (`vscode` user) and on a host login with a different
+  username.

--- a/tests/test_dogfooding_rules.py
+++ b/tests/test_dogfooding_rules.py
@@ -1,14 +1,16 @@
-"""Tests for the semantic self-gating advisory rule pool (#72, #253, #242).
+"""Tests for the semantic self-gating advisory rule pool (#72, #253, #242, #246).
 
 These tests pin four contracts:
 
-1. ``docs/dogfooding-rules.md`` extracts to exactly two semantic rules.
+1. ``docs/dogfooding-rules.md`` extracts to exactly three semantic rules.
    The v2 pool (#253) keeps the two PR-description rules and drops the
    former L25 commit-message rule per #242 Option C — the dogfood
    workflow only dispatches ``--artifact-kind pr_description`` so a
    ``commit_message`` rule would short-circuit to ``UNSUPPORTED`` on
-   every run.
-2. The classifier routes both to ``semantic_rubric`` / ``llm-rubric``
+   every run. #246 adds a third PR-description rule that flags PRs
+   landing hardcoded user-specific / container-layout paths in product
+   code (anchor case #245).
+2. The classifier routes all three to ``semantic_rubric`` / ``llm-rubric``
    (no deterministic-backend mis-routing).
 3. With no LLM provider configured, ``llm_rubric.check`` returns
    ``Status.UNAVAILABLE`` with ``provider_unconfigured`` evidence — the
@@ -42,19 +44,25 @@ class TestParserExtraction:
     def test_dogfooding_rules_doc_exists(self):
         assert _RULES_DOC.is_file(), f"missing rules doc: {_RULES_DOC}"
 
-    def test_extracts_exactly_two_rules(self):
+    def test_extracts_exactly_three_rules(self):
         ruleset = _ruleset()
-        assert len(ruleset.rules) == 2, [r.text for r in ruleset.rules]
+        assert len(ruleset.rules) == 3, [r.text for r in ruleset.rules]
 
     def test_rule_texts_match_authored_phrasings(self):
-        # The phrasings adapt docs/semantic-rules.md §3.1 and §3.2. The v2
-        # wording (#253) describes the user-visible change and the
-        # verification method anywhere in the body, matching the real
-        # `Closes #N` + `## Summary` + `## Validation` template both this
-        # repo and uda-lab/hermes-engineering follow. Filesystem-style
-        # verbs (`contain` / `include`) are avoided so the classifier does
-        # not mis-route to FILESYSTEM. L25 (commit-message rule) was
-        # dropped per #242 Option C.
+        # The first two phrasings adapt docs/semantic-rules.md §3.1 and
+        # §3.2. The v2 wording (#253) describes the user-visible change
+        # and the verification method anywhere in the body, matching the
+        # real `Closes #N` + `## Summary` + `## Validation` template both
+        # this repo and uda-lab/hermes-engineering follow. Filesystem-
+        # style verbs (`contain` / `include`) are avoided so the
+        # classifier does not mis-route to FILESYSTEM. L25 (commit-
+        # message rule) was dropped per #242 Option C.
+        #
+        # The third rule (#246, anchor case #245) extends the pool to
+        # cover hardcoded user/container-layout filesystem paths in
+        # product code. The wording preserves the full boundary
+        # definition — acceptable spellings and the test-fixture
+        # exemption — so the rubric prompt has unambiguous context.
         ruleset = _ruleset()
         texts = [r.text for r in ruleset.rules]
         # Identify each rule by a substring rather than exact match — v2
@@ -62,8 +70,10 @@ class TestParserExtraction:
         # whenever rationale grows.
         _l23_prefix = "The PR description body should describe the user-visible change introduced by this PR."
         _l24_prefix = "The PR description should describe how the change was verified"
+        _env_safety_prefix = "Product code must not hardcode absolute filesystem locations"
         assert any(t.startswith(_l23_prefix) for t in texts), texts
         assert any(t.startswith(_l24_prefix) for t in texts), texts
+        assert any(t.startswith(_env_safety_prefix) for t in texts), texts
         # No commit-message rule must remain in the pool.
         assert not any(t.lower().startswith("the commit message") for t in texts), texts
 


### PR DESCRIPTION
Closes #246
Umbrella: #255
Anchor case: #245

## Summary

Extend the dogfood semantic-rule seed pool from two rules to three. The new rule targets the regression class first observed in #245 (a module-level `Path("/home/vscode/.config/...")` literal in `src/`):

> Product code must not hardcode absolute filesystem locations that assume a specific user account, devcontainer user, host username, or workspace root layout. Acceptable spellings include `~`, `$HOME`, `${HOME}`, `home()` from pathlib, `platformdirs`, documented placeholders, and CI-only locations explicitly scoped to a workflow step. Test fixtures that exercise location handling are exempt when the test scope makes the intent obvious.

The rule carries `[target_kind: pr_description]` so it joins the existing dispatch pool — the dogfood workflow only sends `--artifact-kind pr_description` per #242 Option C / #256, so no new artifact-kind or workflow wiring is needed. The rubric judges "does this PR introduce user-specific paths?" from the PR description.

## What changed

- `docs/dogfooding-rules.md`: one new bullet in `## Semantic advisory rules`; rationale section + table extended with an env-safety row that cross-links #245 (anchor) and #246 (tracking).
- `docs/dogfooding.md`: prose count "two rules" → "three rules" to match the pool.
- `tests/test_dogfooding_rules.py`: expects 3 rules (was 2), all `target_kind=pr_description`, all `backend=llm-rubric`; adds a third prefix assertion for the env-safety wording. Updated header docstring.
- `tests/fixtures/semantic/entries/env-safety-01-hardcoded-vscode-path.json`: anchor positive (`expected_judgment: fail`) — PR description plainly describes hardcoding `/home/vscode/.config/...`.
- `tests/fixtures/semantic/entries/env-safety-02-portable-home.json`: negative counterpart (`expected_judgment: pass`) — PR description uses `Path.home() / ".config/..."`.
- `tests/fixtures/semantic/targets/pr_description_hardcoded_path.md` and `pr_description_portable_home.md`: realistic PR-body markdown for the two fixture entries.

## Out of scope (explicit)

- No literal scanner script, no new deterministic backend, no `Backend` enum value.
- No `target_kind` additions.
- No `.github/workflows/dogfooding.yml` changes.
- No edits to `llm_rubric.py`, scheduler/validate code (#249's PR #258 is in-flight against `main`).

## Wording note

The bullet uses `locations` instead of `paths`, and the acceptable-spelling list says `home() from pathlib` instead of `Path.home()`, so the classifier's `_PATH_MEDIUM_RE` (`\\b(?:path|glob|filename|directory|folder)\\b`) does not fire and the rule routes to `RuleKind.SEMANTIC_RUBRIC` as required. Routing is verified by `TestClassifierRouting` in `tests/test_dogfooding_rules.py`.

## Validation

- `uv run pytest tests/test_dogfooding_rules.py tests/test_semantic_fixtures.py tests/test_format_dogfooding_comment.py` — **35 passed**.
- `uv run pytest` — **1446 passed, 1 failed**. The single failure is `tests/test_dependency_validator.py::test_validator_emit_shape`, which is **pre-existing on `origin/main`** (`017af3a`) and unrelated to this PR — verified by running the test on a stashed working tree.
- `uvx ruff check .` — **all checks passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)