### PR TITLE
fix(ci): align dogfooding dotenv projection with backend path; remove advisory wording (closes #261)

### DIFF
--- a/.github/workflows/dogfooding.yml
+++ b/.github/workflows/dogfooding.yml
@@ -1,30 +1,37 @@
-# dogfooding — semantic self-gating advisory comment on PRs (#131)
+# dogfooding — semantic self-gating PR comment (#131, #261)
 #
 # Trigger: `pull_request`. The job runs `gate-keeper validate` with the
-# `llm-rubric` backend against `docs/dogfooding-rules.md` and posts the JSON
-# diagnostic as a markdown table comment on the PR.
+# `llm-rubric` backend against `docs/dogfooding-rules.md` and posts the
+# JSON diagnostic as a markdown table comment on the PR.
 #
-# Status: **advisory only**. Per `docs/dogfooding.md`, semantic self-gating
-# rules do not block merge. The job is wired so that any provider error,
-# secret-absent path, or formatter failure exits 0 (`continue-on-error` on
-# the validate/format/post steps); the workflow conclusion never gates merge.
+# Per-rule promotion model (process; not user-facing comment wording):
+# `docs/dogfooding.md` defines the path from semantic self-gating to
+# required check. The job is wired so that any provider error,
+# secret-absent path, or formatter failure exits 0 (`continue-on-error`
+# on the validate/format/post steps).
+#
+# Per issue #261, the user-facing PR comment body MUST NOT include
+# "advisory" / "does not gate merge" / equivalent non-gating disclaimer
+# wording. That contract is enforced in
+# `tests/test_format_dogfooding_comment.py` with a forbidden-substring
+# regression check across every rendered output shape.
 #
 # Secret handling (no log leakage):
 #   - Provider credentials live behind the `OPENAI_API_KEY` repo secret.
-#   - Job-level `if: ${{ secrets.OPENAI_API_KEY != '' }}` guards the entire
-#     job: when the secret is unregistered the job is skipped silently
-#     (no fail, no advisory comment).
-#   - Credentials are projected into the host-side dotenv path the
-#     llm-rubric backend already loads
-#     (`/home/vscode/.config/hermes-projects/gate-keeper.env`); see
-#     `docs/llm-rubric.md` "CI exception" sub-section.
-#   - The provision step uses `printf` redirected to the dotenv file. It
-#     does NOT use `echo $VAR` or `set -x`. The dotenv file is written
-#     under `umask 077` and never uploaded as a workflow artifact. The
-#     directory mode is `700`.
-#
-# Out of scope (per #131):
-#   - Promotion to required check — promotion path is owned by #79.
+#   - The first step skips the rest of the job when the secret is absent
+#     (typical on forks and pre-secret states) so no half-configured run
+#     surfaces.
+#   - Credentials are projected into the dotenv path the llm-rubric
+#     backend reads by default, computed at runtime as
+#     `$HOME/.config/hermes-projects/gate-keeper.env` (post-#247 /
+#     #261). On GitHub-hosted runners `$HOME=/home/runner`; in the
+#     devcontainer it is `/home/vscode`. We MUST follow `$HOME` so the
+#     backend's read path matches the workflow's write path on every
+#     host. See `docs/llm-rubric.md` "CI exception" sub-section.
+#   - The provision step uses `printf` redirected to the dotenv file.
+#     It does NOT use `echo $VAR` or `set -x`. The dotenv file is
+#     written under `umask 077` (mode 600) and never uploaded as a
+#     workflow artifact.
 
 name: dogfooding
 
@@ -36,7 +43,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  advisory-comment:
+  dogfood-comment:
     # Skip silently when the provider secret is not registered. This keeps
     # the workflow no-op on forks and pre-secret states without surfacing
     # a red check.
@@ -57,7 +64,7 @@ jobs:
             echo "secret_present=true" >> "$GITHUB_OUTPUT"
           else
             echo "secret_present=false" >> "$GITHUB_OUTPUT"
-            echo "OPENAI_API_KEY secret is not set; skipping advisory comment."
+            echo "OPENAI_API_KEY secret is not set; skipping dogfooding comment."
           fi
 
       - uses: astral-sh/setup-uv@v5
@@ -76,21 +83,32 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           # NB: never `set -x` here — it would echo the API key.
-          # The llm-rubric backend reads from this absolute path
-          # (DOTENV_PATH in src/gate_keeper/backends/llm_rubric.py).
+          # The llm-rubric backend reads from `$HOME/.config/hermes-projects/
+          # gate-keeper.env` by default (DOTENV_PATH in
+          # src/gate_keeper/backends/llm_rubric.py, post-#247). On
+          # GitHub-hosted runners `$HOME` resolves to `/home/runner`, so we
+          # MUST project the dotenv to `$HOME/...` rather than the
+          # devcontainer-specific `/home/vscode/...` path — otherwise the
+          # backend reads a file the workflow never wrote and reports
+          # `provider_unconfigured` (issue #261).
           set +x
           umask 077
-          sudo install -d -m 700 -o "$USER" -g "$USER" /home/vscode
-          sudo install -d -m 700 -o "$USER" -g "$USER" /home/vscode/.config
-          sudo install -d -m 700 -o "$USER" -g "$USER" /home/vscode/.config/hermes-projects
+          mkdir -p "$HOME/.config/hermes-projects"
+          # Log the projection target BEFORE writing so a missing/wrong
+          # parent directory is obvious; never log the dotenv contents.
+          echo "dotenv projection target: $HOME/.config/hermes-projects/gate-keeper.env"
+          ls -ld "$HOME/.config/hermes-projects" || true
           # printf + redirect — does not echo via `echo $VAR` and is not
           # affected by `-x` since we explicitly disabled it. The dotenv
           # file inherits the 077 umask (mode 600).
           printf 'GATE_KEEPER_LLM_PROVIDER=openai\nOPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" \
-            > /home/vscode/.config/hermes-projects/gate-keeper.env
-          chmod 600 /home/vscode/.config/hermes-projects/gate-keeper.env
+            > "$HOME/.config/hermes-projects/gate-keeper.env"
+          chmod 600 "$HOME/.config/hermes-projects/gate-keeper.env"
+          # Post-write confirmation: file exists, mode 600, owned by runner.
+          # `ls -l` does not print file contents.
+          ls -l "$HOME/.config/hermes-projects/gate-keeper.env" || true
 
-      - name: Run gate-keeper validate (advisory)
+      - name: Run gate-keeper validate
         if: steps.secret_guard.outputs.secret_present == 'true'
         id: validate
         continue-on-error: true
@@ -98,26 +116,27 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set +x
-          # `--format json` so the post step can transform reliably; failures
-          # are tolerated by continue-on-error and surface as a "no advisory"
-          # log in the post step.
-          # Pass the actual PR body text as --target so the llm-rubric backend
-          # evaluates real prose rather than a URL literal (fixes #189).
-          # github.event.pull_request.body is null for body-less PRs; default
-          # to a single space to keep CLI arg parsing consistent. The rule will
-          # then produce an "insufficient content" evidence result naturally.
+          # `--format json` so the post step can transform reliably;
+          # failures are tolerated by continue-on-error and surface as a
+          # fallback body in the post step.
+          # Pass the actual PR body text as --target so the llm-rubric
+          # backend evaluates real prose rather than a URL literal
+          # (fixes #189). github.event.pull_request.body is null for
+          # body-less PRs; default to a single space to keep CLI arg
+          # parsing consistent. The rule will then produce an
+          # "insufficient content" evidence result naturally.
           BODY="${PR_BODY:- }"
           uv run gate-keeper validate docs/dogfooding-rules.md \
             --target "$BODY" \
             --artifact-kind pr_description \
             --backend llm-rubric \
             --format json \
-            > /tmp/dogfood.json 2> /tmp/dogfood.err || echo "validate exited non-zero (advisory; see stderr below)"
+            > /tmp/dogfood.json 2> /tmp/dogfood.err || echo "validate exited non-zero (see stderr below)"
           echo "::group::stderr"
           cat /tmp/dogfood.err || true
           echo "::endgroup::"
 
-      - name: Format advisory comment
+      - name: Format dogfooding comment
         if: steps.secret_guard.outputs.secret_present == 'true'
         id: format
         continue-on-error: true
@@ -133,19 +152,19 @@ jobs:
           cat /tmp/dogfood-comment.md
           echo "::endgroup::"
 
-      - name: Guard low-signal advisory output
+      - name: Guard low-signal output
         if: steps.secret_guard.outputs.secret_present == 'true' && steps.format.outcome == 'success'
         id: comment_guard
         run: |
           set +x
           if rg -q "<!-- gate-keeper-dogfooding-comment:fallback -->" /tmp/dogfood-comment.md; then
             echo "post_comment=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping PR comment because advisory output is fallback/noisy."
+            echo "Skipping PR comment because output is fallback/noisy."
           else
             echo "post_comment=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Upsert advisory comment
+      - name: Upsert dogfooding comment
         if: steps.secret_guard.outputs.secret_present == 'true' && steps.format.outcome == 'success' && steps.comment_guard.outputs.post_comment == 'true'
         continue-on-error: true
         env:
@@ -176,4 +195,4 @@ jobs:
           set +x
           # Best-effort cleanup. The runner is ephemeral, but explicit
           # removal documents intent.
-          rm -f /home/vscode/.config/hermes-projects/gate-keeper.env || true
+          rm -f "$HOME/.config/hermes-projects/gate-keeper.env" || true

--- a/.github/workflows/format_dogfooding_comment.py
+++ b/.github/workflows/format_dogfooding_comment.py
@@ -8,22 +8,25 @@ workflow without bumping the library version.
 
 The script accepts a single positional arg (path to the JSON file produced
 by ``gate-keeper validate ... --format json``) and writes a Markdown
-comment to stdout. It prints a fallback "no advisory" body when the JSON
-cannot be parsed; the workflow tolerates that path with
-``continue-on-error`` on the validate step.
+comment to stdout. It prints a fallback body when the JSON cannot be
+parsed; the workflow tolerates that path with ``continue-on-error`` on
+the validate step.
 
-Output shape (matches issue #131 acceptance criteria):
+User-facing wording rule (issue #261): the rendered comment MUST NOT
+contain any "advisory" / "does not gate merge" / equivalent non-gating
+disclaimer. Owner directive: remove that wording entirely. The
+``test_format_dogfooding_comment.py`` suite pins this with a
+forbidden-substring regression test so it cannot silently regress.
 
-  ## gate-keeper dogfooding (advisory)
+Output shape:
+
+  ## gate-keeper dogfooding
 
   | rule | status | judgment | primary_reason |
   | --- | --- | --- | --- |
   | <title-or-id> | PASS | pass | ... |
 
   Tokens: in=N out=N, latency: N ms, model: <model>, prompt_version: vX
-
-  <small>This comment is advisory and does not gate merge. See
-  docs/dogfooding.md.</small>
 
 Structural skips (#240): UNSUPPORTED diagnostics whose primary evidence
 kind is ``target_kind_mismatch`` (deterministic precheck, #178) or
@@ -38,19 +41,16 @@ import json
 import sys
 from typing import Any
 
-_FALLBACK_HEADER = "## gate-keeper dogfooding (advisory)"
+_FALLBACK_HEADER = "## gate-keeper dogfooding"
 _MARKER_BASE = "gate-keeper-dogfooding-comment"
 _MARKER_FALLBACK = f"<!-- {_MARKER_BASE}:fallback -->"
 _MARKER_REPORT = f"<!-- {_MARKER_BASE}:report -->"
 _FALLBACK_BODY = (
-    "Advisory evaluation could not be produced for this PR.\n\n"
-    "The validate step exited without a usable JSON report. This does not "
-    "block merge. See the workflow run logs for details."
+    "Evaluation could not be produced for this PR.\n\n"
+    "The validate step exited without a usable JSON report. See the "
+    "workflow run logs for details."
 )
-_TRAILER = (
-    "<sub>This comment is advisory and does not gate merge. "
-    "See [`docs/dogfooding.md`](docs/dogfooding.md) for the promotion path.</sub>"
-)
+_TRAILER = "<sub>See [`docs/dogfooding.md`](docs/dogfooding.md) for the per-rule promotion path.</sub>"
 
 # UNSUPPORTED diagnostics whose primary evidence falls in this set are
 # "structural skips": the system correctly short-circuited or self-defended

--- a/tests/test_format_dogfooding_comment.py
+++ b/tests/test_format_dogfooding_comment.py
@@ -1,4 +1,4 @@
-"""Tests for the dogfooding advisory-comment formatter (#240).
+"""Tests for the dogfooding PR-comment formatter (#240, #261).
 
 The formatter lives outside ``src/`` (it is workflow glue, not a public
 package surface), so we load it via ``importlib`` from the repo-relative
@@ -11,6 +11,10 @@ path. The tests pin:
    placeholder plus the ``<details>`` block.
 4. Mixed inputs render only the actionable rows in the main table, with the
    skipped rows under the ``<details>`` block.
+5. Forbidden-wording regression (#261): the rendered comment MUST NOT contain
+   any "advisory" / "does not gate merge" / equivalent non-gating disclaimer
+   wording in the user-facing body, regardless of input shape (fallback,
+   actionable-only, skip-only, mixed).
 """
 
 from __future__ import annotations
@@ -187,3 +191,83 @@ def test_non_structural_unsupported_is_not_filtered(tmp_path: Path) -> None:
     out = _run(tmp_path, {"diagnostics": [diag]})
     assert "rule-some-unavailable" in out
     assert "<details>" not in out
+
+
+# Forbidden user-facing substrings the PR comment MUST NOT contain (#261).
+#
+# Owner directive (issue #261): remove all "advisory" / "does not gate merge"
+# / equivalent non-gating disclaimer wording from the rendered comment.
+# These substrings are checked case-insensitively against EVERY rendered
+# output shape (fallback, actionable-only, skip-only, mixed) so the wording
+# cannot regress silently — e.g. by re-introducing a trailer, header
+# suffix, or fallback-body disclaimer.
+_FORBIDDEN_SUBSTRINGS = (
+    "advisory",
+    "does not gate merge",
+    "does not block merge",
+    "non-gating",
+    "non-blocking",
+    "not gate",
+    "not block",
+)
+
+
+def _assert_no_forbidden_wording(out: str) -> None:
+    lower = out.lower()
+    for needle in _FORBIDDEN_SUBSTRINGS:
+        assert needle not in lower, (
+            f"forbidden user-facing wording {needle!r} found in rendered "
+            f"PR comment (issue #261); offending output:\n{out}"
+        )
+
+
+def test_fallback_body_has_no_forbidden_wording(tmp_path: Path) -> None:
+    """Unparseable / missing JSON renders the fallback body — it MUST NOT
+    contain advisory / does-not-gate disclaimers (#261)."""
+    # Empty diagnostics list triggers the fallback branch.
+    out = _run(tmp_path, {"diagnostics": []})
+    _assert_no_forbidden_wording(out)
+
+
+def test_actionable_only_has_no_forbidden_wording(tmp_path: Path) -> None:
+    out = _run(tmp_path, {"diagnostics": [_diag_actionable_fail()]})
+    _assert_no_forbidden_wording(out)
+
+
+def test_structural_skip_only_has_no_forbidden_wording(tmp_path: Path) -> None:
+    out = _run(
+        tmp_path,
+        {
+            "diagnostics": [
+                _diag_structural_target_kind(),
+                _diag_structural_quote_fabrication(),
+            ]
+        },
+    )
+    _assert_no_forbidden_wording(out)
+
+
+def test_mixed_input_has_no_forbidden_wording(tmp_path: Path) -> None:
+    out = _run(
+        tmp_path,
+        {
+            "diagnostics": [
+                _diag_actionable_fail(),
+                _diag_structural_quote_fabrication(),
+                _diag_structural_target_kind(),
+            ]
+        },
+    )
+    _assert_no_forbidden_wording(out)
+
+
+def test_malformed_json_fallback_has_no_forbidden_wording(tmp_path: Path) -> None:
+    """The on-disk JSON-decode-error path emits the fallback — same gate (#261)."""
+    formatter = _load_formatter()
+    json_path = tmp_path / "bad.json"
+    json_path.write_text("this is not json", encoding="utf-8")
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = formatter.main(["format_dogfooding_comment.py", str(json_path)])
+    assert rc == 0
+    _assert_no_forbidden_wording(buf.getvalue())


### PR DESCRIPTION
Closes #261

## Summary

- **Credential projection fix**: `.github/workflows/dogfooding.yml` now writes the dotenv to `$HOME/.config/hermes-projects/gate-keeper.env`, matching the backend default (`Path.home() / ".config/hermes-projects/gate-keeper.env"` since #247). Previously the workflow wrote to a hardcoded `/home/vscode/...` path, which mismatched the backend's read path on GitHub-hosted runners (`$HOME=/home/runner`), causing every PR to surface `provider_unconfigured` / `LLM rubric backend is not configured; skipping rule.`
- **PR-comment wording cleanup (owner directive on #261)**: removes `advisory`, `does not gate merge`, and equivalent non-gating disclaimer text from the formatter's header, fallback body, and trailer, and from the workflow's user-visible step names.
- **Regression pin**: new `tests/test_format_dogfooding_comment.py::test_*_has_no_forbidden_wording` cases assert the formatter output (across the four rendered shapes plus the JSON-decode-error fallback) contains none of `advisory`, `does not gate merge`, `does not block merge`, `non-gating`, `non-blocking`, `not gate`, `not block`.

## Secret hygiene preserved

- No `set -x` on the credential-write step.
- `printf` (not `echo`) into the dotenv file.
- `umask 077` + explicit `chmod 600`.
- No artifact upload.
- New logging only prints the projection target path and `ls -l` of the file (mode/owner/size) — never the file contents.

## Validation

```
uv run pytest                # 1467 passed, 1 pre-existing failure on origin/main
                             # (tests/test_dependency_validator.py::test_validator_emit_shape)
uvx ruff check .             # All checks passed!
uvx ruff format --check .    # 77 files already formatted
uv run pyright               # 0 errors, 0 warnings, 0 informations
```

Manually rendered the formatter against a sample report to confirm output contains none of the forbidden substrings.

The strongest signal that the credential-projection fix works is the dogfooding comment that this very PR will produce once CI runs — it should show real LLM rubric verdicts rather than `provider_unconfigured`.

## Test plan

- [x] `uv run pytest tests/test_format_dogfooding_comment.py` — all 9 tests including 5 new forbidden-wording cases pass.
- [x] Manually rendered formatter against sample JSON; output has no forbidden wording.
- [x] CI dogfooding comment on this PR no longer shows `provider_unconfigured` — now shows `provider error (openai)` (UNAVAILABLE), confirming credentials reach the backend. The remaining provider-permission issue is out-of-scope per #261 body.
