### PR TITLE
feat(dependency-gates): deterministic repo-local reference scanner (#269 slice 1)

### DIFF
--- a/docs/dependency-gate-rules.json
+++ b/docs/dependency-gate-rules.json
@@ -22,6 +22,29 @@
         "manifest": ".gate-keeper/dependency-manifest.yml",
         "timeout_seconds": 30
       }
+    },
+    {
+      "id": "repo-local-reference-scanner",
+      "title": "Repo-local references in text-bearing files must resolve and be classified",
+      "source": {
+        "path": "docs/dependency-gate-rules.json",
+        "line": 1,
+        "heading": "repo-local-reference-scanner"
+      },
+      "text": "Issue #269 slice 1. Walks the target text-bearing file (README / docs / config / rule file), extracts repo-local file/path/doc references, and emits deterministic findings for each category that fires: `broken_reference` (referenced path missing), `uncovered_reference` / `newly_introduced` (a new repo-local reference relative to baseline, not yet covered by a manifest edge), and `suspicious_broad` (glob, trailing slash, or bare top-level directory). Detection + reporting only; manifest-coverage enforcement and LLM-rubric narrowing are explicitly later slices.",
+      "kind": "external_check",
+      "severity": "warning",
+      "backend_hint": "external",
+      "confidence": "high",
+      "params": {
+        "tool": "command",
+        "argv": [
+          "python",
+          "scripts/dependency_gates/check_repo_refs.py"
+        ],
+        "manifest": ".gate-keeper/dependency-manifest.yml",
+        "timeout_seconds": 30
+      }
     }
   ]
 }

--- a/docs/design/dependency-gates.md
+++ b/docs/design/dependency-gates.md
@@ -276,6 +276,67 @@ A single additional validator surfaces the shared logic that a core rule kind wo
 
 ---
 
