### PR TITLE
llm-rubric: adaptive escalation on quote-fabrication (closes #254)

### DIFF
--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -896,3 +896,50 @@ not retroactively.  The template in "Regression tolerance and justification
 template" above is the required format; attach it under a
 `## Prompt regression justification` header in the PR description, referencing
 the prior-version baseline commit SHA for reproducibility.
+
+## Adaptive strategy escalation (`strategy=adaptive`)
+
+The adaptive strategy runs a Tier 1 single-judge call and escalates to a
+multi-call Tier 2 strategy only when the Tier 1 outcome is ambiguous. Two
+escalation triggers exist:
+
+| Tier 1 evidence kind        | Default behaviour              | Tier 2 strategy | Opt-in?                                                     | `adaptive_escalation_reason`     |
+|-----------------------------|--------------------------------|-----------------|-------------------------------------------------------------|----------------------------------|
+| `target_kind_mismatch`      | escalate (always)              | `consensus` (3) | n/a                                                         | `"tier1_unsupported"`            |
+| `llm_quote_fabrication`     | commit Tier 1 UNSUPPORTED      | `review` (2)    | `params.adaptive_escalate_on_quote_fabrication: true` (#254) | `"tier1_quote_fabrication"`      |
+| `provider_error` / `provider_unconfigured` / `strategy_unavailable` | fail-closed at Tier 1 | n/a             | n/a                                                         | `null`                           |
+| `llm_judgment` (`pass` / `fail`) | commit Tier 1 verdict     | n/a             | n/a                                                         | `null`                           |
+
+### Quote-fabrication recovery (`adaptive_escalate_on_quote_fabrication`, #254)
+
+Default: `false`. When a rule sets this param true and the Tier 1 single
+judge returns `llm_quote_fabrication` (one or more supporting quotes are
+not substrings of the artifact), the adaptive strategy escalates to
+`review` — a fresh primary + reviewer pair — instead of committing the
+Tier 1 UNSUPPORTED verdict. The reviewer pass *still* runs every quote
+through `_find_fabricated_quotes`; this path does not weaken the substring
+contract. Three outcomes are possible:
+
+- **Tier 2 grounded verdict (recovery succeeds).** Diagnostic carries
+  `status=pass|fail`, `evidence[0].kind == "llm_adaptive"`,
+  `adaptive_tier == 2`,
+  `adaptive_escalation_reason == "tier1_quote_fabrication"`,
+  `adaptive_recovery_outcome == "tier2_recovered"`, and the original
+  Tier 1 fabrication evidence nested under
+  `tier1_evidence = {"kind": "llm_quote_fabrication", "data": {...}}`.
+- **Tier 2 also UNSUPPORTED (recovery fails).** Diagnostic propagates the
+  *Tier 1* UNSUPPORTED with `evidence[0].kind == "llm_adaptive"`,
+  `adaptive_recovery_outcome == "tier2_unsupported"`, and both
+  `tier1_evidence` and `tier2_evidence` nested so the auditor can see the
+  failure on both passes. No ungrounded verdict is ever emitted.
+- **Param absent or false.** Behaviour is identical to today — Tier 1
+  fabrication commits directly with `adaptive_tier == 1`,
+  `adaptive_escalation_reason == null`.
+
+**Cost note.** Enabling the param can roughly 3× provider calls on the
+affected fraction of rules (1 fabricated Tier 1 + 2 review-pass Tier 2 =
+3 calls per fabrication event). Aggregated `llm_call_count`,
+`cost_estimate_usd_total`, and `latency_ms_total` in `evidence[0].data`
+reflect the combined tier totals. Promote per-rule only after measuring
+the fabrication rate against the rule's baseline; do not flip on at the
+profile or project level.

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -3562,10 +3562,7 @@ def _run_adaptive_strategy(request: JudgmentRequest) -> Diagnostic:
     # path).  The ``target_kind_mismatch`` path retains its original
     # propagation semantics (Tier 2 verdict surfaces directly) so existing
     # callers continue to see the consensus result on disagreement.
-    if (
-        escalation_reason == "tier1_quote_fabrication"
-        and tier2_diag.status is Status.UNSUPPORTED
-    ):
+    if escalation_reason == "tier1_quote_fabrication" and tier2_diag.status is Status.UNSUPPORTED:
         adaptive_overlay_fail: dict[str, Any] = {
             "llm_strategy": "adaptive",
             "adaptive_tier": 2,

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -3364,13 +3364,28 @@ def _run_adaptive_strategy(request: JudgmentRequest) -> Diagnostic:
     escalate to consensus (Tier 2: panel of 3) only when the Tier 1 outcome
     is ambiguous.  Escalation triggers (slice 1):
 
-    - ``target_kind_mismatch`` evidence from Tier 1 → escalate.  The model
-      produced an ``unsupported`` LLM verdict (rule premise does not apply to
-      this artifact kind); a consensus panel may resolve the ambiguity.
-    - ``llm_quote_fabrication`` / ``provider_error`` / ``provider_unconfigured``
-      / ``strategy_unavailable`` evidence → **fail-closed without escalation**.
-      Consensus cannot recover malformed provider responses; surfacing the
-      Tier 1 failure directly is the correct action.
+    - ``target_kind_mismatch`` evidence from Tier 1 → escalate to consensus.
+      The model produced an ``unsupported`` LLM verdict (rule premise does not
+      apply to this artifact kind); a consensus panel may resolve the ambiguity.
+    - ``llm_quote_fabrication`` evidence from Tier 1 → escalate to **review**
+      (Tier 2) **iff** ``params.adaptive_escalate_on_quote_fabrication`` is
+      true (#254).  Default is ``False``; behaviour is unchanged when the
+      param is absent or false.  Recovery uses ``review`` (primary+reviewer)
+      rather than ``consensus`` because the failure mode is a single judge
+      that fabricated quotes — a reviewer pass on a fresh primary call is the
+      cheapest path that still re-validates grounding through
+      :func:`_find_fabricated_quotes` (substring contract is *not* weakened).
+      When Tier 2 also returns fabricated quotes (or any UNSUPPORTED), the
+      original Tier 1 ``llm_quote_fabrication`` UNSUPPORTED is propagated
+      with ``adaptive_escalation_reason = "tier1_quote_fabrication"`` and the
+      Tier 1 evidence nested under ``tier1_evidence`` — no ungrounded verdict
+      is ever emitted.  **Cost note:** enabling this param can roughly 3×
+      provider calls (1 fabricated tier-1 + 2 review-pass tier-2) on the
+      affected fraction of rules.
+    - ``provider_error`` / ``provider_unconfigured`` / ``strategy_unavailable``
+      evidence → **fail-closed without escalation**.  Consensus cannot recover
+      malformed provider responses; surfacing the Tier 1 failure directly is
+      the correct action.
     - ``llm_judgment`` (``pass`` / ``fail``) from Tier 1 → commit to verdict,
       no escalation.
 
@@ -3424,14 +3439,35 @@ def _run_adaptive_strategy(request: JudgmentRequest) -> Diagnostic:
 
     # Determine whether Tier 1 warrants escalation.
     #
-    # Escalation gate: trigger iff the first evidence record has kind
+    # Escalation gate: trigger when the first evidence record has kind
     # ``target_kind_mismatch`` — the model produced an LLM-level
     # ``"unsupported"`` verdict (rule premise does not apply to this artifact
-    # kind).  All other outcomes are either conclusive (PASS/FAIL) or
-    # fail-closed (UNAVAILABLE, llm_quote_fabrication) — consensus cannot
-    # recover those and surfacing the Tier 1 result directly is correct.
+    # kind) — *or* (opt-in via #254) when it has kind
+    # ``llm_quote_fabrication`` and the rule sets
+    # ``params.adaptive_escalate_on_quote_fabrication`` to a truthy value.
+    # All other outcomes are either conclusive (PASS/FAIL) or fail-closed
+    # (UNAVAILABLE, provider_error, provider_unconfigured) — escalation
+    # cannot recover those and surfacing the Tier 1 result directly is correct.
     tier1_ev_kind = tier1_diag.evidence[0].kind if tier1_diag.evidence else ""
-    should_escalate = tier1_ev_kind == "target_kind_mismatch"
+    escalate_on_kind_mismatch = tier1_ev_kind == "target_kind_mismatch"
+    escalate_on_quote_fabrication = tier1_ev_kind == "llm_quote_fabrication" and bool(
+        request.rule.params.get("adaptive_escalate_on_quote_fabrication", False)
+    )
+    should_escalate = escalate_on_kind_mismatch or escalate_on_quote_fabrication
+    # Map the escalation trigger to a stable reason string surfaced via the
+    # ``adaptive_escalation_reason`` evidence field.  Both reasons share the
+    # same Tier 2 plumbing below; only the dispatched strategy and the reason
+    # label differ.
+    escalation_reason: str | None
+    if escalate_on_quote_fabrication:
+        escalation_reason = "tier1_quote_fabrication"
+        tier2_strategy = "review"
+    elif escalate_on_kind_mismatch:
+        escalation_reason = "tier1_unsupported"
+        tier2_strategy = "consensus"
+    else:
+        escalation_reason = None
+        tier2_strategy = ""  # unused
 
     if not should_escalate:
         # Tier 1 is conclusive (PASS/FAIL) or already fail-closed (UNAVAILABLE).
@@ -3470,13 +3506,17 @@ def _run_adaptive_strategy(request: JudgmentRequest) -> Diagnostic:
             remediation=tier1_diag.remediation,
         )
 
-    # --- Tier 2: escalate to consensus ---
-    # Build a consensus request with panel_size=3 (the default) by injecting
-    # consensus_panel_size into a copy of the rule params.
+    # --- Tier 2: escalate using the strategy selected by the trigger ---
+    # ``target_kind_mismatch`` → consensus (panel of 3) to disambiguate.
+    # ``llm_quote_fabrication`` (opt-in, #254) → review (primary+reviewer)
+    # because the failure mode is a single judge producing ungrounded quotes;
+    # a fresh primary call audited by a reviewer is the cheapest path that
+    # still re-validates grounding via ``_find_fabricated_quotes``.
     rule = request.rule
     escalation_params = dict(rule.params)
-    escalation_params["strategy"] = "consensus"
-    escalation_params.setdefault("consensus_panel_size", 3)
+    escalation_params["strategy"] = tier2_strategy
+    if tier2_strategy == "consensus":
+        escalation_params.setdefault("consensus_panel_size", 3)
 
     escalation_rule = dataclasses.replace(rule, params=escalation_params)
     escalation_request = JudgmentRequest(
@@ -3484,12 +3524,16 @@ def _run_adaptive_strategy(request: JudgmentRequest) -> Diagnostic:
         target=request.target,
         artifact_kind=request.artifact_kind,
     )
-    tier2_diag = _run_consensus_strategy(escalation_request)
+    if tier2_strategy == "review":
+        tier2_diag = _run_review_strategy(escalation_request)
+    else:
+        tier2_diag = _run_consensus_strategy(escalation_request)
 
     tier2_ev_data: dict[str, Any] = tier2_diag.evidence[0].data if tier2_diag.evidence else {}
 
-    # Default llm_call_count to 0 for the same reason as Tier 1: if consensus
-    # returns early (e.g. provider_unconfigured), no LLM calls were made.
+    # Default llm_call_count to 0 for the same reason as Tier 1: if the
+    # escalation strategy returns early (e.g. provider_unconfigured), no LLM
+    # calls were made.
     tier2_call_count: int = int(tier2_ev_data.get("llm_call_count", 0))
     tier2_models: list[str] = list(tier2_ev_data.get("models", []))  # type: ignore[arg-type]
     tier2_cost: float | None = tier2_ev_data.get("cost_estimate_usd_total")  # type: ignore[assignment]
@@ -3505,13 +3549,59 @@ def _run_adaptive_strategy(request: JudgmentRequest) -> Diagnostic:
         total_cost = tier1_cost + tier2_cost
     total_latency = tier1_latency + tier2_latency
 
+    # Recovery failure (only on the quote-fabrication path, #254): when the
+    # Tier 1 trigger was ``llm_quote_fabrication`` and Tier 2 also returns
+    # UNSUPPORTED, propagate the *original* Tier 1 fabrication UNSUPPORTED.
+    # Surfacing Tier 2's UNSUPPORTED kind (e.g. ``llm_quote_fabrication``
+    # again, ``review_disagreement``) as the outer evidence kind would mask
+    # the recovery context; emitting ``llm_adaptive`` with the recovery
+    # reason and both tiers' evidence nested keeps the audit trail intact
+    # and prevents any ungrounded verdict from ever being emitted (the
+    # substring contract enforced by ``_find_fabricated_quotes`` is *not*
+    # weakened — Tier 2's grounded-verdict path remains the only success
+    # path).  The ``target_kind_mismatch`` path retains its original
+    # propagation semantics (Tier 2 verdict surfaces directly) so existing
+    # callers continue to see the consensus result on disagreement.
+    if (
+        escalation_reason == "tier1_quote_fabrication"
+        and tier2_diag.status is Status.UNSUPPORTED
+    ):
+        adaptive_overlay_fail: dict[str, Any] = {
+            "llm_strategy": "adaptive",
+            "adaptive_tier": 2,
+            "adaptive_escalation_reason": escalation_reason,
+            "adaptive_recovery_outcome": "tier2_unsupported",
+            "llm_call_count": total_call_count,
+            "models": total_models,
+            "cost_estimate_usd_total": total_cost,
+            "latency_ms_total": total_latency,
+            "tier1_evidence": {"kind": tier1_ev_kind, "data": tier1_ev_data},
+            "tier2_evidence": {"kind": tier2_ev_kind, "data": tier2_ev_data},
+        }
+        return Diagnostic(
+            rule_id=tier1_diag.rule_id,
+            source=tier1_diag.source,
+            backend=tier1_diag.backend,
+            status=Status.UNSUPPORTED,
+            severity=tier1_diag.severity,
+            message=tier1_diag.message,
+            evidence=[
+                Evidence(
+                    kind="llm_adaptive",
+                    data={**tier1_ev_data, **adaptive_overlay_fail},
+                )
+            ],
+            remediation=tier1_diag.remediation,
+        )
+
     # Nest both tier evidence objects as {kind, data} so the original inner
-    # evidence kinds (e.g. llm_consensus, consensus_tie, provider_unconfigured)
-    # are preserved for downstream programmatic inspection.
+    # evidence kinds (e.g. llm_consensus, consensus_tie, llm_review,
+    # provider_unconfigured) are preserved for downstream programmatic
+    # inspection.
     adaptive_overlay_t2: dict[str, Any] = {
         "llm_strategy": "adaptive",
         "adaptive_tier": 2,
-        "adaptive_escalation_reason": "tier1_unsupported",
+        "adaptive_escalation_reason": escalation_reason,
         "llm_call_count": total_call_count,
         "models": total_models,
         "cost_estimate_usd_total": total_cost,
@@ -3519,6 +3609,9 @@ def _run_adaptive_strategy(request: JudgmentRequest) -> Diagnostic:
         "tier1_evidence": {"kind": tier1_ev_kind, "data": tier1_ev_data},
         "tier2_evidence": {"kind": tier2_ev_kind, "data": tier2_ev_data},
     }
+    if escalation_reason == "tier1_quote_fabrication":
+        # Tier 2 produced a grounded verdict (PASS/FAIL via review-agree path).
+        adaptive_overlay_t2["adaptive_recovery_outcome"] = "tier2_recovered"
     updated_ev_t2 = [
         Evidence(
             kind="llm_adaptive",

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -3891,6 +3891,273 @@ class TestAdaptiveStrategy:
 
 
 # ---------------------------------------------------------------------------
+# Adaptive strategy quote-fabrication recovery (#254)
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptiveQuoteFabricationRecovery:
+    """Issue #254 — opt-in adaptive escalation on Tier 1 quote fabrication.
+
+    When ``rule.params.adaptive_escalate_on_quote_fabrication`` is true,
+    a Tier 1 ``llm_quote_fabrication`` UNSUPPORTED is no longer terminal:
+    the adaptive strategy escalates to ``review`` (Tier 2) and propagates
+    its outcome. When Tier 2 also returns UNSUPPORTED, the original Tier 1
+    fabrication is preserved (no ungrounded verdict ever emitted).
+
+    All tests use fake provider stubs; no live LLM calls are made.
+    The substring contract enforced by ``_find_fabricated_quotes`` is not
+    weakened — Tier 2 PASS/FAIL only emerges when its quotes ground.
+    """
+
+    _ENV = {
+        "GATE_KEEPER_LLM_PROVIDER": "openai",
+        "OPENAI_API_KEY": "sk-openai-test",
+    }
+
+    # Tier-1 payload: claims a "pass" verdict with a quote that is NOT a
+    # substring of the canned _STUB_ARTIFACT_TEXT — triggers
+    # ``llm_quote_fabrication``.
+    _FABRICATED_PASS_JSON = json.dumps(
+        {
+            "judgment": "pass",
+            "primary_reason": "All good.",
+            "supporting_evidence_quotes": [
+                "This phrase does not exist in the artifact at all."
+            ],
+            "suggested_action": None,
+        }
+    )
+
+    # Reviewer agree payload for the review-strategy Tier 2.
+    _REVIEWER_AGREE_JSON = json.dumps(
+        {"review_verdict": "agree", "review_reason": "Well-grounded."}
+    )
+
+    def _rule(self, *, escalate: bool) -> "Rule":
+        params: dict[str, object] = {"strategy": "adaptive"}
+        if escalate:
+            params["adaptive_escalate_on_quote_fabrication"] = True
+        return Rule(
+            id="stub-adaptive-qf-rule",
+            title="Stub adaptive quote-fab rule",
+            source=SourceLocation(path="rules.md", line=1),
+            text="The documentation should be clear and comprehensive",
+            kind=RuleKind.SEMANTIC_RUBRIC,
+            severity=Severity.ERROR,
+            backend_hint=Backend.LLM_RUBRIC,
+            confidence=Confidence.LOW,
+            params=params,
+        )
+
+    def _make_spy(self, responses: list[str]) -> "tuple[list[tuple], object]":
+        calls: list[tuple] = []
+        idx = {"i": 0}
+
+        def _spy(api_key, system, user, model):
+            calls.append((api_key, model))
+            text = responses[idx["i"] % len(responses)]
+            idx["i"] += 1
+            return _stub_response(text, {"latency_ms": 50, "tokens_in": 100, "tokens_out": 20})
+
+        return calls, _spy
+
+    # ---- (a) recovery succeeds: tier-2 review returns grounded pass ----
+
+    def test_quote_fabrication_recovery_succeeds_returns_grounded_pass(
+        self, monkeypatch, tmp_path
+    ):
+        """Tier 1 fabricates → Tier 2 review (primary+reviewer) → grounded PASS."""
+        _patch_env(monkeypatch, self._ENV)
+        # 1 fabricated tier-1 + 2 review-strategy calls (primary + reviewer).
+        responses = [
+            self._FABRICATED_PASS_JSON,
+            _VALID_PASS_JSON,
+            self._REVIEWER_AGREE_JSON,
+        ]
+        calls, spy = self._make_spy(responses)
+        monkeypatch.setattr(llm_backend, "_call_openai", spy)
+        diag = llm_backend.check(self._rule(escalate=True), _target_with_artifact(tmp_path))
+
+        # 3 total provider calls: 1 tier-1 + 2 tier-2 review (primary+reviewer).
+        assert len(calls) == 3
+        assert diag.status is Status.PASS
+
+        data = diag.evidence[0].data
+        assert diag.evidence[0].kind == "llm_adaptive"
+        assert data["llm_strategy"] == "adaptive"
+        assert data["adaptive_tier"] == 2
+        assert data["adaptive_escalation_reason"] == "tier1_quote_fabrication"
+        assert data["adaptive_recovery_outcome"] == "tier2_recovered"
+
+        # Aggregated telemetry covers both tiers (>= 2 because tier-1
+        # llm_quote_fabrication evidence stores llm_call_count=1 implicitly
+        # via the tier-1 helper, and tier-2 review adds 2).
+        assert data["llm_call_count"] >= 2
+        assert len(data["models"]) >= 2
+
+        # Tier 1 fabrication evidence is preserved for audit.
+        assert "tier1_evidence" in data
+        t1 = data["tier1_evidence"]
+        assert t1["kind"] == "llm_quote_fabrication"
+        # The Tier 1 evidence carries the fabricated quotes list.
+        assert "fabricated_quotes" in t1["data"]
+        assert t1["data"]["fabricated_quotes"]
+
+        # Tier 2 review evidence is also preserved.
+        assert "tier2_evidence" in data
+        assert data["tier2_evidence"]["kind"] == "llm_review"
+
+    # ---- (b) recovery fails: tier-2 also fabricates → preserve UNSUPPORTED ----
+
+    def test_quote_fabrication_recovery_fails_propagates_tier1_unsupported(
+        self, monkeypatch, tmp_path
+    ):
+        """Tier 1 fabricates → Tier 2 also fabricates → UNSUPPORTED preserved.
+
+        No ungrounded verdict is emitted; the outer evidence kind is
+        ``llm_adaptive`` so callers can see the recovery context, but the
+        diagnostic status remains ``UNSUPPORTED`` and the substring contract
+        is honoured at both tiers.
+        """
+        _patch_env(monkeypatch, self._ENV)
+        # Tier 2 primary also fabricates → the review-strategy primary-call
+        # path emits ``llm_quote_fabrication`` immediately and never calls
+        # the reviewer (see _run_review_strategy line ~3137 fabrication
+        # guard).  So we feed 2 total responses (1 tier-1 + 1 tier-2 primary).
+        responses = [self._FABRICATED_PASS_JSON, self._FABRICATED_PASS_JSON]
+        calls, spy = self._make_spy(responses)
+        monkeypatch.setattr(llm_backend, "_call_openai", spy)
+        diag = llm_backend.check(self._rule(escalate=True), _target_with_artifact(tmp_path))
+
+        # Tier-1 single + tier-2 review primary (reviewer is skipped because
+        # the primary fabricated).  Exactly 2 calls total.
+        assert len(calls) == 2
+
+        # Critical: final verdict is UNSUPPORTED, never an ungrounded PASS/FAIL.
+        assert diag.status is Status.UNSUPPORTED
+        assert diag.evidence[0].kind == "llm_adaptive"
+
+        data = diag.evidence[0].data
+        assert data["llm_strategy"] == "adaptive"
+        assert data["adaptive_tier"] == 2
+        assert data["adaptive_escalation_reason"] == "tier1_quote_fabrication"
+        assert data["adaptive_recovery_outcome"] == "tier2_unsupported"
+
+        # Original tier-1 fabrication context is preserved.
+        assert "tier1_evidence" in data
+        assert data["tier1_evidence"]["kind"] == "llm_quote_fabrication"
+        assert data["tier1_evidence"]["data"]["fabricated_quotes"]
+
+        # Tier-2 fabrication context is also preserved so the auditor sees
+        # both passes failed for the same reason.
+        assert "tier2_evidence" in data
+        assert data["tier2_evidence"]["kind"] == "llm_quote_fabrication"
+
+    # ---- (c) param defaults to false: no behaviour change ----
+
+    def test_quote_fabrication_param_absent_keeps_tier1_behaviour(
+        self, monkeypatch, tmp_path
+    ):
+        """Default (param absent) → Tier 1 UNSUPPORTED committed, no escalation."""
+        _patch_env(monkeypatch, self._ENV)
+        calls, spy = self._make_spy([self._FABRICATED_PASS_JSON])
+        monkeypatch.setattr(llm_backend, "_call_openai", spy)
+        # ``escalate=False`` → param is omitted from rule.params entirely.
+        diag = llm_backend.check(self._rule(escalate=False), _target_with_artifact(tmp_path))
+
+        # Only one call — escalation gate did not fire.
+        assert len(calls) == 1
+        assert diag.status is Status.UNSUPPORTED
+
+        data = diag.evidence[0].data
+        # Existing #186 contract: tier-1 fabrication commits with llm_adaptive
+        # overlay at adaptive_tier=1 and adaptive_escalation_reason=None.
+        assert data["adaptive_tier"] == 1
+        assert data["adaptive_escalation_reason"] is None
+        assert "adaptive_recovery_outcome" not in data
+        # tier-1 fabrication is still nested under tier1_evidence (the
+        # commit-overlay path preserves the original evidence kind, #186).
+        assert "tier1_evidence" in data
+        assert data["tier1_evidence"]["kind"] == "llm_quote_fabrication"
+
+    def test_quote_fabrication_param_false_keeps_tier1_behaviour(
+        self, monkeypatch, tmp_path
+    ):
+        """Explicit ``adaptive_escalate_on_quote_fabrication=False`` → no escalation."""
+        _patch_env(monkeypatch, self._ENV)
+        calls, spy = self._make_spy([self._FABRICATED_PASS_JSON])
+        monkeypatch.setattr(llm_backend, "_call_openai", spy)
+        rule = self._rule(escalate=False)
+        # Explicit false (in addition to the default absence).
+        rule = dataclasses.replace(
+            rule,
+            params={**rule.params, "adaptive_escalate_on_quote_fabrication": False},
+        )
+        diag = llm_backend.check(rule, _target_with_artifact(tmp_path))
+
+        assert len(calls) == 1
+        assert diag.status is Status.UNSUPPORTED
+        data = diag.evidence[0].data
+        assert data["adaptive_tier"] == 1
+        assert data["adaptive_escalation_reason"] is None
+
+    # ---- target_kind_mismatch escalation reason unchanged ----
+
+    def test_target_kind_mismatch_reason_unchanged_when_qf_param_set(
+        self, monkeypatch, tmp_path
+    ):
+        """Setting the QF param must NOT change the target_kind_mismatch path.
+
+        The two escalation reasons are mutually exclusive (distinct evidence
+        kinds at tier 1).  Enabling QF recovery must leave the existing
+        ``tier1_unsupported`` consensus escalation untouched.
+        """
+        from gate_keeper.models import TargetKind
+
+        _patch_env(monkeypatch, self._ENV)
+        unsupported_json = json.dumps(
+            {
+                "judgment": "unsupported",
+                "primary_reason": "Rule targets PR descriptions; this is a commit message.",
+                "supporting_evidence_quotes": [],
+                "suggested_action": None,
+            }
+        )
+        # 1 tier-1 unsupported + 3 consensus panel calls (unchanged behaviour).
+        responses = [unsupported_json] + [_VALID_PASS_JSON] * 3
+        calls, spy = self._make_spy(responses)
+        monkeypatch.setattr(llm_backend, "_call_openai", spy)
+
+        rule = Rule(
+            id="stub-adaptive-qf-tkm-rule",
+            title="Stub adaptive rule with QF flag",
+            source=SourceLocation(path="rules.md", line=1),
+            text="The documentation should be clear and comprehensive",
+            kind=RuleKind.SEMANTIC_RUBRIC,
+            severity=Severity.ERROR,
+            backend_hint=Backend.LLM_RUBRIC,
+            confidence=Confidence.LOW,
+            params={
+                "strategy": "adaptive",
+                "adaptive_escalate_on_quote_fabrication": True,
+            },
+            target_kind=TargetKind.PR_DESCRIPTION,
+        )
+        diag = llm_backend.check(rule, _target_with_artifact(tmp_path))
+
+        # Same 4 calls as the existing #186 target_kind_mismatch path.
+        assert len(calls) == 4
+        data = diag.evidence[0].data
+        assert data["adaptive_tier"] == 2
+        # Reason label stays ``tier1_unsupported`` — the QF flag must not
+        # repurpose this trigger.
+        assert data["adaptive_escalation_reason"] == "tier1_unsupported"
+        # And the consensus-recovery path does NOT set
+        # ``adaptive_recovery_outcome`` (only the QF path does).
+        assert "adaptive_recovery_outcome" not in data
+
+
+# ---------------------------------------------------------------------------
 # Multi-target context assembly (#182, slice 1)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -3921,17 +3921,13 @@ class TestAdaptiveQuoteFabricationRecovery:
         {
             "judgment": "pass",
             "primary_reason": "All good.",
-            "supporting_evidence_quotes": [
-                "This phrase does not exist in the artifact at all."
-            ],
+            "supporting_evidence_quotes": ["This phrase does not exist in the artifact at all."],
             "suggested_action": None,
         }
     )
 
     # Reviewer agree payload for the review-strategy Tier 2.
-    _REVIEWER_AGREE_JSON = json.dumps(
-        {"review_verdict": "agree", "review_reason": "Well-grounded."}
-    )
+    _REVIEWER_AGREE_JSON = json.dumps({"review_verdict": "agree", "review_reason": "Well-grounded."})
 
     def _rule(self, *, escalate: bool) -> "Rule":
         params: dict[str, object] = {"strategy": "adaptive"}
@@ -3963,9 +3959,7 @@ class TestAdaptiveQuoteFabricationRecovery:
 
     # ---- (a) recovery succeeds: tier-2 review returns grounded pass ----
 
-    def test_quote_fabrication_recovery_succeeds_returns_grounded_pass(
-        self, monkeypatch, tmp_path
-    ):
+    def test_quote_fabrication_recovery_succeeds_returns_grounded_pass(self, monkeypatch, tmp_path):
         """Tier 1 fabricates → Tier 2 review (primary+reviewer) → grounded PASS."""
         _patch_env(monkeypatch, self._ENV)
         # 1 fabricated tier-1 + 2 review-strategy calls (primary + reviewer).
@@ -4009,9 +4003,7 @@ class TestAdaptiveQuoteFabricationRecovery:
 
     # ---- (b) recovery fails: tier-2 also fabricates → preserve UNSUPPORTED ----
 
-    def test_quote_fabrication_recovery_fails_propagates_tier1_unsupported(
-        self, monkeypatch, tmp_path
-    ):
+    def test_quote_fabrication_recovery_fails_propagates_tier1_unsupported(self, monkeypatch, tmp_path):
         """Tier 1 fabricates → Tier 2 also fabricates → UNSUPPORTED preserved.
 
         No ungrounded verdict is emitted; the outer evidence kind is
@@ -4055,9 +4047,7 @@ class TestAdaptiveQuoteFabricationRecovery:
 
     # ---- (c) param defaults to false: no behaviour change ----
 
-    def test_quote_fabrication_param_absent_keeps_tier1_behaviour(
-        self, monkeypatch, tmp_path
-    ):
+    def test_quote_fabrication_param_absent_keeps_tier1_behaviour(self, monkeypatch, tmp_path):
         """Default (param absent) → Tier 1 UNSUPPORTED committed, no escalation."""
         _patch_env(monkeypatch, self._ENV)
         calls, spy = self._make_spy([self._FABRICATED_PASS_JSON])
@@ -4080,9 +4070,7 @@ class TestAdaptiveQuoteFabricationRecovery:
         assert "tier1_evidence" in data
         assert data["tier1_evidence"]["kind"] == "llm_quote_fabrication"
 
-    def test_quote_fabrication_param_false_keeps_tier1_behaviour(
-        self, monkeypatch, tmp_path
-    ):
+    def test_quote_fabrication_param_false_keeps_tier1_behaviour(self, monkeypatch, tmp_path):
         """Explicit ``adaptive_escalate_on_quote_fabrication=False`` → no escalation."""
         _patch_env(monkeypatch, self._ENV)
         calls, spy = self._make_spy([self._FABRICATED_PASS_JSON])
@@ -4103,9 +4091,7 @@ class TestAdaptiveQuoteFabricationRecovery:
 
     # ---- target_kind_mismatch escalation reason unchanged ----
 
-    def test_target_kind_mismatch_reason_unchanged_when_qf_param_set(
-        self, monkeypatch, tmp_path
-    ):
+    def test_target_kind_mismatch_reason_unchanged_when_qf_param_set(self, monkeypatch, tmp_path):
         """Setting the QF param must NOT change the target_kind_mismatch path.
 
         The two escalation reasons are mutually exclusive (distinct evidence


### PR DESCRIPTION
## Summary

Implement Option A from the Phase A lite-spec on #254 (under umbrella #255): an opt-in adaptive recovery path for Tier 1 `llm_quote_fabrication` UNSUPPORTED. When `rule.params.adaptive_escalate_on_quote_fabrication: true`, `_run_adaptive_strategy` escalates to `review` (primary + reviewer) instead of committing the Tier 1 fail-closed. Recovery still re-validates every quote via `_find_fabricated_quotes`; the substring contract is **not** weakened. When Tier 2 also fabricates (or returns UNSUPPORTED for any reason), the original Tier 1 fabrication is preserved — no ungrounded verdict is ever emitted.

- Insertion point: the existing `should_escalate` gate in `_run_adaptive_strategy` (the same seam used by the #186 `target_kind_mismatch` escalation).
- Tier 2 strategy: `review` (not `consensus`) — cheapest path that still re-validates quote grounding for a fabrication-class failure.
- Param defaults to `false`; behaviour is identical to today when absent or false.
- Evidence: `adaptive_escalation_reason = "tier1_quote_fabrication"` and `adaptive_recovery_outcome = "tier2_recovered" | "tier2_unsupported"`. `tier1_evidence` and `tier2_evidence` are both nested as `{kind, data}` for downstream auditing.
- The `target_kind_mismatch` → `consensus` path is unchanged (mutually exclusive evidence kinds; one test asserts this directly).

Closes #254 (under umbrella #255).

## Files touched

- `src/gate_keeper/backends/llm_rubric.py` — extend escalation gate; add `review`-strategy dispatch path; add failed-recovery propagation branch; update docstring.
- `tests/test_llm_rubric_backend.py` — 5 new fake-provider tests in `TestAdaptiveQuoteFabricationRecovery`.
- `docs/llm-rubric.md` — new "Adaptive strategy escalation" section with trigger table and the QF subsection.

`_find_fabricated_quotes` and `_find_per_target_fabricated_quotes` are **unmodified** (verified by diff).

## Validation

```
uv sync                                                                    # ok
uv run pytest tests/test_llm_rubric_backend.py -q                          # 309 passed
uv run pytest tests/test_llm_rubric_backend.py::TestAdaptiveQuoteFabricationRecovery -v   # 5 passed
uv run pytest -q                                                           # 1462 passed, 1 pre-existing failure unrelated to this PR (tests/test_dependency_validator.py::test_validator_emit_shape — fails on origin/main HEAD too)
uvx ruff check src/gate_keeper/backends/llm_rubric.py tests/test_llm_rubric_backend.py   # All checks passed!
uv run pyright src/gate_keeper/backends/llm_rubric.py                      # 0 errors
```

The unrelated `test_validator_emit_shape` failure on `main` was verified by stashing this branch's diff and re-running — same failure reproduces on bare `origin/main`. Out of scope for this PR.

## Benchmark note

No live benchmark in this PR. The lite-spec allows "fake-provider tests are sufficient for this PR" and the umbrella #255 wave caps cost at $5 — a 30-rule `#251` re-run is deferred. The intended follow-up is to flip the param on for the high-fabrication-rate rules identified in #251 (~30–50% fabrication on `single` + `gpt-4o-mini`), then measure usable-signal rate (non-UNSUPPORTED fraction) per rule. Baseline status: `#253` has landed (`3be1fe7`), so the post-v2 dogfooding-rules pool is the relevant baseline.

## Out of scope (per lite-spec)

- Option B (quote-repair pass).
- Weakening substring matching / changes to `_find_fabricated_quotes`.
- CLI shape changes.
- Promotion of the new path to default or required behaviour.

## Test plan

- [x] `uv run pytest tests/test_llm_rubric_backend.py -q` — 309 passed.
- [x] `uv run pytest -q` — 1462 passed (1 unrelated pre-existing failure on `main`).
- [x] `uvx ruff check` on touched files — clean.
- [x] `uv run pyright` on touched files — clean.
- [x] Verified `_find_fabricated_quotes` / `_find_per_target_fabricated_quotes` unchanged via `git diff`.
- [x] Verified `test_tier1_fabricated_quotes_failclosed_no_escalation` (#186) still passes — default behaviour preserved.