### PR TITLE
feat(llm-rubric): use line-range evidence refs in primary reports

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -201,7 +201,7 @@ Provide either a single positional `rules` document **or** one or more
 | `--rules-format {markdown,ir}` | option | `markdown` | How to interpret `rules`. `markdown` (default) parses and classifies a Markdown rule document — the historical behaviour. `ir` loads a precompiled `RuleSet` JSON file (the same shape `compile` emits) using the strict IR parser and **bypasses the classifier**, so hand-authored `kind`, `backend_hint`, and `params` fields reach the validator unchanged. |
 | `--backend {auto,filesystem,github,llm-rubric,external}` | option | `auto` | Validation backend. `auto` delegates each rule to the backend the classifier (or the IR file) selected. |
 | `--format {text,json}` | option | `text` | Output format. |
-| `--verbose, -v` | flag | off | Expand structured LLM-rubric rationale (judgment, reason, evidence quotes, suggested action, model) as indented lines below each diagnostic. Has no effect for non-LLM backends. |
+| `--verbose, -v` | flag | off | Expand structured LLM-rubric rationale (judgment, reason, reconstructed evidence quotes, suggested action, model) as indented lines below each diagnostic. Has no effect for non-LLM backends. |
 | `--reproducibility N` | option | `1` | Run each LLM-rubric rule N times and record an agreement-rate `reproducibility_score` evidence entry. **No-op for non-LLM backends** (filesystem, GitHub, external ignore this flag). |
 | `--concurrency N` | option | `1` | Maximum number of rule checks executed in parallel via a bounded `ThreadPoolExecutor` (#249, Slice 1). Default `1` preserves strict sequential dispatch. Deterministic prechecks (target-kind mismatch, registry miss) short-circuit before scheduling, so no provider call is made for short-circuited rules. Diagnostics are emitted in `ruleset.rules` order regardless of completion order. See [Bounded rule-level concurrency (#249)](#bounded-rule-level-concurrency-249) for the cost-rate warning. |
 | `--allow-command-adapter` | flag | off | Enable the project-local `command` external adapter for this run only. **Security: pass this only for rule documents you fully trust** — the adapter executes whatever `params.argv` the rule document defines. Without this flag, every `external_check` rule whose `params.tool == "command"` returns `unavailable` / `command_adapter_disabled` and no subprocess runs. See [Project-local `command` adapter (#149)](#project-local-command-adapter-149) below. |
@@ -292,6 +292,9 @@ Each line: `path:line: severity: [backend/status] rule_id: message [evidence]`.
             "primary_reason": "The PR description does not specify the user-visible change.",
             "prompt_version": "v1",
             "suggested_action": "Rewrite the first sentence to state the user-visible change.",
+            "supporting_evidence_refs": [
+              {"target_id": null, "path": "README.md", "line_start": 12, "line_end": 18}
+            ],
             "supporting_evidence_quotes": ["..."],
             "tokens_in": 383,
             "tokens_out": 76

--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -256,82 +256,44 @@ context passed to the model:
 
 ### Structured judgment schema (`LlmJudgment`)
 
-The model is instructed (via `RUBRIC_PROMPT_TEMPLATE`, prompt version `PROMPT_VERSION = "v6"`)
-to respond with a JSON object matching the `LlmJudgment` dataclass:
+The model is instructed (via `RUBRIC_PROMPT_TEMPLATE`, prompt version
+`PROMPT_VERSION = "v7"`) to return **line-range evidence references**:
 
 ```json
 {
-  "judgment":                    "pass" | "fail",
-  "primary_reason":              "<one sentence>",
-  "supporting_evidence_quotes":  ["<near-verbatim substring of the target>", ...],
-  "suggested_action":            "<concrete fix>" | null
+  "judgment": "pass" | "fail" | "unsupported",
+  "primary_reason": "<one sentence>",
+  "supporting_evidence_refs": [
+    {"target_id": null, "path": "README.md", "line_start": 12, "line_end": 18}
+  ],
+  "suggested_action": "<concrete fix>" | null
 }
 ```
 
-Constraints enforced by `_parse_llm_judgment()`:
-- `judgment` must be exactly `"pass"` or `"fail"`.
-- `primary_reason` must be a non-empty string (single sentence).
-- `supporting_evidence_quotes` must contain at least one entry for **every
-  verdict — both `"pass"` and `"fail"`** (#168). The prompt additionally
-  instructs the model to draw quotes as near-verbatim substrings of the
-  target text and to favor representative content over opening-line
-  citations on long artifacts.
-- `suggested_action` must be a non-empty string on `"fail"` and is coerced to `null` on `"pass"`.
-- Extra fields in the JSON response are silently ignored (forward-compatible).
+Primary contract (#268):
+- Prompt target blocks are rendered with stable 1-based line numbers.
+- `supporting_evidence_refs` is validated against the exact prompt-visible
+  corpus (single-target and multi-target paths share the same resolver).
+- On success, gate-keeper reconstructs `supporting_evidence_quotes`
+  mechanically from the referenced line ranges and emits both:
+  `supporting_evidence_quotes` (compat) and `supporting_evidence_refs`
+  (structured contract).
 
-### Parser-side substring grounding (#172)
+Malformed refs (out-of-range, reversed, non-integer, unknown `target_id`,
+unquotable placeholder target, etc.) are treated as grader contract failures:
+`status=unavailable`, `evidence.kind=invalid_evidence_reference`,
+`failure_mode=grader_error`.
 
-Prompt-side discipline alone is not sufficient. Tick 6 of umbrella #164's
-dogfood loop showed that on the first sample after the v2 prompt merged
-the model returned six fail verdicts whose `supporting_evidence_quotes`
-had **zero overlap** with the artifact (generic "fail-shaped" placeholder
-strings). A model-instruction-only constraint is by design unreliable.
+### Legacy quote fallback (#172)
 
-The backend therefore enforces the substring contract in `check()` after
-`_parse_llm_judgment()` succeeds:
+Legacy quote-shaped outputs (`supporting_evidence_quotes` without refs) are
+still accepted defensively. In that fallback path, the original substring
+anti-fabrication validator remains active:
 
-- Each entry of `supporting_evidence_quotes` must occur as a substring of
-  the artifact text the rule is being evaluated against. Whitespace runs
-  are normalised (collapsed to a single space) and a small set of smart
-  punctuation pairs (curly single/double quotes, en/em dashes) is folded
-  to their ASCII counterparts, so the model may copy with cosmetic
-  differences. **Paraphrase or rewording is not tolerated.**
-- The check runs against the **same string the prompt template rendered**
-  into the `Target reference` block via `_build_prompt`. The substitution
-  rules (issue #191) are:
-  - When the caller declares `--artifact-kind` **and** `target` resolves
-    to a real file on disk, the prompt renders the **file content**;
-    the substring check is therefore performed against that content.
-    This is the post-#191 path — gpt-4o-mini at v4 was observed
-    parroting filenames as artifact-kind evidence on path targets, so
-    the path / filename is intentionally withheld from the prompt.
-  - When `--artifact-kind` is **not** declared, the prompt renders
-    `str(target)` byte-for-byte (legacy v4 behaviour), and the
-    substring check accepts only quotes drawn from the path / inline
-    string the model actually saw.
-  - Inline-string targets and non-existent paths fall back to
-    `str(target)` regardless of `--artifact-kind` — there is no file
-    body to substitute.
-  The provider helpers do not give the model a file-read tool, so the
-  model only ever sees the rendered `Target reference` block. The bench
-  harness pre-resolves path targets to file contents before calling
-  `check`, so for bench callers the target string is already the inline
-  content; for the bench callers, `--artifact-kind` therefore changes
-  nothing at the substring-grounding layer.
-- On any violation the verdict is **rejected**: the diagnostic returns
-  `status=unsupported` with `evidence[0]` of kind
-  `llm_quote_fabrication`. The evidence preserves the model's claimed
-  judgment, primary reason, all returned quotes, the subset that failed
-  containment (`fabricated_quotes`), and the standard telemetry / cost
-  fields. `Diagnostic.remediation` advises the operator not to act on the
-  verdict.
-- Empty / whitespace-only quotes are treated as fabricated (zero-grounding
-  is a degenerate case, not a forgivable normalisation difference).
-
-This is option (A) from #172's design: reject the verdict rather than
-strip-and-flag offending quotes. The user-visible signal "this verdict
-came from a model that ignored the substring contract" is more valuable
-than a verdict whose grounding has been silently degraded.
+- Non-substring / fabricated quotes produce `status=unsupported`,
+  `evidence.kind=llm_quote_fabrication`.
+- Successful legacy outputs still emit `supporting_evidence_quotes` plus
+  span metadata for compatibility.
 
 ### Span-based evidence offsets (#179)
 
@@ -738,6 +700,14 @@ Reference history:
   ever shows IDs the model itself emitted (or `null` after the strict
   fabrication guard). Baseline comparison runs must filter on
   `prompt_version`.
+- v7 (#268): moves the primary evidence contract from free-form quote text
+  to structured `supporting_evidence_refs` line ranges. Prompt artifacts are
+  rendered with stable line numbers, backend validation reconstructs
+  `supporting_evidence_quotes` mechanically from ranges, and malformed refs
+  map to `status=unavailable` with
+  `evidence.kind=invalid_evidence_reference` /
+  `failure_mode=grader_error`. Legacy quote fabrication checks remain as a
+  fallback path only.
 
 ### Per-model dispatch accuracy (#175)
 

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -983,8 +983,7 @@ def _render_multi_target_block(specs: list[MultiTargetSpec], texts: dict[str, st
         text = texts.get(spec.id, "")
         path_line = f"Path: {spec.path}\n\n" if spec.path is not None else "Path: null\n\n"
         sections.append(
-            f"### Target {spec.id} (kind: {spec.kind.value})\n\n"
-            f"{path_line}{_render_numbered_lines(text)}\n"
+            f"### Target {spec.id} (kind: {spec.kind.value})\n\n{path_line}{_render_numbered_lines(text)}\n"
         )
     return "\n".join(sections)
 
@@ -1763,8 +1762,8 @@ def _resolve_evidence_artifacts(
 
 
 def _render_numbered_artifact_text(artifact: EvidenceArtifact) -> str:
-    """Return optional path metadata + numbered text block for one artifact."""
-    header = f"Path: {artifact.path}\n\n" if artifact.path else ""
+    """Return path metadata + numbered text block for one artifact."""
+    header = f"Path: {artifact.path}\n\n" if artifact.path is not None else "Path: null\n\n"
     return f"{header}{_render_numbered_lines(artifact.text)}"
 
 
@@ -2242,7 +2241,13 @@ def _quote_span_from_line_range(
     lines_plain = artifact.lines
     start_offset = sum(len(line) for line in lines_keepends[: line_start - 1])
     end_offset = sum(len(line) for line in lines_keepends[:line_end])
-    if end_offset > start_offset and artifact.text and artifact.text[end_offset - 1 : end_offset] == "\n":
+    # Trim trailing line-break bytes so CRLF/LF artifacts map to the same
+    # quote boundary as reconstructed line-joined evidence text.
+    while (
+        end_offset > start_offset
+        and artifact.text
+        and artifact.text[end_offset - 1 : end_offset] in ("\n", "\r")
+    ):
         end_offset -= 1
     end_line_text = lines_plain[line_end - 1]
     return QuoteSpan(
@@ -2295,9 +2300,7 @@ def _validate_and_reconstruct_evidence_refs(
                 [],
                 [],
                 InvalidEvidenceReference(
-                    detail=(
-                        f"supporting_evidence_refs[{i}]: expected object, got {type(entry).__name__}."
-                    ),
+                    detail=(f"supporting_evidence_refs[{i}]: expected object, got {type(entry).__name__}."),
                     refs_raw=refs_raw,
                 ),
             )
@@ -2778,9 +2781,7 @@ def _run_single_strategy(request: JudgmentRequest) -> Diagnostic:
             **strategy_meta,
         }
         if len(artifacts) > 1:
-            evidence_data["supporting_evidence_quote_target_ids"] = [
-                ref["target_id"] for ref in refs_payload
-            ]
+            evidence_data["supporting_evidence_quote_target_ids"] = [ref["target_id"] for ref in refs_payload]
         evidence = Evidence(kind="llm_judgment", data=evidence_data)
         if status is Status.PASS:
             return Diagnostic(
@@ -3005,7 +3006,7 @@ def _run_consensus_strategy(request: JudgmentRequest) -> Diagnostic:
 
     system, user = _build_prompt(rule, target, artifact_kind)
     artifacts = _resolve_evidence_artifacts(rule, target, artifact_kind)
-    artifact_text = _resolve_artifact_text(target, artifact_kind)
+    artifact_text = _build_artifact_text_for_grounding(rule, target, artifact_kind)
 
     # --- Run N independent provider calls ---
     judge_results: list[dict[str, object]] = []
@@ -3654,7 +3655,7 @@ def _run_review_strategy(request: JudgmentRequest) -> Diagnostic:
                 detail=primary_refs_error.detail,
             )
     elif primary_parsed.judgment in ("pass", "fail"):
-        artifact_text = _resolve_artifact_text(target, artifact_kind)
+        artifact_text = _build_artifact_text_for_grounding(rule, target, artifact_kind)
         fabricated = _find_fabricated_quotes(primary_parsed.supporting_evidence_quotes, artifact_text)
         if fabricated:
             return Diagnostic(

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -181,7 +181,13 @@ _SUPPORTED_PROVIDERS = ("anthropic", "openai")
 # file *path* (and the substring grounding check follows the same
 # substitution). Reproducibility records keyed on ``prompt_version``
 # continue to mean the same thing.
-PROMPT_VERSION = "v6"
+# - v7 (#268): primary evidence contract moves from model-generated free-form
+#   ``supporting_evidence_quotes`` to line-range references
+#   (``supporting_evidence_refs``). Prompt-rendered artifacts now include stable
+#   line numbers, and backend-side reconstruction populates
+#   ``supporting_evidence_quotes`` mechanically from validated ranges. Legacy
+#   quote-shaped responses remain accepted only as a defensive fallback path.
+PROMPT_VERSION = "v7"
 
 # ---------------------------------------------------------------------------
 # Per-model pricing table (#133)
@@ -254,6 +260,12 @@ class LlmJudgment(BaseModel):
         ``primary_reason``, and at least one entry should reflect the
         strongest evidence for or against the rule's predicate rather than
         only the artifact's opening lines.
+    supporting_evidence_refs:
+        Primary evidence shape for #268. Each entry is a model-provided line
+        reference object (target/path/line range) that the backend validates
+        and resolves to concrete quote text. Stored as raw list entries here;
+        structural/range validation happens against the resolved artifact corpus
+        after parsing.
     suggested_action:
         Concrete remediation step. Required on fail; MUST be ``None`` on
         pass and on unsupported.
@@ -275,6 +287,7 @@ class LlmJudgment(BaseModel):
     judgment: Literal["pass", "fail", "unsupported"]
     primary_reason: str
     supporting_evidence_quotes: list[str]
+    supporting_evidence_refs: list[Any] | None = None
     suggested_action: str | None
     supporting_evidence_quote_target_ids: list[str | None] | None = None
 
@@ -287,8 +300,13 @@ class LlmJudgment(BaseModel):
 
     @model_validator(mode="after")
     def _cross_field_constraints(self) -> "LlmJudgment":
-        # pass and fail must have at least one grounding quote (#168).
-        if self.judgment in ("pass", "fail") and len(self.supporting_evidence_quotes) == 0:
+        # #168 legacy contract: pass/fail require at least one quote when the
+        # new #268 refs field is absent.
+        if (
+            self.judgment in ("pass", "fail")
+            and self.supporting_evidence_refs is None
+            and len(self.supporting_evidence_quotes) == 0
+        ):
             raise ValueError(
                 "supporting_evidence_quotes must contain at least one entry"
                 f" when judgment is {self.judgment!r}"
@@ -482,6 +500,9 @@ artifact satisfies the given rule.
 {{
   "judgment": "pass" | "fail" | "unsupported",
   "primary_reason": "<one sentence>",
+  "supporting_evidence_refs": [
+    {{"target_id": null, "path": "<path-or-null>", "line_start": 1, "line_end": 1}}
+  ],
   "supporting_evidence_quotes": ["<near-verbatim substring of the target>", ...],
   "suggested_action": "<concrete step to fix>" | null
 }}
@@ -492,11 +513,16 @@ Constraints:
   ONLY valid when an `## Artifact kind` block is present above. If no
   `## Artifact kind` block is rendered, return `"pass"` or `"fail"` only.
 - `primary_reason` must be a single sentence (no newlines).
+- `supporting_evidence_refs` is the primary evidence field. For pass/fail
+  it must contain at least one reference object. Each object must include
+  integer `line_start` and `line_end` values (1-indexed, inclusive), and
+  `line_start <= line_end`. Use the numbered lines from the target block
+  above. `target_id` is required for multi-target prompts and null/omitted
+  for single-target prompts. `path` must match the rendered path metadata
+  for that target (or null for inline/no-path targets).
 - `supporting_evidence_quotes` must contain **at least one entry** for
-  **every pass or fail verdict**. An empty list is invalid for `"pass"`
-  and `"fail"`. For an `"unsupported"` verdict the list may be empty:
-  when the rule does not address the artifact kind, no artifact
-  substring exists that could ground a verdict.
+  **every pass or fail verdict** only on the legacy fallback shape when
+  `supporting_evidence_refs` is absent.
 - Each quote must be a **near-verbatim substring of the target text** —
   copy the words from the artifact. Do **not** paraphrase
   `primary_reason`, do **not** invent meta-statements about the artifact,
@@ -575,6 +601,9 @@ artifact satisfies the given rule.
 {{
   "judgment": "pass" | "fail" | "unsupported",
   "primary_reason": "<one sentence>",
+  "supporting_evidence_refs": [
+    {{"target_id": "<id>", "path": "<path-or-null>", "line_start": 1, "line_end": 1}}
+  ],
   "supporting_evidence_quotes": ["<near-verbatim substring of the target>", ...],
   "suggested_action": "<concrete step to fix>" | null
 }}
@@ -585,11 +614,16 @@ Constraints:
   ONLY valid when an `## Artifact kind` block is present above. If no
   `## Artifact kind` block is rendered, return `"pass"` or `"fail"` only.
 - `primary_reason` must be a single sentence (no newlines).
+- `supporting_evidence_refs` is the primary evidence field. For pass/fail
+  it must contain at least one reference object. Each object must include
+  integer `line_start` and `line_end` values (1-indexed, inclusive), and
+  `line_start <= line_end`. Use the numbered lines from the corresponding
+  target section. `target_id` is required for multi-target prompts and must
+  match a declared target id. `path` must match the rendered path metadata
+  for that target (or null for no-path targets).
 - `supporting_evidence_quotes` must contain **at least one entry** for
-  **every pass or fail verdict**. An empty list is invalid for `"pass"`
-  and `"fail"`. For an `"unsupported"` verdict the list may be empty:
-  when the rule does not address the artifact kind, no artifact
-  substring exists that could ground a verdict.
+  **every pass or fail verdict** only on the legacy fallback shape when
+  `supporting_evidence_refs` is absent.
 - Each quote must be a **near-verbatim substring of the target text** —
   copy the words from the artifact. Do **not** paraphrase
   `primary_reason`, do **not** invent meta-statements about the artifact,
@@ -947,20 +981,21 @@ def _render_multi_target_block(specs: list[MultiTargetSpec], texts: dict[str, st
     sections: list[str] = ["## Target artifacts (multi)\n"]
     for spec in specs:
         text = texts.get(spec.id, "")
-        sections.append(f"### Target {spec.id} (kind: {spec.kind.value})\n\n{text}\n")
+        path_line = f"Path: {spec.path}\n\n" if spec.path is not None else "Path: null\n\n"
+        sections.append(
+            f"### Target {spec.id} (kind: {spec.kind.value})\n\n"
+            f"{path_line}{_render_numbered_lines(text)}\n"
+        )
     return "\n".join(sections)
 
 
 _MULTI_TARGET_INSTRUCTION_BLOCK = """\
 - This rule is evaluated against **multiple labelled target artifacts** (see \
 the ``## Target artifacts (multi)`` block above). When you cite supporting \
-evidence, each entry of ``supporting_evidence_quotes`` MUST be an object of \
-the form ``{"target_id": "<id>", "quote": "<near-verbatim substring>"}`` \
-where ``<id>`` matches one of the labelled artifact ids above. The \
-``target_id`` field is **required**: plain-string entries without a \
-``target_id`` are not accepted for multi-target rules. The ``quote`` value \
-must be a near-verbatim substring drawn from the artifact identified by \
-``target_id``; it must not be drawn from a different artifact.
+evidence, each entry of ``supporting_evidence_refs`` MUST be an object of the \
+form ``{"target_id": "<id>", "path": "<path-or-null>", "line_start": 10, \
+"line_end": 12}`` where ``<id>`` matches one of the labelled artifact ids \
+above. The ``target_id`` field is **required** for multi-target rules.
 """
 
 
@@ -1057,9 +1092,12 @@ def _build_prompt(
     if multi_targets:
         return _build_multi_target_prompt(rule, multi_targets)
     system = RUBRIC_SYSTEM_PROMPT
+    numbered_target = _render_numbered_artifact_text(
+        _resolve_evidence_artifacts(rule, target, artifact_kind)[0]
+    )
     user = RUBRIC_PROMPT_TEMPLATE.format(
         rule_text=rule.text,
-        target=_resolve_artifact_input(target, artifact_kind),
+        target=numbered_target,
         target_kind_block=_render_target_kind_block(rule.target_kind),
         unsupported_instruction=_render_unsupported_instruction(rule.target_kind),
         unsupported_example_block=_render_unsupported_example_block(rule.target_kind),
@@ -1349,7 +1387,7 @@ def _parse_llm_judgment(text: str) -> LlmJudgment | LlmJudgmentParseError:
         )
 
     # Required fields
-    for required_field in ("judgment", "primary_reason", "supporting_evidence_quotes"):
+    for required_field in ("judgment", "primary_reason"):
         if required_field not in obj:
             return LlmJudgmentParseError(
                 failure_mode="missing_field",
@@ -1373,11 +1411,28 @@ def _parse_llm_judgment(text: str) -> LlmJudgment | LlmJudgmentParseError:
             raw_response_excerpt=excerpt,
         )
 
-    quotes_raw = obj["supporting_evidence_quotes"]
+    refs_present = "supporting_evidence_refs" in obj
+    refs_raw = obj.get("supporting_evidence_refs")
+    refs: list[Any] | None
+    if refs_present:
+        if refs_raw is None:
+            refs = []
+        elif isinstance(refs_raw, list):
+            refs = refs_raw
+        else:
+            # #268: keep parse-time tolerant so malformed evidence coordinates
+            # route through the grader-error classifier rather than provider_error.
+            refs = [refs_raw]
+    else:
+        refs = None
+
+    quotes_raw = obj.get("supporting_evidence_quotes")
+    if quotes_raw is None:
+        quotes_raw = []
     if not isinstance(quotes_raw, list):
         return LlmJudgmentParseError(
             failure_mode="missing_field",
-            detail="supporting_evidence_quotes must be a list.",
+            detail="supporting_evidence_quotes must be a list when present.",
             raw_response_excerpt=excerpt,
         )
 
@@ -1425,11 +1480,12 @@ def _parse_llm_judgment(text: str) -> LlmJudgment | LlmJudgmentParseError:
             raw_response_excerpt=excerpt,
         )
 
-    # #168 — both pass and fail must be grounded by at least one quote.
+    # #168 — both pass and fail must be grounded by at least one quote on the
+    # legacy shape where #268 refs are absent.
     # #169 — `unsupported` may carry an empty list: when the rule's premise
     # does not address the artifact kind, no artifact substring exists that
     # could ground a verdict.
-    if judgment in ("pass", "fail") and len(quotes) == 0:
+    if judgment in ("pass", "fail") and refs is None and len(quotes) == 0:
         return LlmJudgmentParseError(
             failure_mode="missing_field",
             detail=(
@@ -1455,6 +1511,7 @@ def _parse_llm_judgment(text: str) -> LlmJudgment | LlmJudgmentParseError:
             judgment=judgment,
             primary_reason=primary_reason,
             supporting_evidence_quotes=quotes,
+            supporting_evidence_refs=refs,
             suggested_action=suggested_action,
             # Only attach the parallel target-id list when at least one
             # quote arrived in the object form — single-target / legacy
@@ -1635,6 +1692,80 @@ def _resolve_artifact_texts_for_rule(
         # Artifacts whose paths could not be read are intentionally un-quotable.
         return {sid: text for sid, text in texts.items() if sid not in placeholder_ids}
     return {_SINGLE_TARGET_SENTINEL_ID: _resolve_artifact_text(target, artifact_kind)}
+
+
+@dataclass(frozen=True)
+class EvidenceArtifact:
+    """Resolved artifact payload shared by prompt rendering and #268 evidence refs."""
+
+    target_id: str | None
+    path: str | None
+    text: str
+    quotable: bool
+
+    @property
+    def lines(self) -> list[str]:
+        split = self.text.splitlines()
+        return split if split else [""]
+
+
+def _render_numbered_lines(text: str) -> str:
+    """Render *text* as stable 1-based numbered lines for prompt grounding (#268)."""
+    numbered: list[str] = []
+    split = text.splitlines()
+    if not split:
+        split = [""]
+    for i, line in enumerate(split, start=1):
+        numbered.append(f"{i:>4} | {line}")
+    return "\n".join(numbered)
+
+
+def _resolve_single_target_path(target: str | Path) -> str | None:
+    """Return a filesystem path string when *target* resolves to a real file."""
+    try:
+        path = target if isinstance(target, Path) else Path(str(target))
+        if path.is_file():
+            return str(path)
+    except OSError:
+        return None
+    return None
+
+
+def _resolve_evidence_artifacts(
+    rule: Rule,
+    target: str | Path,
+    artifact_kind: TargetKind | None = None,
+) -> list[EvidenceArtifact]:
+    """Return prompt-visible artifacts plus quotability metadata (#268)."""
+    specs = _parse_multi_targets(rule)
+    if specs:
+        texts, placeholder_ids = _load_multi_target_texts(specs)
+        artifacts: list[EvidenceArtifact] = []
+        for spec in specs:
+            artifacts.append(
+                EvidenceArtifact(
+                    target_id=spec.id,
+                    path=spec.path,
+                    text=texts.get(spec.id, ""),
+                    quotable=spec.id not in placeholder_ids,
+                )
+            )
+        return artifacts
+    rendered = _resolve_artifact_input(target, artifact_kind)
+    return [
+        EvidenceArtifact(
+            target_id=None,
+            path=_resolve_single_target_path(target),
+            text=rendered,
+            quotable=True,
+        )
+    ]
+
+
+def _render_numbered_artifact_text(artifact: EvidenceArtifact) -> str:
+    """Return optional path metadata + numbered text block for one artifact."""
+    header = f"Path: {artifact.path}\n\n" if artifact.path else ""
+    return f"{header}{_render_numbered_lines(artifact.text)}"
 
 
 #: Sentinel id used by :func:`_resolve_artifact_texts_for_rule` for the
@@ -2088,6 +2219,237 @@ def _resolve_quote_spans(quotes: list[str], artifact_text: str) -> list[QuoteSpa
     return spans
 
 
+@dataclass(frozen=True)
+class InvalidEvidenceReference:
+    """Structured #268 grader-contract failure."""
+
+    detail: str
+    refs_raw: list[Any] | None
+
+
+def _quote_span_from_line_range(
+    artifact: EvidenceArtifact,
+    quote: str,
+    line_start: int,
+    line_end: int,
+    *,
+    artifact_index: int,
+) -> QuoteSpan:
+    """Build deterministic span metadata directly from validated line ranges."""
+    lines_keepends = artifact.text.splitlines(keepends=True)
+    if not lines_keepends:
+        lines_keepends = [""]
+    lines_plain = artifact.lines
+    start_offset = sum(len(line) for line in lines_keepends[: line_start - 1])
+    end_offset = sum(len(line) for line in lines_keepends[:line_end])
+    if end_offset > start_offset and artifact.text and artifact.text[end_offset - 1 : end_offset] == "\n":
+        end_offset -= 1
+    end_line_text = lines_plain[line_end - 1]
+    return QuoteSpan(
+        quote=quote,
+        artifact_index=artifact_index,
+        start_offset=start_offset,
+        end_offset=end_offset,
+        start_line=line_start,
+        start_column=1,
+        end_line=line_end,
+        end_column=len(end_line_text) + 1,
+        match_normalisation="exact",
+    )
+
+
+def _validate_and_reconstruct_evidence_refs(
+    rule: Rule,
+    parsed: LlmJudgment,
+    artifacts: list[EvidenceArtifact],
+) -> tuple[list[str], list[dict[str, Any]], list[QuoteSpan], InvalidEvidenceReference | None]:
+    """Validate #268 line-range refs and reconstruct evidence strings/spans."""
+    refs_raw = parsed.supporting_evidence_refs
+    if refs_raw is None:
+        return [], [], [], None
+    if parsed.judgment in ("pass", "fail") and len(refs_raw) == 0:
+        return (
+            [],
+            [],
+            [],
+            InvalidEvidenceReference(
+                detail=(
+                    "supporting_evidence_refs must contain at least one entry "
+                    f"when judgment is {parsed.judgment!r}."
+                ),
+                refs_raw=refs_raw,
+            ),
+        )
+    is_multi = bool(_parse_multi_targets(rule))
+    by_target_id: dict[str, tuple[int, EvidenceArtifact]] = {}
+    for idx, artifact in enumerate(artifacts):
+        if artifact.target_id is not None:
+            by_target_id[artifact.target_id] = (idx, artifact)
+    refs_out: list[dict[str, Any]] = []
+    quotes_out: list[str] = []
+    spans_out: list[QuoteSpan] = []
+    for i, entry in enumerate(refs_raw):
+        if not isinstance(entry, dict):
+            return (
+                [],
+                [],
+                [],
+                InvalidEvidenceReference(
+                    detail=(
+                        f"supporting_evidence_refs[{i}]: expected object, got {type(entry).__name__}."
+                    ),
+                    refs_raw=refs_raw,
+                ),
+            )
+        target_id_raw = entry.get("target_id")
+        path_raw = entry.get("path")
+        line_start_raw = entry.get("line_start")
+        line_end_raw = entry.get("line_end")
+
+        if is_multi:
+            if not isinstance(target_id_raw, str) or not target_id_raw:
+                return (
+                    [],
+                    [],
+                    [],
+                    InvalidEvidenceReference(
+                        detail=(
+                            f"supporting_evidence_refs[{i}].target_id: "
+                            "required non-empty string for multi-target."
+                        ),
+                        refs_raw=refs_raw,
+                    ),
+                )
+            if target_id_raw not in by_target_id:
+                return (
+                    [],
+                    [],
+                    [],
+                    InvalidEvidenceReference(
+                        detail=f"supporting_evidence_refs[{i}].target_id: unknown id {target_id_raw!r}.",
+                        refs_raw=refs_raw,
+                    ),
+                )
+            artifact_index, artifact = by_target_id[target_id_raw]
+            target_id: str | None = target_id_raw
+        else:
+            artifact_index = 0
+            artifact = artifacts[0]
+            if target_id_raw is not None:
+                return (
+                    [],
+                    [],
+                    [],
+                    InvalidEvidenceReference(
+                        detail=(
+                            f"supporting_evidence_refs[{i}].target_id: "
+                            "must be null/omitted on single-target rules."
+                        ),
+                        refs_raw=refs_raw,
+                    ),
+                )
+            target_id = None
+
+        if path_raw is not None and not isinstance(path_raw, str):
+            return (
+                [],
+                [],
+                [],
+                InvalidEvidenceReference(
+                    detail=(
+                        f"supporting_evidence_refs[{i}].path: expected str or null, "
+                        f"got {type(path_raw).__name__}."
+                    ),
+                    refs_raw=refs_raw,
+                ),
+            )
+        expected_path = artifact.path
+        if path_raw != expected_path:
+            return (
+                [],
+                [],
+                [],
+                InvalidEvidenceReference(
+                    detail=(
+                        f"supporting_evidence_refs[{i}].path: expected {expected_path!r}, got {path_raw!r}."
+                    ),
+                    refs_raw=refs_raw,
+                ),
+            )
+        if isinstance(line_start_raw, bool) or not isinstance(line_start_raw, int):
+            return (
+                [],
+                [],
+                [],
+                InvalidEvidenceReference(
+                    detail=f"supporting_evidence_refs[{i}].line_start: expected integer.",
+                    refs_raw=refs_raw,
+                ),
+            )
+        if isinstance(line_end_raw, bool) or not isinstance(line_end_raw, int):
+            return (
+                [],
+                [],
+                [],
+                InvalidEvidenceReference(
+                    detail=f"supporting_evidence_refs[{i}].line_end: expected integer.",
+                    refs_raw=refs_raw,
+                ),
+            )
+        line_count = len(artifact.lines)
+        if (
+            line_start_raw < 1
+            or line_end_raw < 1
+            or line_start_raw > line_end_raw
+            or line_end_raw > line_count
+        ):
+            return (
+                [],
+                [],
+                [],
+                InvalidEvidenceReference(
+                    detail=(
+                        f"supporting_evidence_refs[{i}]: invalid range {line_start_raw}-{line_end_raw} "
+                        f"for artifact line_count={line_count}."
+                    ),
+                    refs_raw=refs_raw,
+                ),
+            )
+        if not artifact.quotable:
+            return (
+                [],
+                [],
+                [],
+                InvalidEvidenceReference(
+                    detail=(
+                        f"supporting_evidence_refs[{i}]: target_id={target_id!r} is unquotable "
+                        "(artifact content unavailable)."
+                    ),
+                    refs_raw=refs_raw,
+                ),
+            )
+        quote = "\n".join(artifact.lines[line_start_raw - 1 : line_end_raw])
+        quotes_out.append(quote)
+        refs_out.append(
+            {
+                "target_id": target_id,
+                "path": expected_path,
+                "line_start": line_start_raw,
+                "line_end": line_end_raw,
+            }
+        )
+        spans_out.append(
+            _quote_span_from_line_range(
+                artifact,
+                quote,
+                line_start_raw,
+                line_end_raw,
+                artifact_index=artifact_index,
+            )
+        )
+    return quotes_out, refs_out, spans_out, None
+
+
 # ---------------------------------------------------------------------------
 # Diagnostic constructors — #51 contract preserved byte-for-byte
 # ---------------------------------------------------------------------------
@@ -2137,6 +2499,54 @@ def _unavailable_provider_error(
         remediation=(
             "Investigate the provider error (see evidence for failure mode) "
             "and rerun once the provider is healthy."
+        ),
+    )
+
+
+def _unavailable_invalid_evidence_reference(
+    *,
+    rule: Rule,
+    rubric_input: dict[str, Any],
+    model: str,
+    telemetry: dict[str, int],
+    cost_estimate_usd: float | None,
+    strategy_meta: dict[str, Any],
+    parsed: LlmJudgment,
+    detail: str,
+) -> Diagnostic:
+    """Return #268 grader-contract failure diagnostic."""
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=Backend.LLM_RUBRIC,
+        status=Status.UNAVAILABLE,
+        severity=rule.severity,
+        message="LLM rubric returned malformed evidence references; skipping rule.",
+        evidence=[
+            Evidence(
+                kind="invalid_evidence_reference",
+                data={
+                    **rubric_input,
+                    "model": model,
+                    "prompt_version": PROMPT_VERSION,
+                    "failure_mode": "grader_error",
+                    "detail": detail[:500],
+                    "judgment": parsed.judgment,
+                    "primary_reason": parsed.primary_reason,
+                    "supporting_evidence_refs": parsed.supporting_evidence_refs,
+                    "supporting_evidence_quotes": parsed.supporting_evidence_quotes,
+                    "suggested_action": parsed.suggested_action,
+                    "latency_ms": telemetry["latency_ms"],
+                    "tokens_in": telemetry["tokens_in"],
+                    "tokens_out": telemetry["tokens_out"],
+                    "cost_estimate_usd": cost_estimate_usd,
+                    **strategy_meta,
+                },
+            )
+        ],
+        remediation=(
+            "The grader returned malformed supporting_evidence_refs. Re-run the "
+            "rule; if this persists, update the prompt/model contract."
         ),
     )
 
@@ -2334,37 +2744,81 @@ def _run_single_strategy(request: JudgmentRequest) -> Diagnostic:
             ),
         )
 
-    # #172 — parser-side enforcement of the v2 prompt's substring-grounding
-    # contract. If any quote is not a substring of the artifact text, reject
-    # the verdict and surface UNSUPPORTED with llm_quote_fabrication evidence.
-    # #191 — when ``artifact_kind`` is declared and the target is a real file,
-    # ``_resolve_artifact_text`` returns the file content (mirroring what
-    # ``_build_prompt`` injected). Quotes are validated against what the
-    # model actually saw.
-    # #225 (slice 2) — multi-target rules now perform strict per-target
-    # grounding: a quote claiming ``target_id=A`` must be a substring of
-    # artifact A's text specifically, not merely of the concatenated prompt.
-    # Unknown or missing ``target_id`` values fail closed. The single-target
-    # path is unchanged.
+    artifacts = _resolve_evidence_artifacts(rule, target, artifact_kind)
+    refs_quotes, refs_payload, refs_spans, refs_error = _validate_and_reconstruct_evidence_refs(
+        rule, parsed, artifacts
+    )
+    strict_target_ids: list[str] | None = None
+    if parsed.supporting_evidence_refs is not None:
+        if refs_error is not None:
+            return _unavailable_invalid_evidence_reference(
+                rule=rule,
+                rubric_input=rubric_input,
+                model=model,
+                telemetry=telemetry,
+                cost_estimate_usd=cost,
+                strategy_meta=strategy_meta,
+                parsed=parsed,
+                detail=refs_error.detail,
+            )
+        status = Status.PASS if parsed.judgment == "pass" else Status.FAIL
+        evidence_data: dict[str, Any] = {
+            "model": model,
+            "prompt_version": PROMPT_VERSION,
+            "judgment": parsed.judgment,
+            "primary_reason": parsed.primary_reason,
+            "supporting_evidence_quotes": refs_quotes,
+            "supporting_evidence_refs": refs_payload,
+            "supporting_evidence_spans": [span.to_dict() for span in refs_spans],
+            "suggested_action": parsed.suggested_action,
+            "latency_ms": telemetry["latency_ms"],
+            "tokens_in": telemetry["tokens_in"],
+            "tokens_out": telemetry["tokens_out"],
+            "cost_estimate_usd": cost,
+            **strategy_meta,
+        }
+        if len(artifacts) > 1:
+            evidence_data["supporting_evidence_quote_target_ids"] = [
+                ref["target_id"] for ref in refs_payload
+            ]
+        evidence = Evidence(kind="llm_judgment", data=evidence_data)
+        if status is Status.PASS:
+            return Diagnostic(
+                rule_id=rule.id,
+                source=rule.source,
+                backend=Backend.LLM_RUBRIC,
+                status=status,
+                severity=rule.severity,
+                message=parsed.primary_reason,
+                evidence=[evidence],
+            )
+        return Diagnostic(
+            rule_id=rule.id,
+            source=rule.source,
+            backend=Backend.LLM_RUBRIC,
+            status=status,
+            severity=rule.severity,
+            message=parsed.primary_reason,
+            evidence=[evidence],
+            remediation=parsed.suggested_action,
+        )
+
+    # Legacy fallback path (#268 defensive compatibility): quote fabrication
+    # validator remains enabled for quote-shaped model outputs.
     multi_targets = _parse_multi_targets(rule)
     if multi_targets:
-        # Strict per-target grounding path for multi-target rules.
         texts_by_id = _resolve_artifact_texts_for_rule(rule, target, artifact_kind)
         strict_target_ids = _resolve_quote_target_ids_strict(rule, parsed)
-        assert strict_target_ids is not None  # non-empty multi_targets guarantees this
+        assert strict_target_ids is not None
         fabricated = _find_per_target_fabricated_quotes(
             parsed.supporting_evidence_quotes,
             strict_target_ids,
             texts_by_id,
         )
-        # Flat text for span resolution (best-effort; per-artifact span
-        # attribution is deferred to a future slice).
         artifact_text = _build_artifact_text_for_grounding(rule, target, artifact_kind)
     else:
-        # Single-target legacy path: flat substring check unchanged.
         artifact_text = _build_artifact_text_for_grounding(rule, target, artifact_kind)
         fabricated = _find_fabricated_quotes(parsed.supporting_evidence_quotes, artifact_text)
-        strict_target_ids = None
     if fabricated:
         return Diagnostic(
             rule_id=rule.id,
@@ -2406,11 +2860,6 @@ def _run_single_strategy(request: JudgmentRequest) -> Diagnostic:
         )
 
     status = Status.PASS if parsed.judgment == "pass" else Status.FAIL
-    # #179 — once the fabrication validator has confirmed every quote is a
-    # normalised substring of the artifact, resolve each to a span pointing
-    # back into the original artifact text. Spans are additive: the
-    # ``supporting_evidence_quotes`` field remains the stable compatibility
-    # surface, ``supporting_evidence_spans`` is the new offset-bearing field.
     spans = _resolve_quote_spans(parsed.supporting_evidence_quotes, artifact_text)
     evidence_data: dict[str, Any] = {
         "model": model,
@@ -2555,6 +3004,7 @@ def _run_consensus_strategy(request: JudgmentRequest) -> Diagnostic:
     panel_size = max(_CONSENSUS_PANEL_SIZE_MIN, min(_CONSENSUS_PANEL_SIZE_MAX, panel_size))
 
     system, user = _build_prompt(rule, target, artifact_kind)
+    artifacts = _resolve_evidence_artifacts(rule, target, artifact_kind)
     artifact_text = _resolve_artifact_text(target, artifact_kind)
 
     # --- Run N independent provider calls ---
@@ -2614,25 +3064,6 @@ def _run_consensus_strategy(request: JudgmentRequest) -> Diagnostic:
             )
             continue
 
-        # Quote-fabrication check per judge.
-        fabricated = _find_fabricated_quotes(parsed.supporting_evidence_quotes, artifact_text)
-        if fabricated:
-            judge_results.append(
-                {
-                    "judge_index": judge_index,
-                    "model": model,
-                    "verdict": "unsupported",
-                    "failure_mode": "quote_fabrication",
-                    "claimed_judgment": parsed.judgment,
-                    "fabricated_quotes": fabricated,
-                    "latency_ms": telemetry["latency_ms"],
-                    "tokens_in": telemetry["tokens_in"],
-                    "tokens_out": telemetry["tokens_out"],
-                    "cost_estimate_usd": call_cost,
-                }
-            )
-            continue
-
         # Mirror the single-strategy contract: an "unsupported" verdict on a
         # rule without ``target_kind`` is a contract violation — the
         # artifact-kind block was never injected, so the model had no basis to
@@ -2659,13 +3090,58 @@ def _run_consensus_strategy(request: JudgmentRequest) -> Diagnostic:
             )
             continue
 
+        resolved_quotes = parsed.supporting_evidence_quotes
+        resolved_refs: list[dict[str, Any]] = []
+        # #268 primary contract: validate refs when present.
+        if parsed.judgment in ("pass", "fail") and parsed.supporting_evidence_refs is not None:
+            refs_quotes, refs_payload, _refs_spans, refs_error = _validate_and_reconstruct_evidence_refs(
+                rule, parsed, artifacts
+            )
+            if refs_error is not None:
+                judge_results.append(
+                    {
+                        "judge_index": judge_index,
+                        "model": model,
+                        "verdict": "unsupported",
+                        "failure_mode": "invalid_evidence_reference",
+                        "detail": refs_error.detail[:500],
+                        "latency_ms": telemetry["latency_ms"],
+                        "tokens_in": telemetry["tokens_in"],
+                        "tokens_out": telemetry["tokens_out"],
+                        "cost_estimate_usd": call_cost,
+                    }
+                )
+                continue
+            resolved_quotes = refs_quotes
+            resolved_refs = refs_payload
+        elif parsed.judgment in ("pass", "fail"):
+            # Legacy fallback only.
+            fabricated = _find_fabricated_quotes(parsed.supporting_evidence_quotes, artifact_text)
+            if fabricated:
+                judge_results.append(
+                    {
+                        "judge_index": judge_index,
+                        "model": model,
+                        "verdict": "unsupported",
+                        "failure_mode": "quote_fabrication",
+                        "claimed_judgment": parsed.judgment,
+                        "fabricated_quotes": fabricated,
+                        "latency_ms": telemetry["latency_ms"],
+                        "tokens_in": telemetry["tokens_in"],
+                        "tokens_out": telemetry["tokens_out"],
+                        "cost_estimate_usd": call_cost,
+                    }
+                )
+                continue
+
         judge_results.append(
             {
                 "judge_index": judge_index,
                 "model": model,
                 "verdict": parsed.judgment,
                 "primary_reason": parsed.primary_reason,
-                "supporting_evidence_quotes": parsed.supporting_evidence_quotes,
+                "supporting_evidence_quotes": resolved_quotes,
+                "supporting_evidence_refs": resolved_refs,
                 "suggested_action": parsed.suggested_action,
                 "latency_ms": telemetry["latency_ms"],
                 "tokens_in": telemetry["tokens_in"],
@@ -2704,6 +3180,8 @@ def _run_consensus_strategy(request: JudgmentRequest) -> Diagnostic:
     seen_quotes: set[str] = set()
     majority_primary_reason: str = ""
     majority_suggested_action: str | None = None
+    majority_refs: list[dict[str, Any]] = []
+    seen_refs: set[tuple[Any, ...]] = set()
     for r in judge_results:
         if r["verdict"] != majority_verdict:
             continue
@@ -2714,6 +3192,19 @@ def _run_consensus_strategy(request: JudgmentRequest) -> Diagnostic:
             if isinstance(q, str) and q not in seen_quotes:
                 seen_quotes.add(q)
                 majority_quotes.append(q)
+        for ref in r.get("supporting_evidence_refs", []):  # type: ignore[union-attr]
+            if not isinstance(ref, dict):
+                continue
+            key = (
+                ref.get("target_id"),
+                ref.get("path"),
+                ref.get("line_start"),
+                ref.get("line_end"),
+            )
+            if key in seen_refs:
+                continue
+            seen_refs.add(key)
+            majority_refs.append(dict(ref))
 
     consensus_evidence_base: dict[str, object] = {
         "llm_strategy": "consensus",
@@ -2781,6 +3272,7 @@ def _run_consensus_strategy(request: JudgmentRequest) -> Diagnostic:
         **consensus_evidence_base,
         "primary_reason": majority_primary_reason,
         "supporting_evidence_quotes": majority_quotes,
+        "supporting_evidence_refs": majority_refs,
         "suggested_action": majority_suggested_action,
     }
     evidence = Evidence(kind="llm_consensus", data=evidence_data)
@@ -3133,54 +3625,90 @@ def _run_review_strategy(request: JudgmentRequest) -> Diagnostic:
             ),
         )
 
-    artifact_text = _resolve_artifact_text(target, artifact_kind)
-    fabricated = _find_fabricated_quotes(primary_parsed.supporting_evidence_quotes, artifact_text)
-    if fabricated:
-        return Diagnostic(
-            rule_id=rule.id,
-            source=rule.source,
-            backend=Backend.LLM_RUBRIC,
-            status=Status.UNSUPPORTED,
-            severity=rule.severity,
-            message=(
-                "LLM rubric verdict rejected: the model returned "
-                f"{len(fabricated)} of {len(primary_parsed.supporting_evidence_quotes)} "
-                "supporting quotes that are not substrings of the artifact "
-                "(quote fabrication)."
-            ),
-            evidence=[
-                Evidence(
-                    kind="llm_quote_fabrication",
-                    data={
-                        "model": model,
-                        "prompt_version": PROMPT_VERSION,
-                        "claimed_judgment": primary_parsed.judgment,
-                        "primary_reason": primary_parsed.primary_reason,
-                        "supporting_evidence_quotes": primary_parsed.supporting_evidence_quotes,
-                        "fabricated_quotes": fabricated,
-                        "suggested_action": primary_parsed.suggested_action,
-                        "latency_ms": primary_telemetry["latency_ms"],
-                        "tokens_in": primary_telemetry["tokens_in"],
-                        "tokens_out": primary_telemetry["tokens_out"],
-                        "cost_estimate_usd": primary_cost,
-                        "llm_strategy": "review",
-                        "llm_call_count": 1,
-                        "models": [model],
-                        "cost_estimate_usd_total": primary_cost,
-                        "latency_ms_total": primary_telemetry["latency_ms"],
-                    },
-                )
-            ],
-            remediation=(
-                "The model violated the substring-grounding contract for "
-                "supporting_evidence_quotes (v2 prompt, #168). Re-run the "
-                "rule; if the failure persists, investigate prompt drift or "
-                "switch model. Do not act on this verdict."
-            ),
+    artifacts = _resolve_evidence_artifacts(rule, target, artifact_kind)
+    primary_refs_quotes: list[str] = []
+    primary_refs_payload: list[dict[str, Any]] = []
+    primary_refs_spans: list[QuoteSpan] = []
+    if primary_parsed.judgment in ("pass", "fail") and primary_parsed.supporting_evidence_refs is not None:
+        (
+            primary_refs_quotes,
+            primary_refs_payload,
+            primary_refs_spans,
+            primary_refs_error,
+        ) = _validate_and_reconstruct_evidence_refs(rule, primary_parsed, artifacts)
+        if primary_refs_error is not None:
+            return _unavailable_invalid_evidence_reference(
+                rule=rule,
+                rubric_input=rubric_input,
+                model=model,
+                telemetry=primary_telemetry,
+                cost_estimate_usd=primary_cost,
+                strategy_meta={
+                    "llm_strategy": "review",
+                    "llm_call_count": 1,
+                    "models": [model],
+                    "cost_estimate_usd_total": primary_cost,
+                    "latency_ms_total": primary_telemetry["latency_ms"],
+                },
+                parsed=primary_parsed,
+                detail=primary_refs_error.detail,
+            )
+    elif primary_parsed.judgment in ("pass", "fail"):
+        artifact_text = _resolve_artifact_text(target, artifact_kind)
+        fabricated = _find_fabricated_quotes(primary_parsed.supporting_evidence_quotes, artifact_text)
+        if fabricated:
+            return Diagnostic(
+                rule_id=rule.id,
+                source=rule.source,
+                backend=Backend.LLM_RUBRIC,
+                status=Status.UNSUPPORTED,
+                severity=rule.severity,
+                message=(
+                    "LLM rubric verdict rejected: the model returned "
+                    f"{len(fabricated)} of {len(primary_parsed.supporting_evidence_quotes)} "
+                    "supporting quotes that are not substrings of the artifact "
+                    "(quote fabrication)."
+                ),
+                evidence=[
+                    Evidence(
+                        kind="llm_quote_fabrication",
+                        data={
+                            "model": model,
+                            "prompt_version": PROMPT_VERSION,
+                            "claimed_judgment": primary_parsed.judgment,
+                            "primary_reason": primary_parsed.primary_reason,
+                            "supporting_evidence_quotes": primary_parsed.supporting_evidence_quotes,
+                            "fabricated_quotes": fabricated,
+                            "suggested_action": primary_parsed.suggested_action,
+                            "latency_ms": primary_telemetry["latency_ms"],
+                            "tokens_in": primary_telemetry["tokens_in"],
+                            "tokens_out": primary_telemetry["tokens_out"],
+                            "cost_estimate_usd": primary_cost,
+                            "llm_strategy": "review",
+                            "llm_call_count": 1,
+                            "models": [model],
+                            "cost_estimate_usd_total": primary_cost,
+                            "latency_ms_total": primary_telemetry["latency_ms"],
+                        },
+                    )
+                ],
+                remediation=(
+                    "The model violated the substring-grounding contract for "
+                    "supporting_evidence_quotes (v2 prompt, #168). Re-run the "
+                    "rule; if the failure persists, investigate prompt drift or "
+                    "switch model. Do not act on this verdict."
+                ),
+            )
+
+    if primary_refs_quotes:
+        primary_for_review = primary_parsed.model_copy(
+            update={"supporting_evidence_quotes": primary_refs_quotes}
         )
+    else:
+        primary_for_review = primary_parsed
 
     # ---- Pass 2: reviewer ----
-    rev_system, rev_user = _build_review_prompt(rule, target, primary_parsed, artifact_kind)
+    rev_system, rev_user = _build_review_prompt(rule, target, primary_for_review, artifact_kind)
 
     reviewer_text: str | None = None
     reviewer_telemetry: dict[str, int] | None = None
@@ -3260,7 +3788,7 @@ def _run_review_strategy(request: JudgmentRequest) -> Diagnostic:
     primary_judgment_record: dict[str, object] = {
         "judgment": primary_parsed.judgment,
         "primary_reason": primary_parsed.primary_reason,
-        "quotes": primary_parsed.supporting_evidence_quotes,
+        "quotes": primary_for_review.supporting_evidence_quotes,
     }
 
     # ---- Aggregation: route by reviewer_verdict ----
@@ -3309,7 +3837,13 @@ def _run_review_strategy(request: JudgmentRequest) -> Diagnostic:
 
     # agree or abstain: emit primary verdict.
     status = Status.PASS if primary_parsed.judgment == "pass" else Status.FAIL
-    spans = _resolve_quote_spans(primary_parsed.supporting_evidence_quotes, artifact_text)
+    if primary_refs_quotes:
+        resolved_quotes_for_output = primary_refs_quotes
+        spans = primary_refs_spans
+    else:
+        artifact_text = _resolve_artifact_text(target, artifact_kind)
+        resolved_quotes_for_output = primary_parsed.supporting_evidence_quotes
+        spans = _resolve_quote_spans(primary_parsed.supporting_evidence_quotes, artifact_text)
     evidence_data: dict[str, object] = {
         "llm_strategy": "review",
         "review_primary_judgment": primary_judgment_record,
@@ -3324,7 +3858,8 @@ def _run_review_strategy(request: JudgmentRequest) -> Diagnostic:
         "models": models_used,
         "cost_estimate_usd_total": total_cost,
         "latency_ms_total": total_latency_ms,
-        "supporting_evidence_quotes": primary_parsed.supporting_evidence_quotes,
+        "supporting_evidence_quotes": resolved_quotes_for_output,
+        "supporting_evidence_refs": primary_refs_payload,
         "supporting_evidence_spans": [span.to_dict() for span in spans],
         "suggested_action": primary_parsed.suggested_action,
     }

--- a/src/gate_keeper/diagnostics.py
+++ b/src/gate_keeper/diagnostics.py
@@ -111,6 +111,8 @@ def _derive_failure_mode(diagnostic: Diagnostic) -> str | None:
             return "adapter_unknown"
         if e.kind == "params_error":
             return "params_error"
+        if e.kind == "invalid_evidence_reference":
+            return str(e.data.get("failure_mode", "grader_error"))
         if e.kind == "llm_judgment":
             judgment = e.data.get("judgment", "")
             return f"llm_{judgment}" if judgment else "llm_fail"

--- a/src/gate_keeper/diagnostics.py
+++ b/src/gate_keeper/diagnostics.py
@@ -112,7 +112,10 @@ def _derive_failure_mode(diagnostic: Diagnostic) -> str | None:
         if e.kind == "params_error":
             return "params_error"
         if e.kind == "invalid_evidence_reference":
-            return str(e.data.get("failure_mode", "grader_error"))
+            failure_mode = e.data.get("failure_mode")
+            if isinstance(failure_mode, str) and failure_mode.strip():
+                return failure_mode
+            return "grader_error"
         if e.kind == "llm_judgment":
             judgment = e.data.get("judgment", "")
             return f"llm_{judgment}" if judgment else "llm_fail"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -600,3 +600,13 @@ def test_json_provider_error_failure_mode_from_evidence():
     diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.LLM_RUBRIC)]
     parsed = json.loads(render_json(diags))
     assert parsed["diagnostics"][0]["failure_mode"] == "invalid_json"
+
+
+def test_json_invalid_evidence_reference_maps_to_grader_error():
+    ev = Evidence(
+        kind="invalid_evidence_reference",
+        data={"failure_mode": "grader_error", "detail": "line_start must be integer"},
+    )
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.LLM_RUBRIC)]
+    parsed = json.loads(render_json(diags))
+    assert parsed["diagnostics"][0]["failure_mode"] == "grader_error"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -610,3 +610,13 @@ def test_json_invalid_evidence_reference_maps_to_grader_error():
     diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.LLM_RUBRIC)]
     parsed = json.loads(render_json(diags))
     assert parsed["diagnostics"][0]["failure_mode"] == "grader_error"
+
+
+def test_json_invalid_evidence_reference_non_string_defaults_to_grader_error():
+    ev = Evidence(
+        kind="invalid_evidence_reference",
+        data={"failure_mode": None, "detail": "bad refs"},
+    )
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.LLM_RUBRIC)]
+    parsed = json.loads(render_json(diags))
+    assert parsed["diagnostics"][0]["failure_mode"] == "grader_error"

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -18,7 +18,7 @@ import pytest
 
 from gate_keeper.backends import llm_rubric as llm_backend
 from gate_keeper.backends.llm_rubric import LlmJudgment, LlmJudgmentParseError
-from gate_keeper.diagnostics import EXIT_FAIL, EXIT_OK, compute_exit_code
+from gate_keeper.diagnostics import EXIT_FAIL, EXIT_OK, compute_exit_code, render_json, render_text
 from gate_keeper.models import (
     Backend,
     Confidence,
@@ -1138,6 +1138,7 @@ class TestLlmJudgmentPydantic:
             "judgment",
             "primary_reason",
             "supporting_evidence_quotes",
+            "supporting_evidence_refs",
             "suggested_action",
             "supporting_evidence_quote_target_ids",
         }
@@ -1906,7 +1907,9 @@ class TestPromptVersion:
         # now declares the {target_id, quote} object form **required**
         # (slice 1 said preferred) and backend enforcement is tightened
         # in lockstep — v5 and v6 evidence are not interchangeable.
-        assert llm_backend.PROMPT_VERSION == "v6"
+        # #268 bumps v6 → v7 to switch the primary evidence contract to
+        # supporting_evidence_refs line-range references.
+        assert llm_backend.PROMPT_VERSION == "v7"
 
     def test_evidence_includes_prompt_version(self, monkeypatch, tmp_path):
         _patch_env(
@@ -1919,8 +1922,8 @@ class TestPromptVersion:
             lambda *_a, **_k: _stub_response(_VALID_PASS_JSON),
         )
         diag = llm_backend.check(_semantic_rule(), _target_with_artifact(tmp_path))
-        # #225 — PROMPT_VERSION is now v6.
-        assert diag.evidence[0].data["prompt_version"] == "v6"
+        # #268 — PROMPT_VERSION is now v7.
+        assert diag.evidence[0].data["prompt_version"] == "v7"
 
 
 # ---------------------------------------------------------------------------
@@ -2343,8 +2346,8 @@ class TestUnsupportedDispatch:
         assert diag.evidence[0].kind == "target_kind_mismatch"
         assert diag.evidence[0].data["judgment"] == "unsupported"
         assert diag.evidence[0].data["rule_target_kind"] == "pr_description"
-        # #225 — PROMPT_VERSION is now v6.
-        assert diag.evidence[0].data["prompt_version"] == "v6"
+        # #268 — PROMPT_VERSION is now v7.
+        assert diag.evidence[0].data["prompt_version"] == "v7"
 
     def test_unsupported_remediation_explains_mismatch(self, monkeypatch):
         from gate_keeper.models import TargetKind
@@ -2423,12 +2426,12 @@ class TestArtifactKindStripsFilenameFromPrompt:
             artifact_kind=TargetKind.COMMIT_MESSAGE,
         )
 
-        # The file content must appear inline.
-        assert commit_body in user
-        # The path / filename must NOT appear in the rendered prompt — the
-        # whole point of #191 is to deny the model a filename to parrot.
-        assert str(commit_path) not in user
-        assert commit_path.name not in user
+        # The file content must appear inline as numbered lines.
+        assert "fix(parser): handle CRLF in evidence blocks" in user
+        assert "related to #foo" in user
+        assert "1 | fix(parser): handle CRLF in evidence blocks" in user
+        # #268 line-range refs include path metadata in the rendered artifact.
+        assert str(commit_path) in user
 
     def test_path_target_with_artifact_kind_string_path_also_strips(self, tmp_path):
         """The substitution applies to both ``Path`` and string-path
@@ -2445,9 +2448,10 @@ class TestArtifactKindStripsFilenameFromPrompt:
             artifact_kind=TargetKind.COMMIT_MESSAGE,
         )
 
-        assert commit_body in user
-        assert str(commit_path) not in user
-        assert commit_path.name not in user
+        assert "feat(cli): emit --help on stderr" in user
+        assert "because stdout is reserved for results" in user
+        assert "1 | feat(cli): emit --help on stderr" in user
+        assert str(commit_path) in user
 
     def test_path_target_without_artifact_kind_preserves_legacy_path_render(self, tmp_path):
         """When ``artifact_kind`` is omitted, legacy v4 behaviour is
@@ -2478,7 +2482,9 @@ class TestArtifactKindStripsFilenameFromPrompt:
             inline,
             artifact_kind=TargetKind.COMMIT_MESSAGE,
         )
-        assert inline in user
+        assert "fix(parser): handle CRLF in evidence blocks" in user
+        assert "related to #foo" in user
+        assert "1 | fix(parser): handle CRLF in evidence blocks" in user
 
     def test_nonexistent_path_with_artifact_kind_falls_back_to_string(self, tmp_path):
         """A non-existent path with ``artifact_kind`` set must not raise;
@@ -2575,8 +2581,8 @@ class TestArtifactKindStripsFilenameFromPrompt:
         assert isinstance(captured["user"], str)
         rendered_prompt: str = captured["user"]  # type: ignore[assignment]
         assert body_quote in rendered_prompt
-        assert str(commit_path) not in rendered_prompt
-        assert commit_path.name not in rendered_prompt
+        assert str(commit_path) in rendered_prompt
+        assert commit_path.name in rendered_prompt
 
         # End result: PASS with content-grounded evidence (no fabrication).
         assert diag.status is Status.PASS
@@ -4302,8 +4308,155 @@ class TestMultiTargetPromptRendering:
         with pytest.raises(ValueError, match=r"path traversal"):
             llm_backend._parse_multi_targets(rule)
 
-    def test_prompt_version_constant_is_v6(self):
-        assert llm_backend.PROMPT_VERSION == "v6"
+    def test_prompt_version_constant_is_v7(self):
+        assert llm_backend.PROMPT_VERSION == "v7"
+
+
+class TestEvidenceRefsPrimaryContract:
+    """#268 — primary path validates refs and reconstructs quotes mechanically."""
+
+    _ENV = {"GATE_KEEPER_LLM_PROVIDER": "openai", "OPENAI_API_KEY": "sk-test"}
+
+    def test_single_target_refs_reconstruct_quotes(self, monkeypatch):
+        _patch_env(monkeypatch, self._ENV)
+        artifact = "line one\nline two\nline three"
+        response = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "Grounded by middle lines.",
+                "supporting_evidence_refs": [
+                    {"target_id": None, "path": None, "line_start": 2, "line_end": 3}
+                ],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(llm_backend, "_call_openai", lambda *a, **k: _stub_response(response))
+        diag = llm_backend.check(_semantic_rule(), artifact)
+        assert diag.status is Status.PASS
+        data = diag.evidence[0].data
+        assert data["supporting_evidence_quotes"] == ["line two\nline three"]
+        assert data["supporting_evidence_refs"] == [
+            {"target_id": None, "path": None, "line_start": 2, "line_end": 3}
+        ]
+        assert data["supporting_evidence_spans"][0]["start_line"] == 2
+        assert data["supporting_evidence_spans"][0]["end_line"] == 3
+
+    def test_multi_target_refs_reconstruct_quotes(self, monkeypatch, tmp_path):
+        _patch_env(monkeypatch, self._ENV)
+        target_a = tmp_path / "a.md"
+        target_b = tmp_path / "b.md"
+        target_a.write_text("a1\na2\na3", encoding="utf-8")
+        target_b.write_text("b1\nb2\nb3", encoding="utf-8")
+        response = json.dumps(
+            {
+                "judgment": "fail",
+                "primary_reason": "Cross-artifact check failed.",
+                "supporting_evidence_refs": [
+                    {"target_id": "alpha", "path": str(target_a), "line_start": 1, "line_end": 2},
+                    {"target_id": "beta", "path": str(target_b), "line_start": 3, "line_end": 3},
+                ],
+                "suggested_action": "Align both artifacts.",
+            }
+        )
+        monkeypatch.setattr(llm_backend, "_call_openai", lambda *a, **k: _stub_response(response))
+        rule = _multi_target_rule(
+            [
+                {"id": "alpha", "kind": "documentation", "path": str(target_a)},
+                {"id": "beta", "kind": "documentation", "path": str(target_b)},
+            ]
+        )
+        diag = llm_backend.check(rule, "ignored")
+        assert diag.status is Status.FAIL
+        data = diag.evidence[0].data
+        assert data["supporting_evidence_quotes"] == ["a1\na2", "b3"]
+        assert data["supporting_evidence_quote_target_ids"] == ["alpha", "beta"]
+
+    @pytest.mark.parametrize(
+        ("judgment", "refs", "detail_fragment", "suggested_action"),
+        [
+            (
+                "pass",
+                [{"target_id": None, "path": None, "line_start": 1, "line_end": 9}],
+                "invalid range",
+                None,
+            ),
+            (
+                "pass",
+                [{"target_id": None, "path": None, "line_start": 3, "line_end": 2}],
+                "invalid range",
+                None,
+            ),
+            (
+                "pass",
+                [{"target_id": None, "path": None, "line_start": "x", "line_end": 2}],
+                "line_start",
+                None,
+            ),
+            ("pass", [], "must contain at least one entry", None),
+            ("fail", [], "must contain at least one entry", "Add evidence refs."),
+        ],
+    )
+    def test_invalid_single_target_refs_map_to_grader_error(
+        self, monkeypatch, judgment, refs, detail_fragment, suggested_action
+    ):
+        _patch_env(monkeypatch, self._ENV)
+        response = json.dumps(
+            {
+                "judgment": judgment,
+                "primary_reason": "x",
+                "supporting_evidence_refs": refs,
+                "suggested_action": suggested_action,
+            }
+        )
+        monkeypatch.setattr(llm_backend, "_call_openai", lambda *a, **k: _stub_response(response))
+        diag = llm_backend.check(_semantic_rule(), "line one\nline two")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "invalid_evidence_reference"
+        assert diag.evidence[0].data["failure_mode"] == "grader_error"
+        assert detail_fragment in diag.evidence[0].data["detail"]
+
+    def test_unknown_target_id_maps_to_grader_error(self, monkeypatch, tmp_path):
+        _patch_env(monkeypatch, self._ENV)
+        target = tmp_path / "a.md"
+        target.write_text("a1\na2", encoding="utf-8")
+        rule = _multi_target_rule([{"id": "alpha", "kind": "documentation", "path": str(target)}])
+        response = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "x",
+                "supporting_evidence_refs": [
+                    {"target_id": "unknown", "path": str(target), "line_start": 1, "line_end": 1}
+                ],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(llm_backend, "_call_openai", lambda *a, **k: _stub_response(response))
+        diag = llm_backend.check(rule, "ignored")
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "invalid_evidence_reference"
+        assert "unknown id" in diag.evidence[0].data["detail"]
+
+    def test_ref_based_output_in_json_and_verbose(self, monkeypatch):
+        _patch_env(monkeypatch, self._ENV)
+        artifact = "alpha\nbeta\ngamma"
+        response = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "Grounded.",
+                "supporting_evidence_refs": [
+                    {"target_id": None, "path": None, "line_start": 2, "line_end": 2}
+                ],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(llm_backend, "_call_openai", lambda *a, **k: _stub_response(response))
+        diag = llm_backend.check(_semantic_rule(), artifact)
+        payload = json.loads(render_json([diag]))
+        assert payload["diagnostics"][0]["failure_mode"] is None
+        ev_data = payload["diagnostics"][0]["evidence"][0]["data"]
+        assert ev_data["supporting_evidence_refs"][0]["line_start"] == 2
+        verbose = render_text([diag], verbose=True)
+        assert 'evidence  : "beta"' in verbose
 
 
 class TestMultiTargetQuoteParsing:

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -2485,6 +2485,7 @@ class TestArtifactKindStripsFilenameFromPrompt:
         assert "fix(parser): handle CRLF in evidence blocks" in user
         assert "related to #foo" in user
         assert "1 | fix(parser): handle CRLF in evidence blocks" in user
+        assert "Path: null" in user
 
     def test_nonexistent_path_with_artifact_kind_falls_back_to_string(self, tmp_path):
         """A non-existent path with ``artifact_kind`` set must not raise;
@@ -4457,6 +4458,89 @@ class TestEvidenceRefsPrimaryContract:
         assert ev_data["supporting_evidence_refs"][0]["line_start"] == 2
         verbose = render_text([diag], verbose=True)
         assert 'evidence  : "beta"' in verbose
+
+    def test_crlf_ref_span_excludes_dangling_carriage_return(self, monkeypatch):
+        _patch_env(monkeypatch, self._ENV)
+        artifact = "alpha\r\nbeta\r\n"
+        response = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "Grounded.",
+                "supporting_evidence_refs": [
+                    {"target_id": None, "path": None, "line_start": 1, "line_end": 2}
+                ],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(llm_backend, "_call_openai", lambda *a, **k: _stub_response(response))
+        diag = llm_backend.check(_semantic_rule(), artifact)
+        assert diag.status is Status.PASS
+        span = diag.evidence[0].data["supporting_evidence_spans"][0]
+        # CRLF boundary must not leave a dangling '\r' at end of span.
+        assert artifact[span["end_offset"] - 1] == "a"
+        assert span["end_line"] == 2
+
+
+class TestLegacyQuoteFallbackRuleAwareGrounding:
+    """#268 fallback path should still ground against prompt-visible multi-target corpus."""
+
+    _ENV = {"GATE_KEEPER_LLM_PROVIDER": "openai", "OPENAI_API_KEY": "sk-test"}
+
+    def test_consensus_legacy_quote_fallback_uses_multi_target_grounding(self, monkeypatch, tmp_path):
+        _patch_env(monkeypatch, self._ENV)
+        target_a = tmp_path / "a.md"
+        target_b = tmp_path / "b.md"
+        target_a.write_text("alpha quote substring here.", encoding="utf-8")
+        target_b.write_text("beta quote substring here.", encoding="utf-8")
+        response = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "Grounded.",
+                "supporting_evidence_quotes": ["alpha quote substring"],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(llm_backend, "_call_openai", lambda *a, **k: _stub_response(response))
+        rule = _multi_target_rule(
+            [
+                {"id": "alpha", "kind": "documentation", "path": str(target_a)},
+                {"id": "beta", "kind": "documentation", "path": str(target_b)},
+            ]
+        )
+        rule = dataclasses.replace(
+            rule, params={**rule.params, "strategy": "consensus", "consensus_panel_size": 2}
+        )
+        diag = llm_backend.check(rule, "ignored")
+        assert diag.status is Status.PASS, diag.evidence[0].to_dict()
+        assert diag.evidence[0].data["llm_strategy"] == "consensus"
+
+    def test_review_legacy_quote_fallback_uses_multi_target_grounding(self, monkeypatch, tmp_path):
+        _patch_env(monkeypatch, self._ENV)
+        target_a = tmp_path / "a.md"
+        target_b = tmp_path / "b.md"
+        target_a.write_text("alpha quote substring here.", encoding="utf-8")
+        target_b.write_text("beta quote substring here.", encoding="utf-8")
+        primary_response = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "Grounded.",
+                "supporting_evidence_quotes": ["alpha quote substring"],
+                "suggested_action": None,
+            }
+        )
+        reviewer_response = json.dumps({"review_verdict": "agree", "review_reason": "Grounded."})
+        calls = iter([primary_response, reviewer_response])
+        monkeypatch.setattr(llm_backend, "_call_openai", lambda *a, **k: _stub_response(next(calls)))
+        rule = _multi_target_rule(
+            [
+                {"id": "alpha", "kind": "documentation", "path": str(target_a)},
+                {"id": "beta", "kind": "documentation", "path": str(target_b)},
+            ]
+        )
+        rule = dataclasses.replace(rule, params={**rule.params, "strategy": "review"})
+        diag = llm_backend.check(rule, "ignored")
+        assert diag.status is Status.PASS, diag.evidence[0].to_dict()
+        assert diag.evidence[0].data["llm_strategy"] == "review"
 
 
 class TestMultiTargetQuoteParsing:


### PR DESCRIPTION
Closes #268

## Summary
- switch LLM-rubric primary evidence contract to supporting_evidence_refs (line ranges) and mechanically reconstruct report quotes
- validate refs against prompt-visible artifact corpus across single, consensus, review primary, and adaptive via underlying strategies
- classify malformed refs as status=unavailable, evidence.kind=invalid_evidence_reference, failure_mode=grader_error
- retain legacy quote-fabrication validation as defensive fallback when only quote-shaped output is returned
- keep report compatibility fields (supporting_evidence_quotes, supporting_evidence_spans) and add supporting_evidence_refs
- update diagnostics failure-mode derivation plus docs/tests for the new contract

## Validation
- uv run pytest -q (pass: 1478 passed)
- uvx ruff check . (pass)
- uvx pyright (fails in current repo environment due unresolved imports/missing stubs across project scripts and tests; unchanged pre-existing baseline)

## Notes
- No unchecked task boxes are included in this PR body.