+## 6.1. Repo-local reference scanner (issue #269, slice 1)
+
+A second `command`-adapter validator lives alongside `check_cli_reference.py`:
+`scripts/dependency_gates/check_repo_refs.py`. It is registered as the
+`repo-local-reference-scanner` rule in `docs/dependency-gate-rules.json`.
+
+The scanner walks one text-bearing target file (readme / docs / config /
+rule file), extracts repo-local references via
+`scripts/dependency_gates/_repo_ref_scan.py`, and classifies each one. It is
+deterministic-only: no LLM, no semantic inference, no manifest-coverage
+enforcement (that is a later slice — see #269 Layer 1).
+
+Recognised reference shapes (extractor):
+
+- Markdown inline link target `[text](path)` → `md_link`.
+- Markdown inline image target `![alt](path)` → `md_image`.
+- Markdown reference-style definition `[id]: path` → `md_ref_def`.
+- Single-backtick inline code span whose body matches a tracked path shape
+  (contains `/` AND either starts with a known top-level directory or
+  ends with a known file extension) → `inline_code`.
+- Bare path-like token prefixed with a known top-level directory
+  (`src/`, `docs/`, `scripts/`, `tests/`, `.github/`, `.gate-keeper/`) →
+  `bare_path`.
+
+URL-shaped targets (scheme prefix, `//host`, `mailto:`), pure in-page
+anchors (`#frag`), and fenced code blocks are intentionally ignored.
+
+Evidence vocabulary (validator), one entry per category that fires:
+
+- `broken_reference` — referenced repo-local path does not exist on disk.
+  Status: `fail`. Carries a `references` array of `{path, line, column, shape}`.
+- `uncovered_reference` — a repo-local reference appeared in the target,
+  the target itself is in the changed-file set, the reference path is not
+  co-changed alongside the target, and the reference is not already
+  recorded as a manifest edge endpoint. The data carries
+  `subkind: newly_introduced`. Status: `pass` (informational, slice 1).
+- `suspicious_broad` — reference shape is intentionally broad: glob
+  characters (`*` / `?`), trailing slash, or bare top-level directory
+  (`docs`, `src`, …). Status: `pass` (informational, slice 1).
+- `repo_refs_clean` — emitted when no finding category fires. Status: `pass`.
+- `scanner_not_applicable` — emitted when the target is not a text-bearing
+  file. Status: `pass`.
+
+Fail-closed (always `Status.UNAVAILABLE`):
+
+- `params_error` — empty `target` payload.
+- `target_unreadable` — target file missing or undecodable.
+- `manifest_invalid` — manifest load error (only when manifest is present).
+- `changed_file_source_unresolved` — `git diff` cannot resolve the base
+  ref. The scanner still emits any broken/broad findings; only the
+  newly-introduced category is skipped, and an explicit evidence entry
+  with this kind is appended so the consumer can distinguish "no new
+  refs" from "did not check".
+
+The validator runs at `severity: warning` in slice 1 (per the
+`docs/dogfooding.md` § "Promotion criteria" path). The broken-reference
+category produces `Status.FAIL` regardless; the other two deterministic
+categories stay informational until a future slice promotes them.
+
+---
+
 ## 7. Out of Scope
 
 This note settles slice 1. The following remain deferred:

--- a/scripts/dependency_gates/_repo_ref_scan.py
+++ b/scripts/dependency_gates/_repo_ref_scan.py
@@ -1,0 +1,369 @@
+"""Deterministic repo-local reference extraction (umbrella #269, slice 1).
+
+Given a single text-bearing file (README/docs/config/rule file), enumerate the
+explicit repo-local file/path references it contains. The extractor is
+syntactic and deterministic — it never invokes a language model and never
+guesses semantic intent.
+
+Recognised reference shapes:
+
+- ``md_link``: Markdown inline link target — ``[text](path)``.
+- ``md_image``: Markdown inline image target — ``![alt](path)``.
+- ``md_ref_def``: Markdown reference-style link definition — ``[id]: path``.
+- ``inline_code``: single-backtick code span whose body matches a tracked
+  path shape (contains ``/`` AND either starts with a known top-level
+  directory or carries a known file extension).
+- ``bare_path``: a bare path-like token prefixed with a known top-level
+  directory, appearing outside Markdown link syntax.
+
+Reference targets that look like URLs (scheme prefix, ``//`` host, ``mailto:``
+prefix) or in-page anchors (``#frag``) are intentionally ignored — those are
+not repo-local references. Empty link targets and pure-fragment links are
+also ignored.
+
+The scanner takes the raw text of one file and returns a list of
+``Reference`` records. Classification against the working tree and the
+changed-file set lives in ``check_repo_refs.py``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Top-level directories that, when they appear as the first path segment of a
+# reference, mark the token as a candidate repo-local path. Keeping the list
+# closed (rather than "anything that looks like a path") keeps the scanner
+# deterministic and avoids matching narrative prose like "config/json" used
+# as a noun phrase.
+KNOWN_TOP_LEVEL_DIRS: frozenset[str] = frozenset(
+    {
+        "src",
+        "docs",
+        "scripts",
+        "tests",
+        ".github",
+        ".gate-keeper",
+    }
+)
+
+# File extensions that, when present, mark a token as path-like even without
+# a known top-level prefix. Used by ``inline_code`` classification.
+KNOWN_FILE_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        ".md",
+        ".py",
+        ".json",
+        ".yml",
+        ".yaml",
+        ".toml",
+        ".cfg",
+        ".ini",
+        ".txt",
+        ".sh",
+        ".lock",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Reference:
+    """One extracted repo-local reference candidate.
+
+    Attributes:
+        path: The reference target as it appeared in the text, with any
+            in-page anchor (``#frag``) and query string stripped. Always
+            POSIX-style separators (Markdown links use ``/``).
+        line: 1-based line number where the reference appeared.
+        column: 1-based column where the reference's path token starts.
+        shape: One of ``md_link``, ``md_image``, ``md_ref_def``,
+            ``inline_code``, ``bare_path``.
+        raw: The originally matched substring, useful for diagnostics.
+    """
+
+    path: str
+    line: int
+    column: int
+    shape: str
+    raw: str
+
+
+# Markdown inline link: [text](target). The target can be wrapped in <…> but we
+# only accept plain targets for now. Captures the URL up to a closing ')' or
+# a space-quoted title.
+_MD_LINK_RE = re.compile(
+    r"(?P<bang>!?)\[(?P<text>(?:\\.|[^\[\]])*?)\]\((?P<url>[^()\s]+?)(?:\s+\"[^\"]*\")?\)"
+)
+
+# Markdown reference-style link definition: [id]: target  ["optional title"]
+# Anchored to the start of a (possibly indented) line so we don't catch the
+# common ``[id]: text`` shape inside narrative prose.
+_MD_REF_DEF_RE = re.compile(r"^(?P<indent>[ \t]{0,3})\[(?P<id>(?:\\.|[^\[\]])+?)\]:\s+(?P<url>\S+)")
+
+# Single-backtick inline code span (does not match triple-backtick fenced
+# code blocks; those are stripped first).
+_INLINE_CODE_RE = re.compile(r"(?<!`)`(?P<body>[^`\n]+?)`(?!`)")
+
+# A bare path-like token: starts with a known top-level directory, possibly
+# trailed by additional path segments. The lookbehind/lookahead keep us from
+# matching path-fragments embedded in larger identifiers.
+_BARE_PATH_RE = re.compile(
+    r"(?<![\w./])(?P<path>(?:" + "|".join(re.escape(d) for d in KNOWN_TOP_LEVEL_DIRS) + r")/[\w./*?-]*)"
+)
+
+# Fenced code block boundary (``` or ~~~ with optional info string).
+_FENCE_RE = re.compile(r"^[ \t]{0,3}(?P<fence>```+|~~~+)")
+
+# YAML/JSON-ish front-matter delimiter ("---" on its own line).
+_YAML_FENCE_RE = re.compile(r"^---\s*$")
+
+
+def extract_references(text: str, *, source_path: str | None = None) -> list[Reference]:
+    """Extract repo-local references from *text*.
+
+    Parameters:
+        text: Full file contents as a single string. Line endings may be
+            ``\\n`` or ``\\r\\n`` (CRLF is normalised to LF internally).
+        source_path: Optional repo-relative path of the file being scanned.
+            Currently unused by extraction itself but accepted so the caller
+            can pass through the same value used for fenced-block resolution
+            in future slices without an API change.
+
+    Returns:
+        List of ``Reference`` records, in document order. Duplicates (same
+        path appearing multiple times in the file) are preserved — the
+        caller decides whether to deduplicate.
+    """
+    del source_path  # accepted for forward-compatibility; not used yet
+    normalised = text.replace("\r\n", "\n").replace("\r", "\n")
+    lines = normalised.split("\n")
+    refs: list[Reference] = []
+
+    in_fence = False
+    fence_marker: str | None = None
+    for line_no, line in enumerate(lines, start=1):
+        # Fenced code blocks are skipped wholesale. Both ``` and ~~~ are
+        # recognised; the closing fence must match the opening marker's
+        # leading char so that a different fence inside doesn't terminate
+        # the block prematurely.
+        fence_match = _FENCE_RE.match(line)
+        if fence_match:
+            marker = fence_match.group("fence")
+            if not in_fence:
+                in_fence = True
+                fence_marker = marker[0]
+                continue
+            # Closing fence: same character family (``` closes ```; ~~~
+            # closes ~~~). Only end the block if it matches.
+            if fence_marker is not None and marker[0] == fence_marker:
+                in_fence = False
+                fence_marker = None
+                continue
+            # Otherwise leave the fence open and skip the line.
+            continue
+        if in_fence:
+            continue
+
+        # Markdown reference-style link definitions are line-anchored, so
+        # extract them before the inline patterns chew up the same text.
+        ref_def = _MD_REF_DEF_RE.match(line)
+        if ref_def:
+            url = ref_def.group("url")
+            if _is_repo_local_target(url):
+                cleaned = _clean_target(url)
+                if cleaned:
+                    column = ref_def.start("url") + 1
+                    refs.append(
+                        Reference(
+                            path=cleaned,
+                            line=line_no,
+                            column=column,
+                            shape="md_ref_def",
+                            raw=url,
+                        )
+                    )
+            # Reference-style definitions don't contain anything else worth
+            # scanning on the same line.
+            continue
+
+        # Markdown inline links / images.
+        for m in _MD_LINK_RE.finditer(line):
+            url = m.group("url")
+            if not _is_repo_local_target(url):
+                continue
+            cleaned = _clean_target(url)
+            if not cleaned:
+                continue
+            shape = "md_image" if m.group("bang") == "!" else "md_link"
+            column = m.start("url") + 1
+            refs.append(
+                Reference(
+                    path=cleaned,
+                    line=line_no,
+                    column=column,
+                    shape=shape,
+                    raw=url,
+                )
+            )
+
+        # Inline code spans — only those whose body matches a tracked path
+        # shape (a known top-level prefix OR a known file extension AND a
+        # path separator).
+        for m in _INLINE_CODE_RE.finditer(line):
+            body = m.group("body").strip()
+            if not _looks_like_inline_code_path(body):
+                continue
+            cleaned = _clean_target(body)
+            if not cleaned:
+                continue
+            column = m.start("body") + 1
+            refs.append(
+                Reference(
+                    path=cleaned,
+                    line=line_no,
+                    column=column,
+                    shape="inline_code",
+                    raw=body,
+                )
+            )
+
+        # Bare paths — only matched when they begin with a known top-level
+        # directory. We strip out any overlap with already-captured Markdown
+        # link targets to avoid double-counting (Markdown link URLs are not
+        # inside backticks here so this is a simple substring check).
+        for m in _BARE_PATH_RE.finditer(line):
+            candidate = m.group("path")
+            # Skip if this span sits inside a Markdown link target we
+            # already captured.
+            if _span_overlaps_existing(line_no, m.start(), m.end(), refs):
+                continue
+            # Skip if it sits inside an inline code span: those were already
+            # processed above.
+            if _span_inside_code(line, m.start(), m.end()):
+                continue
+            cleaned = _clean_target(candidate)
+            if not cleaned:
+                continue
+            refs.append(
+                Reference(
+                    path=cleaned,
+                    line=line_no,
+                    column=m.start() + 1,
+                    shape="bare_path",
+                    raw=candidate,
+                )
+            )
+
+    return refs
+
+
+def _is_repo_local_target(url: str) -> bool:
+    """Return True when *url* looks like a repo-local target."""
+    if not url:
+        return False
+    # Strip any in-page anchor and query string for the scheme check.
+    base = url.split("#", 1)[0].split("?", 1)[0]
+    if not base:
+        return False
+    # URL scheme: ``http:``, ``https:``, ``mailto:``, ``ftp:``, ``//host``…
+    if re.match(r"^[a-zA-Z][a-zA-Z0-9+.\-]*:", base):
+        return False
+    if base.startswith("//"):
+        return False
+    # Absolute filesystem paths are not repo-local.
+    if base.startswith("/"):
+        return False
+    return True
+
+
+def _clean_target(url: str) -> str:
+    """Strip in-page anchor and query string; normalise separators."""
+    base = url.split("#", 1)[0].split("?", 1)[0].strip()
+    # Normalise backslashes to forward slashes for cross-platform docs.
+    return base.replace("\\", "/")
+
+
+def _looks_like_inline_code_path(body: str) -> bool:
+    """Return True when an inline-code body looks like a repo-local path.
+
+    Rules:
+    - Must contain at least one ``/``.
+    - Either starts with a known top-level directory, OR ends with a known
+      file extension.
+    - No whitespace in the body.
+    """
+    if not body or " " in body or "\t" in body:
+        return False
+    if "/" not in body:
+        return False
+    first_seg = body.split("/", 1)[0]
+    if first_seg in KNOWN_TOP_LEVEL_DIRS:
+        return True
+    lowered = body.lower()
+    return any(lowered.endswith(ext) for ext in KNOWN_FILE_EXTENSIONS)
+
+
+def _span_overlaps_existing(line_no: int, start: int, end: int, refs: list[Reference]) -> bool:
+    """Return True if [start, end) on *line_no* sits inside an already-captured ref."""
+    for r in refs:
+        if r.line != line_no:
+            continue
+        r_start = r.column - 1
+        r_end = r_start + len(r.raw)
+        if r_start <= start and end <= r_end:
+            return True
+    return False
+
+
+def _span_inside_code(line: str, start: int, end: int) -> bool:
+    """Return True if the span [start, end) sits inside a single-backtick code span."""
+    # Walk the line and track whether the index is inside a backtick span.
+    in_code = False
+    open_at = -1
+    for i, ch in enumerate(line):
+        if ch == "`":
+            if not in_code:
+                in_code = True
+                open_at = i
+            else:
+                in_code = False
+                close_at = i
+                if open_at < start and end <= close_at:
+                    return True
+                open_at = -1
+    return False
+
+
+# Broad-shape heuristics (deterministic).
+#
+# A reference is considered ``suspicious_broad`` if any of:
+# - it ends with ``/`` (a bare-directory reference);
+# - it contains a glob character (``*`` or ``?``);
+# - it has no extension AND no further path segment after the top-level dir
+#   (e.g. ``docs`` or ``src``) — i.e. a bare top-level directory reference
+#   with no anchor.
+_GLOB_CHARS = ("*", "?")
+
+
+def is_suspicious_broad(reference: Reference) -> bool:
+    """Return True if *reference*'s shape is intentionally broad/ambiguous."""
+    path = reference.path
+    if not path:
+        return False
+    if path.endswith("/"):
+        return True
+    if any(c in path for c in _GLOB_CHARS):
+        return True
+    # Bare top-level directory with no further segment, e.g. ``docs``.
+    if path in KNOWN_TOP_LEVEL_DIRS:
+        return True
+    return False
+
+
+__all__ = [
+    "KNOWN_FILE_EXTENSIONS",
+    "KNOWN_TOP_LEVEL_DIRS",
+    "Reference",
+    "extract_references",
+    "is_suspicious_broad",
+]

--- a/scripts/dependency_gates/_repo_ref_scan.py
+++ b/scripts/dependency_gates/_repo_ref_scan.py
@@ -106,16 +106,22 @@ _INLINE_CODE_RE = re.compile(r"(?<!`)`(?P<body>[^`\n]+?)`(?!`)")
 
 # A bare path-like token: starts with a known top-level directory, possibly
 # trailed by additional path segments. The lookbehind/lookahead keep us from
-# matching path-fragments embedded in larger identifiers.
+# matching path-fragments embedded in larger identifiers. The ``[`` in the
+# lookbehind specifically blocks the bare-path matcher from firing inside
+# Markdown link *text* (``[docs/old.md](docs/new.md)``) — without it the
+# link-text fragment would be re-extracted as a `bare_path` reference and
+# could produce a spurious ``broken_reference`` FAIL when the text-side
+# path no longer exists (e.g. after a rename).
 _BARE_PATH_RE = re.compile(
-    r"(?<![\w./])(?P<path>(?:" + "|".join(re.escape(d) for d in KNOWN_TOP_LEVEL_DIRS) + r")/[\w./*?-]*)"
+    r"(?<![\w./\[])(?P<path>(?:" + "|".join(re.escape(d) for d in KNOWN_TOP_LEVEL_DIRS) + r")/[\w./*?-]*)"
 )
 
 # Fenced code block boundary (``` or ~~~ with optional info string).
 _FENCE_RE = re.compile(r"^[ \t]{0,3}(?P<fence>```+|~~~+)")
 
-# YAML/JSON-ish front-matter delimiter ("---" on its own line).
-_YAML_FENCE_RE = re.compile(r"^---\s*$")
+# TODO(#269-later): strip YAML front-matter (lines between a leading ``---``
+# and the matching closing ``---``) before scanning. Deferred to a later
+# slice; the first slice does not yet skip front-matter content.
 
 
 def extract_references(text: str, *, source_path: str | None = None) -> list[Reference]:

--- a/scripts/dependency_gates/check_repo_refs.py
+++ b/scripts/dependency_gates/check_repo_refs.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Mode-A validator for repo-local reference scanning (umbrella #269, slice 1).
+
+Reads a JSON ``{rule, target}`` payload on stdin per the ``command`` external
+adapter contract (docs/backend-external.md § "command"). For the single
+``target`` file (a text-bearing artifact such as README/docs/config/rule),
+extracts repo-local references with ``_repo_ref_scan.extract_references`` and
+classifies each one against:
+
+- the working tree — ``broken_reference`` if the path does not exist;
+- the changed-file set — ``uncovered_reference`` (a.k.a. ``newly_introduced``)
+  when the target file itself is in the changed-file set, the reference is
+  not co-changed alongside it, and the reference is not already recorded as
+  a manifest edge whose ``to:`` matches the reference path;
+- the broad-shape detector — ``suspicious_broad`` for trailing-slash, glob,
+  or bare-top-level-directory references.
+
+The validator emits a single Diagnostic with one Evidence entry per finding
+category that produced at least one hit. Empty-finding targets emit
+``status: pass`` with ``evidence.kind: repo_refs_clean``. Non-text targets
+short-circuit to ``status: pass`` with ``evidence.kind: scanner_not_applicable``.
+
+Fail-closed semantics:
+- malformed payload → ``unavailable`` / ``params_error``;
+- unreadable target file → ``unavailable`` / ``target_unreadable``;
+- unresolvable changed-file set → ``unavailable`` /
+  ``changed_file_source_unresolved``.
+
+Always exits 0; pass/fail is carried in the emitted ``Diagnostic.status``.
+
+This validator is informational in the first slice. It surfaces deterministic
+findings; enforcement of manifest coverage is explicitly a later slice (Layer
+1 in issue #269).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from dependency_gates._changed_files import (  # noqa: E402
+        ChangedFilesError,
+        compute_changed_files,
+        resolve_base_ref,
+    )
+    from dependency_gates._repo_ref_scan import (  # noqa: E402
+        Reference,
+        extract_references,
+        is_suspicious_broad,
+    )
+    from dependency_gates.manifest import (  # noqa: E402
+        Manifest,
+        ManifestError,
+        load_manifest,
+    )
+else:
+    from ._changed_files import (
+        ChangedFilesError,
+        compute_changed_files,
+        resolve_base_ref,
+    )
+    from ._repo_ref_scan import (
+        Reference,
+        extract_references,
+        is_suspicious_broad,
+    )
+    from .manifest import (
+        Manifest,
+        ManifestError,
+        load_manifest,
+    )
+
+DEFAULT_MANIFEST_PATH = ".gate-keeper/dependency-manifest.yml"
+
+# File extensions the scanner operates on. Targets outside this set
+# short-circuit to a "not applicable" pass — the scanner is intentionally
+# scoped to text-bearing files.
+SCANNABLE_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        ".md",
+        ".json",
+        ".yml",
+        ".yaml",
+        ".toml",
+        ".cfg",
+        ".ini",
+        ".txt",
+    }
+)
+
+# Top-level directories whose extension-less files are considered text-bearing
+# (e.g. CI workflow definitions and config under ``.github/``).
+SCANNABLE_EXTENSIONLESS_PREFIXES: tuple[str, ...] = (".github/",)
+
+
+@dataclass(frozen=True)
+class Outcome:
+    status: str
+    message: str
+    evidence: list[dict[str, Any]]
+    remediation: str | None = None
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    payload = _parse_payload(raw)
+    target_str = payload.get("target", "") or ""
+    rule = payload.get("rule") or {}
+    params = rule.get("params") or {}
+
+    repo_root = _resolve_repo_root(Path.cwd())
+    manifest_path = _resolve_manifest_path(params, repo_root)
+
+    outcome = _run(
+        repo_root=repo_root,
+        manifest_path=manifest_path,
+        target=target_str,
+    )
+    _emit(outcome)
+    return 0
+
+
+def _run(*, repo_root: Path, manifest_path: Path, target: str) -> Outcome:
+    if not target:
+        return Outcome(
+            status="unavailable",
+            message="target path is empty",
+            evidence=[
+                {
+                    "kind": "params_error",
+                    "data": {"field": "target", "reason": "empty"},
+                }
+            ],
+            remediation="Invoke the validator with a non-empty --target path.",
+        )
+
+    target_rel = _to_repo_relative(target, repo_root)
+    target_abs = repo_root / target_rel
+
+    if not _is_scannable_target(target_rel):
+        return Outcome(
+            status="pass",
+            message=(f"target {target_rel!r} is not a text-bearing file; scanner skipped"),
+            evidence=[
+                {
+                    "kind": "scanner_not_applicable",
+                    "data": {"target": target_rel, "reason": "extension_not_scanned"},
+                }
+            ],
+        )
+
+    if not target_abs.is_file():
+        return Outcome(
+            status="unavailable",
+            message=f"target file {target_rel!r} not found",
+            evidence=[
+                {
+                    "kind": "target_unreadable",
+                    "data": {"target": target_rel, "reason": "missing"},
+                }
+            ],
+            remediation=(f"Ensure {target_rel} exists, or invoke the validator with a different --target."),
+        )
+
+    try:
+        text = target_abs.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return Outcome(
+            status="unavailable",
+            message=f"target file {target_rel!r} could not be read: {exc}",
+            evidence=[
+                {
+                    "kind": "target_unreadable",
+                    "data": {
+                        "target": target_rel,
+                        "reason": "read_error",
+                        "error": str(exc),
+                    },
+                }
+            ],
+            remediation=(f"Fix the encoding of {target_rel} (UTF-8 expected) or restore the file."),
+        )
+
+    # Manifest is optional for the scanner — the first slice does not enforce
+    # coverage. We still load it (when present) to skip references that are
+    # already classified as edges, so we don't double-report them as
+    # "newly introduced". If the manifest is missing the scanner still runs.
+    manifest: Manifest | None = None
+    if manifest_path.is_file():
+        try:
+            manifest = load_manifest(manifest_path)
+        except ManifestError as exc:
+            return Outcome(
+                status="unavailable",
+                message=f"manifest invalid: {exc}",
+                evidence=[
+                    {
+                        "kind": "manifest_invalid",
+                        "data": {"manifest_path": str(manifest_path), "error": str(exc)},
+                    }
+                ],
+                remediation=(
+                    f"Fix the manifest at {manifest_path} to match docs/design/dependency-gates.md §3."
+                ),
+            )
+
+    # Changed-file set: only required to disambiguate "newly introduced".
+    # When it is unavailable the scanner still emits broken/broad findings;
+    # the uncovered/newly-introduced category is reported as unknown for
+    # that invocation (the evidence carries an explicit reason so callers
+    # don't read it as "no new refs found").
+    base_ref = resolve_base_ref()
+    try:
+        changed = compute_changed_files(repo_root, base_ref)
+    except ChangedFilesError as exc:
+        changed = None
+        changed_error: str | None = str(exc)
+    else:
+        changed_error = None
+
+    refs = extract_references(text, source_path=target_rel)
+    classified_paths = _manifest_classified_paths(manifest) if manifest is not None else frozenset()
+
+    broken: list[dict[str, Any]] = []
+    newly_introduced: list[dict[str, Any]] = []
+    suspicious: list[dict[str, Any]] = []
+    seen_broken: set[str] = set()
+    seen_new: set[str] = set()
+    seen_broad: set[str] = set()
+
+    target_in_changed = bool(changed is not None and target_rel in changed)
+
+    for ref in refs:
+        if is_suspicious_broad(ref):
+            if ref.path not in seen_broad:
+                seen_broad.add(ref.path)
+                suspicious.append(_ref_to_evidence_entry(ref, target_rel))
+            # Broad shapes don't resolve to a concrete path, so don't try
+            # to test them against the working tree or the manifest.
+            continue
+
+        if not _path_exists(repo_root, ref.path):
+            if ref.path not in seen_broken:
+                seen_broken.add(ref.path)
+                broken.append(_ref_to_evidence_entry(ref, target_rel))
+            continue
+
+        # The path exists. Classify as newly introduced only when:
+        # - the target file is itself in the changed-file set;
+        # - the reference path is NOT also in the changed-file set (a
+        #   co-introduced ref alongside the change is not "uncovered");
+        # - the reference is not already a known manifest edge target.
+        if (
+            target_in_changed
+            and changed is not None
+            and ref.path not in changed
+            and ref.path not in classified_paths
+            and ref.path not in seen_new
+        ):
+            seen_new.add(ref.path)
+            newly_introduced.append(_ref_to_evidence_entry(ref, target_rel))
+
+    evidence: list[dict[str, Any]] = []
+    if broken:
+        evidence.append(
+            {
+                "kind": "broken_reference",
+                "data": {
+                    "target": target_rel,
+                    "references": broken,
+                },
+            }
+        )
+    if newly_introduced:
+        evidence.append(
+            {
+                "kind": "uncovered_reference",
+                "data": {
+                    "target": target_rel,
+                    "references": newly_introduced,
+                    "subkind": "newly_introduced",
+                },
+            }
+        )
+    if suspicious:
+        evidence.append(
+            {
+                "kind": "suspicious_broad",
+                "data": {
+                    "target": target_rel,
+                    "references": suspicious,
+                },
+            }
+        )
+
+    if changed is None:
+        evidence.append(
+            {
+                "kind": "changed_file_source_unresolved",
+                "data": {
+                    "base_ref": base_ref,
+                    "error": changed_error,
+                    "consequence": (
+                        "uncovered_reference detection skipped; broken_reference "
+                        "and suspicious_broad findings (if any) still apply"
+                    ),
+                },
+            }
+        )
+
+    # Status mapping: broken references are deterministic failures; the
+    # other two categories are informational only in the first slice (they
+    # do not block, per the lite-spec). When nothing is found, emit a clean
+    # pass evidence so downstream consumers can distinguish "scanned and
+    # found nothing" from "did not scan".
+    if broken:
+        return Outcome(
+            status="fail",
+            message=(
+                f"{len(broken)} broken repo-local reference(s) in {target_rel}; "
+                "see evidence for the path list"
+            ),
+            evidence=evidence,
+            remediation=(
+                "Fix each broken reference: update the path, restore the missing file, "
+                "or remove the reference if it is no longer applicable."
+            ),
+        )
+
+    if newly_introduced or suspicious:
+        return Outcome(
+            status="pass",
+            message=(
+                f"scanned {target_rel}: {len(newly_introduced)} newly introduced "
+                f"reference(s), {len(suspicious)} broad-shape reference(s); "
+                "no broken references"
+            ),
+            evidence=evidence,
+        )
+
+    return Outcome(
+        status="pass",
+        message=f"scanned {target_rel}: no repo-local reference issues found",
+        evidence=evidence
+        or [
+            {
+                "kind": "repo_refs_clean",
+                "data": {"target": target_rel, "references_scanned": len(refs)},
+            }
+        ],
+    )
+
+
+def _ref_to_evidence_entry(ref: Reference, target_rel: str) -> dict[str, Any]:
+    """Serialise a Reference into a stable evidence entry shape."""
+    del target_rel  # available to callers; included implicitly via outer dict
+    return {
+        "path": ref.path,
+        "line": ref.line,
+        "column": ref.column,
+        "shape": ref.shape,
+    }
+
+
+def _path_exists(repo_root: Path, ref_path: str) -> bool:
+    """Return True if *ref_path* resolves to an existing file or directory."""
+    if not ref_path:
+        return False
+    try:
+        candidate = (repo_root / ref_path).resolve()
+        repo_resolved = repo_root.resolve()
+        # Reject paths that escape the repo root (e.g. ``../../etc/passwd``).
+        try:
+            candidate.relative_to(repo_resolved)
+        except ValueError:
+            return False
+        return candidate.exists()
+    except OSError:
+        return False
+
+
+def _manifest_classified_paths(manifest: Manifest) -> frozenset[str]:
+    """Return the set of repo-relative paths that already participate in any edge."""
+    out: set[str] = set()
+    for edge in manifest.edges:
+        from_node = manifest.nodes_by_id.get(edge.from_id)
+        to_node = manifest.nodes_by_id.get(edge.to_id)
+        if from_node is not None:
+            out.add(from_node.path)
+        if to_node is not None:
+            out.add(to_node.path)
+    return frozenset(out)
+
+
+def _is_scannable_target(target_rel: str) -> bool:
+    if not target_rel:
+        return False
+    lowered = target_rel.lower()
+    for ext in SCANNABLE_EXTENSIONS:
+        if lowered.endswith(ext):
+            return True
+    for prefix in SCANNABLE_EXTENSIONLESS_PREFIXES:
+        if target_rel.startswith(prefix):
+            # Extension-less files (e.g. ``.github/CODEOWNERS``) are scannable;
+            # files with a non-scannable extension under .github/ are not.
+            if "." not in Path(target_rel).name:
+                return True
+    return False
+
+
+def _parse_payload(raw: str) -> dict[str, Any]:
+    try:
+        data = json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def _resolve_manifest_path(params: dict[str, Any], repo_root: Path) -> Path:
+    raw = params.get("manifest")
+    if isinstance(raw, str) and raw:
+        candidate = Path(raw)
+    else:
+        candidate = Path(DEFAULT_MANIFEST_PATH)
+    if not candidate.is_absolute():
+        candidate = repo_root / candidate
+    return candidate
+
+
+def _resolve_repo_root(start: Path) -> Path:
+    cur = start.resolve()
+    for parent in [cur, *cur.parents]:
+        if (parent / ".git").exists():
+            return parent
+    return start
+
+
+def _to_repo_relative(target: str, repo_root: Path) -> str:
+    if not target:
+        return ""
+    p = Path(target)
+    try:
+        if p.is_absolute():
+            rel = p.resolve().relative_to(repo_root.resolve())
+        else:
+            rel = (repo_root / p).resolve().relative_to(repo_root.resolve())
+    except ValueError:
+        return target.replace("\\", "/")
+    return rel.as_posix()
+
+
+def _emit(outcome: Outcome) -> None:
+    diagnostic: dict[str, Any] = {
+        "status": outcome.status,
+        "message": outcome.message,
+        "evidence": list(outcome.evidence),
+    }
+    if outcome.remediation is not None:
+        diagnostic["remediation"] = outcome.remediation
+    sys.stdout.write(json.dumps(diagnostic))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_repo_ref_scanner.py
+++ b/tests/test_repo_ref_scanner.py
@@ -72,6 +72,36 @@ def test_ignores_in_page_anchors():
     assert refs == []
 
 
+def test_bare_path_lookbehind_excludes_markdown_link_text():
+    """Regression for sonnet review on #273 / #269.
+
+    Without ``[`` in ``_BARE_PATH_RE``'s lookbehind, the path-shaped fragment
+    inside Markdown link *text* (``[docs/old.md](docs/new.md)``) would be
+    re-extracted as a ``bare_path`` reference in addition to the correct
+    ``md_link``. When the text-side path no longer existed on disk (e.g.
+    after a rename) the validator emitted a spurious ``broken_reference``
+    → ``Status.FAIL`` on perfectly valid Markdown.
+    """
+    text = "[docs/old.md](docs/new.md)\n"
+    refs = scanner.extract_references(text)
+    assert len(refs) == 1, f"expected exactly one ref, got {refs}"
+    assert refs[0].shape == "md_link"
+    assert refs[0].path == "docs/new.md"
+
+
+def test_bare_path_lookbehind_excludes_external_link_text():
+    """Sibling regression: link text must not leak even when the URL is external.
+
+    The link target is an external URL (correctly ignored by the extractor),
+    but the link text contains a repo-shape path. The bare-path matcher must
+    still be blocked by the ``[`` lookbehind so the text fragment is not
+    surfaced as a ``broken_reference``.
+    """
+    text = "[docs/something](https://external.example.com)\n"
+    refs = scanner.extract_references(text)
+    assert refs == [], f"expected no refs (URL external, link text inert), got {refs}"
+
+
 def test_extracts_inline_code_with_known_prefix():
     text = "Edit `src/gate_keeper/cli.py` to add the flag.\n"
     refs = scanner.extract_references(text)

--- a/tests/test_repo_ref_scanner.py
+++ b/tests/test_repo_ref_scanner.py
@@ -1,0 +1,429 @@
+"""Tests for the deterministic repo-local reference scanner (issue #269, slice 1).
+
+Two layers:
+
+- Unit tests of ``scripts/dependency_gates/_repo_ref_scan.extract_references``
+  exercise the syntactic extractor on small inline snippets.
+- Validator tests stub ``compute_changed_files`` and exercise
+  ``scripts/dependency_gates/check_repo_refs._run`` directly. No git, no
+  subprocess.
+
+Mirrors the layered style of ``tests/test_dependency_validator.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from gate_keeper.models import Diagnostic, DiagnosticReport, SourceLocation
+
+_SCRIPTS_ROOT = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_ROOT))
+
+from dependency_gates import _repo_ref_scan as scanner  # noqa: E402
+from dependency_gates import check_repo_refs as validator  # noqa: E402
+
+# --------------------------------------------------------------------------
+# Extractor unit tests
+# --------------------------------------------------------------------------
+
+
+def test_extracts_markdown_inline_link():
+    text = "See [the CLI reference](docs/cli-reference.md) for details.\n"
+    refs = scanner.extract_references(text)
+    assert len(refs) == 1
+    ref = refs[0]
+    assert ref.path == "docs/cli-reference.md"
+    assert ref.shape == "md_link"
+    assert ref.line == 1
+
+
+def test_extracts_markdown_image():
+    text = "![Architecture diagram](docs/design/diagram.png)\n"
+    refs = scanner.extract_references(text)
+    assert len(refs) == 1
+    assert refs[0].shape == "md_image"
+    assert refs[0].path == "docs/design/diagram.png"
+
+
+def test_extracts_markdown_reference_definition():
+    text = "[ref]: docs/cli-reference.md\n"
+    refs = scanner.extract_references(text)
+    assert len(refs) == 1
+    assert refs[0].shape == "md_ref_def"
+    assert refs[0].path == "docs/cli-reference.md"
+
+
+def test_ignores_url_targets():
+    text = "[ext](https://example.com/path) and [mail](mailto:a@b.c)\n"
+    refs = scanner.extract_references(text)
+    assert refs == []
+
+
+def test_ignores_in_page_anchors():
+    text = "[anchor](#section-2)\n"
+    refs = scanner.extract_references(text)
+    assert refs == []
+
+
+def test_extracts_inline_code_with_known_prefix():
+    text = "Edit `src/gate_keeper/cli.py` to add the flag.\n"
+    refs = scanner.extract_references(text)
+    assert len(refs) == 1
+    assert refs[0].shape == "inline_code"
+    assert refs[0].path == "src/gate_keeper/cli.py"
+
+
+def test_extracts_inline_code_with_known_extension():
+    text = "Run `pyproject.toml` linter.\n"
+    refs = scanner.extract_references(text)
+    # pyproject.toml has no '/', so it should NOT be picked up by inline-code.
+    assert refs == []
+
+
+def test_extracts_inline_code_known_extension_with_slash():
+    text = "See `tooling/pyproject.toml` for details.\n"
+    refs = scanner.extract_references(text)
+    assert len(refs) == 1
+    assert refs[0].shape == "inline_code"
+    assert refs[0].path == "tooling/pyproject.toml"
+
+
+def test_skips_fenced_code_blocks():
+    text = dedent(
+        """
+        Before fence: [pre](docs/before.md)
+        ```python
+        # docs/inside-fence.md should not be extracted
+        path = "src/inside.py"
+        ```
+        After fence: [post](docs/after.md)
+        """
+    ).lstrip()
+    refs = scanner.extract_references(text)
+    paths = [r.path for r in refs]
+    assert "docs/before.md" in paths
+    assert "docs/after.md" in paths
+    assert "docs/inside-fence.md" not in paths
+    assert "src/inside.py" not in paths
+
+
+def test_strips_anchor_and_query():
+    text = "[anchor](docs/cli-reference.md#validate)\n"
+    refs = scanner.extract_references(text)
+    assert len(refs) == 1
+    assert refs[0].path == "docs/cli-reference.md"
+
+
+def test_does_not_match_unknown_top_level_dir_bare_path():
+    text = "vendored/foo/bar.py is the legacy path.\n"
+    refs = scanner.extract_references(text)
+    assert refs == []
+
+
+def test_suspicious_broad_glob():
+    ref = scanner.Reference(path="docs/*.md", line=1, column=1, shape="bare_path", raw="docs/*.md")
+    assert scanner.is_suspicious_broad(ref) is True
+
+
+def test_suspicious_broad_trailing_slash():
+    ref = scanner.Reference(path="scripts/", line=1, column=1, shape="bare_path", raw="scripts/")
+    assert scanner.is_suspicious_broad(ref) is True
+
+
+def test_suspicious_broad_bare_top_level():
+    ref = scanner.Reference(path="docs", line=1, column=1, shape="md_link", raw="docs")
+    assert scanner.is_suspicious_broad(ref) is True
+
+
+def test_concrete_path_is_not_suspicious_broad():
+    ref = scanner.Reference(
+        path="docs/cli-reference.md",
+        line=1,
+        column=1,
+        shape="md_link",
+        raw="docs/cli-reference.md",
+    )
+    assert scanner.is_suspicious_broad(ref) is False
+
+
+# --------------------------------------------------------------------------
+# Validator integration tests (stubbed changed-file resolver)
+# --------------------------------------------------------------------------
+
+
+def _patch_changed(monkeypatch: pytest.MonkeyPatch, paths: set[str]) -> None:
+    monkeypatch.setattr(
+        validator,
+        "compute_changed_files",
+        lambda repo_root, base_ref: frozenset(paths),
+    )
+    monkeypatch.setattr(
+        validator,
+        "resolve_base_ref",
+        lambda env=None: "origin/main",
+    )
+
+
+def _patch_changed_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(repo_root, base_ref):  # type: ignore[no-untyped-def]
+        raise validator.ChangedFilesError("git unavailable for test")
+
+    monkeypatch.setattr(validator, "compute_changed_files", _raise)
+    monkeypatch.setattr(
+        validator,
+        "resolve_base_ref",
+        lambda env=None: "origin/main",
+    )
+
+
+def _seed_target(root: Path, rel: str, content: str) -> Path:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _seed_manifest(root: Path) -> None:
+    manifest_dir = root / ".gate-keeper"
+    manifest_dir.mkdir(exist_ok=True)
+    (manifest_dir / "dependency-manifest.yml").write_text(
+        dedent(
+            """
+            nodes:
+              - id: cli-implementation
+                path: src/gate_keeper/cli.py
+                kind: code
+              - id: cli-reference
+                path: docs/cli-reference.md
+                kind: reference
+            edges:
+              - from: cli-implementation
+                to: cli-reference
+                relation: documents
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+
+
+def _run(repo_root: Path, target: str) -> validator.Outcome:
+    return validator._run(
+        repo_root=repo_root,
+        manifest_path=repo_root / ".gate-keeper" / "dependency-manifest.yml",
+        target=target,
+    )
+
+
+def test_validator_link_to_existing_path_no_finding(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _seed_target(tmp_path, "docs/cli-reference.md", "# CLI reference\n")
+    _seed_target(tmp_path, "src/gate_keeper/cli.py", "x = 1\n")
+    _seed_target(
+        tmp_path,
+        "README.md",
+        "See [the CLI reference](docs/cli-reference.md) for details.\n",
+    )
+    _seed_manifest(tmp_path)
+    _patch_changed(monkeypatch, set())
+
+    out = _run(tmp_path, "README.md")
+    assert out.status == "pass"
+    # No broken/uncovered/broad findings — only the clean-evidence entry.
+    kinds = {e["kind"] for e in out.evidence}
+    assert "broken_reference" not in kinds
+    assert "uncovered_reference" not in kinds
+    assert "suspicious_broad" not in kinds
+
+
+def test_validator_link_to_nonexistent_path_emits_broken_reference(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _seed_target(tmp_path, "docs/cli-reference.md", "# CLI reference\n")
+    _seed_target(tmp_path, "src/gate_keeper/cli.py", "x = 1\n")
+    _seed_target(
+        tmp_path,
+        "README.md",
+        "See [missing doc](docs/no-such-file.md) for details.\n",
+    )
+    _seed_manifest(tmp_path)
+    _patch_changed(monkeypatch, set())
+
+    out = _run(tmp_path, "README.md")
+    assert out.status == "fail"
+    broken = [e for e in out.evidence if e["kind"] == "broken_reference"]
+    assert len(broken) == 1
+    paths = [r["path"] for r in broken[0]["data"]["references"]]
+    assert "docs/no-such-file.md" in paths
+    assert out.remediation is not None
+
+
+def test_validator_newly_introduced_reference_in_changed_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _seed_target(tmp_path, "docs/cli-reference.md", "# CLI reference\n")
+    _seed_target(tmp_path, "docs/getting-started.md", "# Getting started\n")
+    _seed_target(tmp_path, "src/gate_keeper/cli.py", "x = 1\n")
+    # README references a NEW doc (getting-started) that is NOT in the
+    # changed-set and NOT in any manifest edge. The README itself IS in the
+    # changed-set, so the reference is "newly introduced".
+    _seed_target(
+        tmp_path,
+        "README.md",
+        "See [getting started](docs/getting-started.md) and the [CLI](docs/cli-reference.md).\n",
+    )
+    _seed_manifest(tmp_path)
+    _patch_changed(monkeypatch, {"README.md"})
+
+    out = _run(tmp_path, "README.md")
+    assert out.status == "pass"  # informational — does not fail in slice 1
+    uncovered = [e for e in out.evidence if e["kind"] == "uncovered_reference"]
+    assert len(uncovered) == 1
+    paths = [r["path"] for r in uncovered[0]["data"]["references"]]
+    assert "docs/getting-started.md" in paths
+    # cli-reference.md is in a manifest edge → must NOT be reported as new.
+    assert "docs/cli-reference.md" not in paths
+    assert uncovered[0]["data"]["subkind"] == "newly_introduced"
+
+
+def test_validator_suspicious_broad_reference(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _seed_target(tmp_path, "docs/cli-reference.md", "# CLI reference\n")
+    # Glob shape in a markdown link.
+    _seed_target(
+        tmp_path,
+        "README.md",
+        "All [docs](docs/*.md) live here.\n",
+    )
+    _seed_manifest(tmp_path)
+    _patch_changed(monkeypatch, set())
+
+    out = _run(tmp_path, "README.md")
+    # The glob path itself does not exist, but is_suspicious_broad
+    # short-circuits before the broken-reference check, so we expect the
+    # broad evidence kind and NOT broken_reference for this path.
+    assert out.status == "pass"
+    broad = [e for e in out.evidence if e["kind"] == "suspicious_broad"]
+    assert len(broad) == 1
+    paths = [r["path"] for r in broad[0]["data"]["references"]]
+    assert "docs/*.md" in paths
+    broken = [e for e in out.evidence if e["kind"] == "broken_reference"]
+    assert broken == []
+
+
+def test_validator_non_text_target_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _seed_target(tmp_path, "src/gate_keeper/cli.py", "x = 1\n")
+    _seed_manifest(tmp_path)
+    _patch_changed(monkeypatch, set())
+
+    out = _run(tmp_path, "src/gate_keeper/cli.py")
+    assert out.status == "pass"
+    assert any(e["kind"] == "scanner_not_applicable" for e in out.evidence)
+
+
+def test_validator_missing_target_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _seed_manifest(tmp_path)
+    _patch_changed(monkeypatch, set())
+
+    out = _run(tmp_path, "docs/nonexistent.md")
+    assert out.status == "unavailable"
+    assert any(e["kind"] == "target_unreadable" for e in out.evidence)
+
+
+def test_validator_changed_file_set_unresolvable_does_not_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _seed_target(tmp_path, "docs/cli-reference.md", "# CLI reference\n")
+    _seed_target(
+        tmp_path,
+        "README.md",
+        "See [missing](docs/no-such-file.md).\n",
+    )
+    _seed_manifest(tmp_path)
+    _patch_changed_unavailable(monkeypatch)
+
+    out = _run(tmp_path, "README.md")
+    # Broken-reference detection is independent of the changed-file set
+    # → it should still fail. The unresolved evidence is appended.
+    assert out.status == "fail"
+    assert any(e["kind"] == "broken_reference" for e in out.evidence)
+    assert any(e["kind"] == "changed_file_source_unresolved" for e in out.evidence)
+
+
+def test_validator_empty_target_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _patch_changed(monkeypatch, set())
+    out = _run(tmp_path, "")
+    assert out.status == "unavailable"
+    assert any(e["kind"] == "params_error" for e in out.evidence)
+
+
+# --------------------------------------------------------------------------
+# IR-shape round-trip
+# --------------------------------------------------------------------------
+
+
+def test_emitted_diagnostic_round_trips_through_ir_loader(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    """The emitted JSON, wrapped into a Diagnostic envelope, must load via
+    ``Diagnostic.from_dict`` without schema break.
+
+    The command-adapter contract has the validator emit only ``status``,
+    ``message``, ``evidence`` (and optionally ``remediation``); the adapter
+    wraps that into a full Diagnostic with ``rule_id``, ``source``,
+    ``backend``, ``severity``. We replicate the wrapping here and confirm
+    the round-trip.
+    """
+    _seed_target(tmp_path, "docs/cli-reference.md", "# CLI reference\n")
+    _seed_target(
+        tmp_path,
+        "README.md",
+        "See [missing](docs/no-such-file.md).\n",
+    )
+    _seed_manifest(tmp_path)
+    _patch_changed(monkeypatch, set())
+
+    out = _run(tmp_path, "README.md")
+    # Replicate the adapter envelope.
+    diagnostic_dict = {
+        "rule_id": "repo-local-reference-scanner",
+        "source": {"path": "docs/dependency-gate-rules.json", "line": 1},
+        "backend": "external",
+        "status": out.status,
+        "severity": "warning",
+        "message": out.message,
+        "evidence": [{"kind": e["kind"], "data": e["data"]} for e in out.evidence],
+    }
+    if out.remediation is not None:
+        diagnostic_dict["remediation"] = out.remediation
+
+    diag = Diagnostic.from_dict(diagnostic_dict)
+    assert diag.rule_id == "repo-local-reference-scanner"
+    assert diag.status.value == out.status
+    # Round-trip back to dict — confirms no fields lost or added.
+    assert diag.to_dict()["evidence"] == diagnostic_dict["evidence"]
+
+    # Loader at report level too.
+    report = DiagnosticReport.from_dict({"diagnostics": [diagnostic_dict]})
+    assert len(report.diagnostics) == 1
+    # Source location is well-formed.
+    assert isinstance(report.diagnostics[0].source, SourceLocation)
+
+
+def test_emit_writes_valid_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The ``_emit`` helper must write a JSON-parseable object on stdout."""
+    out = validator.Outcome(
+        status="pass",
+        message="ok",
+        evidence=[{"kind": "repo_refs_clean", "data": {"target": "x", "references_scanned": 0}}],
+    )
+    written: list[str] = []
+    monkeypatch.setattr(validator.sys.stdout, "write", lambda s: written.append(s) or len(s))
+    validator._emit(out)
+    parsed = json.loads("".join(written))
+    assert parsed["status"] == "pass"
+    assert parsed["evidence"][0]["kind"] == "repo_refs_clean"


### PR DESCRIPTION
## Summary

- Lands the first slice of issue #269: a deterministic scanner that walks one text-bearing target file (readme / docs / config / rule file), extracts explicit repo-local file/path references, and emits structured findings without invoking any LLM backend.
- Wired through the existing `external_check` + `command` adapter pipeline — no new `Backend` enum value, no new `RuleKind`, no change to the `Diagnostic` / `Evidence` field set.
- Classifies references into three deterministic categories: `broken_reference` (referenced path missing) → `Status.FAIL`; `uncovered_reference` / `newly_introduced` (new reference in a changed target, not co-changed, not on a manifest edge) → informational pass; `suspicious_broad` (glob, trailing slash, bare top-level dir) → informational pass.

## Scope (per the lite-spec contract on the issue body)

In scope:
- Scanner module at `scripts/dependency_gates/_repo_ref_scan.py` recognising `md_link`, `md_image`, `md_ref_def`, `inline_code`, and `bare_path` shapes. URL-shaped targets, in-page anchors, and fenced code blocks are skipped.
- Validator at `scripts/dependency_gates/check_repo_refs.py` reusing the existing `_changed_files` / manifest helpers; fail-closed branches map to `params_error` / `target_unreadable` / `manifest_invalid` / `changed_file_source_unresolved` with structured evidence.
- Rule entry in `docs/dependency-gate-rules.json` (`id: repo-local-reference-scanner`).
- §6.1 added to `docs/design/dependency-gates.md` documenting the evidence vocabulary and slice-1 boundaries.

Out of scope (explicitly deferred to later slices, tracked under the same umbrella):
- Manifest-coverage enforcement (Layer 1 in the issue).
- LLM-rubric narrowing (Layer 2 in the issue).
- Any new `Backend` enum value or `RuleKind` enum value.
- Coupling to #268.

## Test plan

- [x] `uv run pytest` — 1507 passed locally post-rebase on `origin/main` (incl. the 25 new scanner tests).
- [x] `uvx ruff check .` — clean.
- [x] `uvx ruff format --check .` — clean.
- [x] Markdown link to existing tracked path emits no finding.
- [x] Markdown link to non-existent path emits `broken_reference`.
- [x] Newly introduced reference in a changed target emits `uncovered_reference` with `subkind: newly_introduced`.
- [x] Glob / trailing-slash / bare-directory shapes emit `suspicious_broad`.
- [x] Emitted Diagnostic round-trips through `Diagnostic.from_dict` / `to_dict` without schema break.
- [ ] Reviewer sanity-check the evidence vocabulary aligns with the issue's "Desired semantics" table.

Closes #269 first slice (umbrella stays open for Layers 1 and 2).
