### PR TITLE
fix(ci): pin GATE_KEEPER_OPENAI_MODEL=gpt-5.4 in dogfooding workflow + cleanup docs/llm-rubric.md leftovers (closes #264)

### DIFF
--- a/.github/workflows/dogfooding.yml
+++ b/.github/workflows/dogfooding.yml
@@ -101,7 +101,12 @@ jobs:
           # printf + redirect — does not echo via `echo $VAR` and is not
           # affected by `-x` since we explicitly disabled it. The dotenv
           # file inherits the 077 umask (mode 600).
-          printf 'GATE_KEEPER_LLM_PROVIDER=openai\nOPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" \
+          # `GATE_KEEPER_OPENAI_MODEL=gpt-5.4` is hard-pinned here because
+          # the CI-side restricted OpenAI key is allow-listed to gpt-5.4
+          # only; the backend default (`gpt-4o-mini`) would be rejected by
+          # the provider and surface as `provider_error` on every rule
+          # (issue #264). The model name is not a secret.
+          printf 'GATE_KEEPER_LLM_PROVIDER=openai\nGATE_KEEPER_OPENAI_MODEL=gpt-5.4\nOPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" \
             > "$HOME/.config/hermes-projects/gate-keeper.env"
           chmod 600 "$HOME/.config/hermes-projects/gate-keeper.env"
           # Post-write confirmation: file exists, mode 600, owned by runner.

--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -193,7 +193,7 @@ from. CI environments do not have a developer-managed home directory, so
 GitHub Actions workflows project the repository secret into the same
 absolute dotenv path before invoking `gate-keeper`.
 
-The advisory dogfooding workflow (`.github/workflows/dogfooding.yml`,
+The dogfooding workflow (`.github/workflows/dogfooding.yml`,
 introduced in #131) demonstrates the pattern:
 
 ```yaml
@@ -204,13 +204,22 @@ introduced in #131) demonstrates the pattern:
   run: |
     set +x
     umask 077
-    sudo install -d -m 700 -o "$USER" -g "$USER" /home/vscode
-    sudo install -d -m 700 -o "$USER" -g "$USER" /home/vscode/.config
-    sudo install -d -m 700 -o "$USER" -g "$USER" /home/vscode/.config/hermes-projects
-    printf 'GATE_KEEPER_LLM_PROVIDER=openai\nOPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" \
-      > /home/vscode/.config/hermes-projects/gate-keeper.env
-    chmod 600 /home/vscode/.config/hermes-projects/gate-keeper.env
+    mkdir -p "$HOME/.config/hermes-projects"
+    printf 'GATE_KEEPER_LLM_PROVIDER=openai\nGATE_KEEPER_OPENAI_MODEL=gpt-5.4\nOPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" \
+      > "$HOME/.config/hermes-projects/gate-keeper.env"
+    chmod 600 "$HOME/.config/hermes-projects/gate-keeper.env"
 ```
+
+The backend's default dotenv path is computed at runtime as
+`Path.home() / ".config/hermes-projects/gate-keeper.env"`. On
+GitHub-hosted runners `$HOME=/home/runner`; in a devcontainer it is
+typically `/home/vscode`. The projection target MUST follow `$HOME` so
+the backend's read path matches the workflow's write path on every host
+(issue #261). `GATE_KEEPER_OPENAI_MODEL` is pinned because the
+repository's restricted CI key is allow-listed to a specific model only;
+without it the backend default would be rejected by the provider and
+surface as `provider_error` on every rule (issue #264). The model name
+is not a secret.
 
 Constraints to preserve when adopting this pattern in another workflow:
 
@@ -225,9 +234,8 @@ Constraints to preserve when adopting this pattern in another workflow:
 - **Mode 700 on the directory, mode 600 on the file.** `umask 077` plus
   `chmod 600` on the dotenv satisfy both, even when run as the runner
   user.
-- **No artifact upload of `$HOME` or `/home/vscode`.** Treat the dotenv
-  path as untrusted output; never include it in `actions/upload-artifact`
-  patterns.
+- **No artifact upload of `$HOME`.** Treat the dotenv path as untrusted
+  output; never include it in `actions/upload-artifact` patterns.
 - **Scrub on completion.** Add an `if: always()` cleanup step that
   removes the projected dotenv. The runner is ephemeral, but the
   scrubbing step documents intent and survives reuse if anyone refactors
@@ -738,7 +746,7 @@ level, but `gpt-4o-mini` still misjudges the **artifact kind** itself in
 some cases — for example, treating a short commit message as a "PR
 description" so the artifact-kind dispatch never fires. This is a
 model-capability limitation, not a prompt bug. When dispatch accuracy
-matters (e.g. for advisory dogfood gates that route per `target_kind`),
+matters (e.g. for dogfood gates that route per `target_kind`),
 prefer a stronger model via the `GATE_KEEPER_OPENAI_MODEL` /
 `GATE_KEEPER_ANTHROPIC_MODEL` dotenv override; gpt-4o-mini is appropriate
 for the per-PR cost target but not for high-confidence artifact-kind


### PR DESCRIPTION
Closes #264.

## Summary

After PR #262 corrected the dotenv projection path, the dogfooding job still surfaced `LLM rubric backend provider error (openai); skipping rule.` on every rule. Local reproduction (owner's restricted key, 2026-05-25) confirmed the repo's CI-side OpenAI key is allow-listed to `gpt-5.4` only; the backend default `gpt-4o-mini` is rejected by the provider, and the workflow never set `GATE_KEEPER_OPENAI_MODEL` so the dotenv fell through to the default.

With `GATE_KEEPER_OPENAI_MODEL=gpt-5.4` projected into the dotenv, all three current dogfooding rules execute correctly via the Responses API.

## Changes

### Part 1 — `.github/workflows/dogfooding.yml`

Extend the credential projection step's `printf` to write `GATE_KEEPER_OPENAI_MODEL=gpt-5.4` alongside `GATE_KEEPER_LLM_PROVIDER=openai` and `OPENAI_API_KEY=...`. All secrecy hygiene from #261/PR #262 preserved verbatim: `set +x`, `umask 077`, no `echo $VAR`, `chmod 600`, no artifact upload. Model name is hard-pinned (not exposed as a repo variable) per the #264 hotfix scope.

### Part 2 — `docs/llm-rubric.md` cleanup (per #263 review comment)

- Update the CI-exception example block to match the actual workflow shape: `$HOME/.config/hermes-projects/gate-keeper.env` instead of the devcontainer-specific `/home/vscode/...` path; `mkdir -p` instead of the (now unused) `sudo install` chain; new `GATE_KEEPER_OPENAI_MODEL` line so the documented pattern matches what the workflow actually does.
- Drop "advisory" from the two places it described the dogfooding workflow specifically — the CI-exception heading line and the `target_kind` dispatch note — per the #261 owner directive that removed identical wording from the PR comment formatter.
- The general LLM-rubric "Advisory status" section (severity ladder for `semantic_rubric` rules in user rule documents) is unchanged — that is a separate concept from the dogfooding workflow's gating posture.

## Scope

`.github/workflows/dogfooding.yml`, `docs/llm-rubric.md` only. No `src/` changes. No backend default change. No new repo secret/variable. `format_dogfooding_comment.py` is #263 territory and untouched here.

## Validation

- `uv run pytest tests/test_format_dogfooding_comment.py -q` — 9 passed.
- `uvx ruff check .` — All checks passed.
- YAML syntax verified via `yaml.safe_load`.
- Verification on this PR's own dogfooding run: the comment must show real per-rule verdicts (pass/fail/unsupported), not `provider error (openai); skipping rule.` (will check after CI runs).

## Refs

- #261 / PR #262 (credential projection fix this builds on)
- #263 (formatter improvement that would have made the diagnosis instant — separate PR)
- #248 / PR #257 (Responses API migration — context for why model access matters)
- `src/gate_keeper/backends/llm_rubric.py:118` (`OPENAI_DEFAULT_MODEL = "gpt-4o-mini"`)