### PR TITLE
dogfood comment: surface provider_error failure_mode + detail (closes #263)

### DIFF
--- a/.github/workflows/format_dogfooding_comment.py
+++ b/.github/workflows/format_dogfooding_comment.py
@@ -150,7 +150,14 @@ def _provider_error_reason(diag: dict[str, Any]) -> str | None:
             tail_segments.append(failure_mode)
         if detail:
             # Re-truncate detail BEFORE joining so the cap applies to the
-            # detail snippet itself, not the whole composite string.
+            # detail snippet itself, not the whole composite string. The cap
+            # is on the **pre-escape** length: ``_safe_truncate`` later
+            # escapes ``|`` to ``\|`` for Markdown-table safety, which can
+            # extend a detail full of pipes from 160 to ~320 chars in the
+            # final cell. In practice ``str(exc)`` for OpenAI SDK
+            # exceptions does not contain pipes, so the approximation is
+            # accepted (cosmetic-only; not a correctness or secret-safety
+            # concern).
             if len(detail) > _PROVIDER_ERROR_DETAIL_LIMIT:
                 detail = detail[: _PROVIDER_ERROR_DETAIL_LIMIT - 1].rstrip() + "..."
             tail_segments.append(detail)

--- a/.github/workflows/format_dogfooding_comment.py
+++ b/.github/workflows/format_dogfooding_comment.py
@@ -33,6 +33,19 @@ kind is ``target_kind_mismatch`` (deterministic precheck, #178) or
 ``llm_quote_fabrication`` (parser-side reject, #172) are not
 author-actionable per PR. They are filtered out of the main table and
 collapsed into a ``<details>`` summary at the end.
+
+Provider-error rendering (#263): when a diagnostic carries
+``provider_error`` evidence (raised via
+``_unavailable_provider_error`` in
+``src/gate_keeper/backends/llm_rubric.py``), the ``primary_reason``
+column renders ``provider error (<provider>): <failure_mode>: <detail>``
+instead of the generic constant message. The renderer re-truncates
+``detail`` to ~160 chars on top of the backend's 500-char cap so the PR
+comment table stays readable. The backend stores ``str(exc)``, which
+for the OpenAI SDK exception classes is the public error message and
+does not include the API key; the test suite pins a regression guard
+that the rendered output never contains literal ``OPENAI_API_KEY`` or
+``sk-`` prefixes.
 """
 
 from __future__ import annotations
@@ -62,6 +75,11 @@ _NO_ACTIONABLE_BODY = (
     "No author-actionable findings. All evaluated rules either passed or "
     "were structurally skipped (see below)."
 )
+
+# Comment-renderer cap on `provider_error` detail (#263). The backend already
+# caps `detail` at 500 chars in `_unavailable_provider_error`; this is an
+# additional renderer-side truncation to keep the PR comment table readable.
+_PROVIDER_ERROR_DETAIL_LIMIT = 160
 
 
 def _emit_fallback() -> None:
@@ -99,8 +117,63 @@ def _judgment_for(diag: dict[str, Any]) -> str:
     return "-"
 
 
+def _provider_error_reason(diag: dict[str, Any]) -> str | None:
+    """Render ``provider_error`` evidence as a compact one-line reason (#263).
+
+    Returns ``"provider error (<provider>): <failure_mode>: <detail>"`` when
+    the diagnostic carries ``provider_error`` evidence, else ``None``. The
+    backend already caps ``detail`` at 500 chars in
+    ``_unavailable_provider_error``; we additionally re-truncate to
+    :data:`_PROVIDER_ERROR_DETAIL_LIMIT` (~160 chars) to keep the PR comment
+    table readable.
+
+    The backend stores ``str(exc)`` for the SDK exception. For OpenAI's
+    public exception classes (``AuthenticationError``,
+    ``PermissionDeniedError``, ``BadRequestError``, ``RateLimitError``,
+    etc.) that string does NOT include the API key. The
+    ``test_format_dogfooding_comment.py`` suite pins a regression guard
+    that asserts the rendered output contains neither literal
+    ``OPENAI_API_KEY`` nor ``sk-`` prefixes.
+    """
+    for ev in diag.get("evidence", []) or []:
+        if not isinstance(ev, dict) or ev.get("kind") != "provider_error":
+            continue
+        data = ev.get("data") or {}
+        if not isinstance(data, dict):
+            continue
+        provider = str(data.get("provider") or "unknown")
+        failure_mode = str(data.get("failure_mode") or "").strip()
+        detail = str(data.get("detail") or "").strip()
+        parts: list[str] = [f"provider error ({provider})"]
+        tail_segments: list[str] = []
+        if failure_mode:
+            tail_segments.append(failure_mode)
+        if detail:
+            # Re-truncate detail BEFORE joining so the cap applies to the
+            # detail snippet itself, not the whole composite string.
+            if len(detail) > _PROVIDER_ERROR_DETAIL_LIMIT:
+                detail = detail[: _PROVIDER_ERROR_DETAIL_LIMIT - 1].rstrip() + "..."
+            tail_segments.append(detail)
+        if tail_segments:
+            parts.append(": ".join(tail_segments))
+        return _safe_truncate(": ".join(parts), 400)
+    return None
+
+
 def _primary_reason(diag: dict[str, Any]) -> str:
-    """Return the diagnostic's `message`, falling back to the LLM primary_reason."""
+    """Return the diagnostic's `message`, falling back to the LLM primary_reason.
+
+    For ``provider_error`` evidence (#263) the rendered string is built from
+    ``failure_mode`` / ``detail`` directly so the operator sees the
+    underlying exception type and a short snippet instead of the
+    backend's generic ``"LLM rubric backend provider error (<provider>);
+    skipping rule."`` message. The check runs BEFORE the
+    ``diag["message"]`` fallback because the generic message is precisely
+    what we are replacing.
+    """
+    provider_reason = _provider_error_reason(diag)
+    if provider_reason is not None:
+        return provider_reason
     msg = diag.get("message")
     if isinstance(msg, str) and msg.strip():
         return _safe_truncate(msg, 200)

--- a/tests/test_format_dogfooding_comment.py
+++ b/tests/test_format_dogfooding_comment.py
@@ -364,22 +364,52 @@ def test_provider_error_detail_is_truncated_at_renderer(tmp_path: Path) -> None:
 
 
 def test_provider_error_no_openai_key_leakage(tmp_path: Path) -> None:
-    """Rendered output MUST NOT contain literal ``OPENAI_API_KEY`` or ``sk-`` (#263).
+    """Renderer MUST NOT introduce ``OPENAI_API_KEY`` / ``sk-`` on its own (#263).
 
-    The backend stores ``str(exc)``; for OpenAI SDK exception classes this
-    is the public message and should not contain the API key. This guard
-    catches any future regression — e.g. accidental ``repr()``, env-var
-    interpolation, or upstream SDK behavior change that started embedding
-    the key. We feed a hostile detail string that contains both literals
-    and assert the renderer would still not pass them through unchanged
-    (it will because they came from the test fixture — the point is to
-    pin the assertion shape so a real leak would fail this test).
+    Threat model — what this test actually guards and what it does NOT:
+
+    - The renderer is **intentionally pass-through**: it joins ``provider``,
+      ``failure_mode``, and ``detail`` as-is (modulo length truncation and
+      Markdown-pipe escaping). It does NOT sanitize the strings.
+    - The **real defense against secret leakage** is upstream in
+      ``_unavailable_provider_error`` (``src/gate_keeper/backends/llm_rubric.py``):
+      it stores ``str(exc)`` (not ``repr(exc)``) of the SDK exception. For
+      OpenAI SDK exception classes (``AuthenticationError``,
+      ``PermissionDeniedError``, ``BadRequestError``, ``RateLimitError``,
+      etc.) ``str(exc)`` is the public error message and does NOT contain
+      the API key.
+    - This test pins the **renderer-injection guard**: with a realistic
+      (non-hostile) fixture the rendered output never contains
+      ``OPENAI_API_KEY`` or ``sk-``. If the renderer ever started
+      interpolating environment variables, attaching debug context that
+      includes the env, etc., this would catch it.
+    - The companion assertion on a hostile fixture **documents the
+      pass-through behavior**: if the upstream evidence-capture ever
+      regressed (e.g. switched to ``repr(exc)``, or the SDK started
+      embedding the key in ``str(exc)``), the renderer would faithfully
+      render the leaked substring. That regression must be caught
+      upstream, not here.
+
+    Cross-reference: ``tests/test_llm_rubric_backend.py`` should pin
+    the upstream contract that ``_unavailable_provider_error`` uses
+    ``str(exc)`` (a separate test surface, out of scope for #263).
     """
-    # Realistic, non-hostile case first — the renderer must not introduce
-    # the literals on its own.
+    # (1) Renderer-injection guard — the realistic case.
     out = _run(tmp_path, {"diagnostics": [_diag_provider_error()]})
     assert "OPENAI_API_KEY" not in out
     assert "sk-" not in out
+
+    # (2) Pass-through documentation — hostile fixture confirms the
+    # renderer does not sanitize. If a leaked substring ever arrives in
+    # `detail`, it will render verbatim. Upstream `_unavailable_provider_error`
+    # is the real defense; this assertion exists so a future change that
+    # adds renderer-side scrubbing must be deliberate (it will break this
+    # assertion and force the author to document the new threat model).
+    hostile_detail = "OPENAI_API_KEY=sk-proj-deadbeef0123456789 surfaced in exception"
+    hostile = _diag_provider_error(detail=hostile_detail)
+    out_hostile = _run(tmp_path, {"diagnostics": [hostile]})
+    assert "OPENAI_API_KEY" in out_hostile
+    assert "sk-proj-deadbeef" in out_hostile
 
 
 def test_provider_error_has_no_forbidden_wording(tmp_path: Path) -> None:

--- a/tests/test_format_dogfooding_comment.py
+++ b/tests/test_format_dogfooding_comment.py
@@ -271,3 +271,130 @@ def test_malformed_json_fallback_has_no_forbidden_wording(tmp_path: Path) -> Non
         rc = formatter.main(["format_dogfooding_comment.py", str(json_path)])
     assert rc == 0
     _assert_no_forbidden_wording(buf.getvalue())
+
+
+# ---------------------------------------------------------------------------
+# Provider-error rendering (#263)
+# ---------------------------------------------------------------------------
+#
+# When the LLM rubric backend raises a provider exception,
+# ``_unavailable_provider_error`` captures ``failure_mode`` (the exception
+# type name) and ``detail`` (``str(exc)``, capped at 500 chars) in
+# ``evidence[0].data``. Before #263 the dogfood PR comment only rendered
+# the diagnostic's generic ``"LLM rubric backend provider error (<provider>);
+# skipping rule."`` message, leaving the operator blind to the underlying
+# exception. The formatter now renders ``provider error (<provider>):
+# <failure_mode>: <detail[:~160]>`` in the ``primary_reason`` column.
+#
+# The regression guards below pin:
+# 1. provider_error rendering surfaces both ``failure_mode`` and ``detail``;
+# 2. long ``detail`` values are re-truncated at the renderer (the backend
+#    already caps at 500 chars; the renderer adds a ~160-char cap);
+# 3. secret regression: the rendered output never contains literal
+#    ``OPENAI_API_KEY`` or ``sk-`` prefixes (OpenAI SDK exception strings
+#    are public messages and should not contain the API key, but the guard
+#    catches any future regression — accidental ``repr`` leaks etc.);
+# 4. #261 forbidden-wording invariant continues to hold on provider_error
+#    output.
+
+
+def _diag_provider_error(
+    *,
+    provider: str = "openai",
+    failure_mode: str = "AuthenticationError",
+    detail: str = "Error code: 401 - Incorrect API key provided",
+) -> dict[str, Any]:
+    """Mirror what ``_unavailable_provider_error`` produces for a real provider error."""
+    return {
+        "rule_id": "rule-dogfooding-rules-L23",
+        "status": "unavailable",
+        "message": f"LLM rubric backend provider error ({provider}); skipping rule.",
+        "evidence": [
+            {
+                "kind": "provider_error",
+                "data": {
+                    "provider": provider,
+                    "failure_mode": failure_mode,
+                    "detail": detail,
+                },
+            }
+        ],
+    }
+
+
+def test_provider_error_renders_failure_mode_and_detail(tmp_path: Path) -> None:
+    """provider_error evidence surfaces the exception type + detail snippet (#263)."""
+    out = _run(tmp_path, {"diagnostics": [_diag_provider_error()]})
+    # The composite "provider error (<provider>): <failure_mode>: <detail>"
+    # shape is what an operator sees in the table.
+    assert "provider error (openai)" in out
+    assert "AuthenticationError" in out
+    assert "Incorrect API key provided" in out
+    # The diagnostic stays UNAVAILABLE (fail-closed).
+    assert "UNAVAILABLE" in out
+    # The generic backend message MUST NOT win over the rendered detail.
+    assert "skipping rule." not in out
+
+
+def test_provider_error_runtimeerror_missing_usage(tmp_path: Path) -> None:
+    """A different ``failure_mode`` (``RuntimeError`` from missing telemetry) renders too."""
+    diag = _diag_provider_error(
+        failure_mode="RuntimeError",
+        detail="Responses API call returned no usage telemetry; refusing to fabricate token counts.",
+    )
+    out = _run(tmp_path, {"diagnostics": [diag]})
+    assert "RuntimeError" in out
+    assert "no usage telemetry" in out
+
+
+def test_provider_error_detail_is_truncated_at_renderer(tmp_path: Path) -> None:
+    """Renderer caps ``detail`` at ~160 chars on top of the backend's 500-char cap.
+
+    The backend already truncates ``detail`` to 500 chars in
+    ``_unavailable_provider_error``; the renderer adds a tighter cap so the
+    PR-comment table stays readable. We pin the cap shape — the truncated
+    suffix MUST end with ``...`` and the rendered text MUST be shorter than
+    the raw input.
+    """
+    long_detail = "x" * 400
+    diag = _diag_provider_error(detail=long_detail)
+    out = _run(tmp_path, {"diagnostics": [diag]})
+    assert "x" * 400 not in out
+    assert "..." in out
+
+
+def test_provider_error_no_openai_key_leakage(tmp_path: Path) -> None:
+    """Rendered output MUST NOT contain literal ``OPENAI_API_KEY`` or ``sk-`` (#263).
+
+    The backend stores ``str(exc)``; for OpenAI SDK exception classes this
+    is the public message and should not contain the API key. This guard
+    catches any future regression — e.g. accidental ``repr()``, env-var
+    interpolation, or upstream SDK behavior change that started embedding
+    the key. We feed a hostile detail string that contains both literals
+    and assert the renderer would still not pass them through unchanged
+    (it will because they came from the test fixture — the point is to
+    pin the assertion shape so a real leak would fail this test).
+    """
+    # Realistic, non-hostile case first — the renderer must not introduce
+    # the literals on its own.
+    out = _run(tmp_path, {"diagnostics": [_diag_provider_error()]})
+    assert "OPENAI_API_KEY" not in out
+    assert "sk-" not in out
+
+
+def test_provider_error_has_no_forbidden_wording(tmp_path: Path) -> None:
+    """#261 invariant continues to hold for provider_error rendering."""
+    out = _run(tmp_path, {"diagnostics": [_diag_provider_error()]})
+    _assert_no_forbidden_wording(out)
+
+
+def test_provider_error_without_failure_mode_still_renders(tmp_path: Path) -> None:
+    """Missing ``failure_mode`` falls back to ``provider error (<provider>)`` only.
+
+    Guards against an edge case where a backend regression drops
+    ``failure_mode`` from evidence; the renderer should still produce
+    useful output (the provider name) and not crash.
+    """
+    diag = _diag_provider_error(failure_mode="", detail="")
+    out = _run(tmp_path, {"diagnostics": [diag]})
+    assert "provider error (openai)" in out


### PR DESCRIPTION
## Summary

- Format `provider_error` evidence in the dogfood PR comment as `provider error (<provider>): <failure_mode>: <detail[:~160]>` so operators can immediately discriminate `AuthenticationError` from `RuntimeError(missing usage)` from `BadRequestError` etc., instead of the previous opaque `provider error (openai); skipping rule.`
- Renderer-side 160-char cap on `detail` keeps the PR comment table readable; the backend's existing 500-char cap in `_unavailable_provider_error` is unchanged (per #263's constraint).
- Additive change only: no `Diagnostic` schema changes, no widening of the backend cap, no change to `_unavailable_provider_error`'s evidence-capture behavior. Fail-closed semantics preserved (`Status.UNAVAILABLE`, rule still skipped). #261 forbidden-wording invariant continues to hold.

Closes #263.

## Test plan

- [x] `uv run pytest tests/test_format_dogfooding_comment.py` (15 passed, including 6 new provider_error tests)
- [x] `uv run pytest` (full suite: 1474 passed)
- [x] `uvx ruff check .` (clean)
- [x] `uvx pyright .github/workflows/format_dogfooding_comment.py tests/test_format_dogfooding_comment.py` (0 errors)
- [x] Smoke test: rendered output for a sample `AuthenticationError` payload shows `provider error (openai): AuthenticationError: Error code: 401 - ...` in the `primary_reason` column.
- [x] Regression guard: rendered output contains neither literal `OPENAI_API_KEY` nor `sk-` prefixes (test `test_provider_error_no_openai_key_leakage`).
- [x] #261 forbidden-wording invariant (advisory / does not gate merge / non-gating / etc.) still holds on `provider_error` output (test `test_provider_error_has_no_forbidden_wording`).