### PR TITLE
fix(dogfood): centralize model config + strict-mode guard (closes #266)

### DIFF
--- a/.github/dogfooding-config.env
+++ b/.github/dogfooding-config.env
@@ -1,0 +1,20 @@
+# Non-secret configuration for the dogfooding workflow
+# (.github/workflows/dogfooding.yml).
+#
+# Sourced by the workflow's "Provision provider credentials" step and
+# interpolated into the dotenv path the llm-rubric backend reads
+# ($HOME/.config/hermes-projects/gate-keeper.env).
+#
+# The model name is NOT a secret. The provider API key remains in the
+# repo secret `OPENAI_API_KEY`.
+#
+# Updating the model value:
+# - The CI-side restricted OpenAI key is allow-listed to a single model.
+#   Update this file AND the OpenAI Platform key allow-list together,
+#   in the same change set, otherwise the next dogfood run reports
+#   `provider_error` on every rule (issue #264).
+# - The backend default (`gpt-4o-mini`) would be rejected by the
+#   provider, so silent fallback is intentionally disabled in CI via
+#   `GATE_KEEPER_REQUIRE_MODEL=1` (issue #266; strict-mode guard in
+#   `src/gate_keeper/backends/llm_rubric.py`).
+GATE_KEEPER_OPENAI_MODEL=gpt-5.4

--- a/.github/workflows/dogfooding.yml
+++ b/.github/workflows/dogfooding.yml
@@ -32,6 +32,17 @@
 #     It does NOT use `echo $VAR` or `set -x`. The dotenv file is
 #     written under `umask 077` (mode 600) and never uploaded as a
 #     workflow artifact.
+#
+# Non-secret configuration (post-#266):
+#   - The model name (`GATE_KEEPER_OPENAI_MODEL`) is sourced from the
+#     tracked file `.github/dogfooding-config.env`, NOT a workflow
+#     literal. Updating the model is a normal PR diff review (see that
+#     file's header for the CI-key allow-list coupling).
+#   - Strict-mode key `GATE_KEEPER_REQUIRE_MODEL=1` is projected into
+#     the runtime dotenv so a blank or missing model value fails fast
+#     with a clear diagnostic rather than silently falling back to the
+#     backend default (`gpt-4o-mini`), which the restricted CI key
+#     would reject as `provider_error` on every rule.
 
 name: dogfooding
 
@@ -93,20 +104,44 @@ jobs:
           # `provider_unconfigured` (issue #261).
           set +x
           umask 077
+
+          # Source the non-secret dogfooding config (#266).  The model
+          # name lives in a tracked file rather than a workflow literal
+          # so updating it is a PR diff, not an Actions UI tweak.  The
+          # `. <file>` sourcing carries `GATE_KEEPER_OPENAI_MODEL` into
+          # this step's environment; the API key remains a secret.
+          # shellcheck disable=SC1091
+          . .github/dogfooding-config.env
+
+          # Fail fast on missing / blank model config so we do not
+          # project an incomplete dotenv that the backend would only
+          # surface as `provider_error` per rule (#266 strict guard).
+          if [ -z "${GATE_KEEPER_OPENAI_MODEL:-}" ]; then
+            echo "::error::GATE_KEEPER_OPENAI_MODEL is unset or blank in .github/dogfooding-config.env" >&2
+            exit 1
+          fi
+
           mkdir -p "$HOME/.config/hermes-projects"
           # Log the projection target BEFORE writing so a missing/wrong
           # parent directory is obvious; never log the dotenv contents.
           echo "dotenv projection target: $HOME/.config/hermes-projects/gate-keeper.env"
+          echo "model (from .github/dogfooding-config.env): $GATE_KEEPER_OPENAI_MODEL"
           ls -ld "$HOME/.config/hermes-projects" || true
           # printf + redirect — does not echo via `echo $VAR` and is not
           # affected by `-x` since we explicitly disabled it. The dotenv
           # file inherits the 077 umask (mode 600).
-          # `GATE_KEEPER_OPENAI_MODEL=gpt-5.4` is hard-pinned here because
-          # the CI-side restricted OpenAI key is allow-listed to gpt-5.4
-          # only; the backend default (`gpt-4o-mini`) would be rejected by
-          # the provider and surface as `provider_error` on every rule
-          # (issue #264). The model name is not a secret.
-          printf 'GATE_KEEPER_LLM_PROVIDER=openai\nGATE_KEEPER_OPENAI_MODEL=gpt-5.4\nOPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" \
+          # `GATE_KEEPER_OPENAI_MODEL` is sourced from
+          # `.github/dogfooding-config.env` because the CI-side restricted
+          # OpenAI key is allow-listed to a specific model; the backend
+          # default (`gpt-4o-mini`) would be rejected by the provider and
+          # surface as `provider_error` on every rule (issue #264).
+          # `GATE_KEEPER_REQUIRE_MODEL=1` switches the backend's
+          # `_resolve_model` into strict mode so a blank/missing model
+          # value here fails closed with a clear `provider_unconfigured`
+          # / `model_unconfigured` diagnostic rather than silently
+          # falling back (issue #266). The model name is not a secret.
+          printf 'GATE_KEEPER_LLM_PROVIDER=openai\nGATE_KEEPER_OPENAI_MODEL=%s\nGATE_KEEPER_REQUIRE_MODEL=1\nOPENAI_API_KEY=%s\n' \
+            "$GATE_KEEPER_OPENAI_MODEL" "$OPENAI_API_KEY" \
             > "$HOME/.config/hermes-projects/gate-keeper.env"
           chmod 600 "$HOME/.config/hermes-projects/gate-keeper.env"
           # Post-write confirmation: file exists, mode 600, owned by runner.

--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -487,6 +487,7 @@ verdict is rejected as ungrounded).  Failure modes recorded in
 | Failure | `status` | `evidence[0].kind` | `data.failure_mode` |
 | --- | --- | --- | --- |
 | File missing or provider unset | `unavailable` | `provider_unconfigured` | n/a |
+| Blank/missing model under strict mode (#266) | `unavailable` | `provider_unconfigured` | `model_unconfigured` |
 | SDK/HTTP error, timeout, etc. | `unavailable` | `provider_error` | exception class name |
 | Response is not the expected JSON shape | `unavailable` | `provider_error` | `unparseable_response` |
 | Quotes not substrings of artifact (#172) | `unsupported` | `llm_quote_fabrication` | n/a (offending quotes in `data.fabricated_quotes`) |

--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -64,8 +64,13 @@ fail-closed behavior: an unconfigured evaluator must not silently pass rules.
 file at:
 
 ```
-/home/vscode/.config/hermes-projects/gate-keeper.env
+$HOME/.config/hermes-projects/gate-keeper.env
 ```
+
+The path resolves via `Path.home()` at runtime, so it matches the
+developer's home directory in a devcontainer (`/home/vscode/...`),
+on a hosted CI runner (`/home/runner/...`), or on a bare developer
+machine.
 
 It is loaded explicitly via `python-dotenv`'s `dotenv_values` into a
 process-local dict; **`os.environ` is intentionally not consulted**. This is
@@ -132,6 +137,25 @@ Behavior:
 
 `gate-keeper diagnose` surfaces the resolved model and whether it came
 from an override or the default.
+
+#### Strict-mode override (`GATE_KEEPER_REQUIRE_MODEL`)
+
+Opt-in via the same dotenv. When set to a truthy value (`1`, `true`,
+`yes`; case-insensitive), an unset / blank `GATE_KEEPER_<PROVIDER>_MODEL`
+raises an internal `ModelConfigurationError` that the backend surfaces
+as:
+
+- `Status.UNAVAILABLE`
+- `evidence[0].kind = "provider_unconfigured"`
+- `evidence[0].data.failure_mode = "model_unconfigured"`
+- `evidence[0].data.provider`, `evidence[0].data.override_key`
+- `remediation` names the override key and the strict-mode opt-out.
+
+Intended use is CI environments whose provider key is allow-listed to a
+specific model — the silent fallback would otherwise be rejected by the
+provider and surface as opaque `provider_error` on every rule, masking
+the real misconfiguration (issue #266 / #264). Strict mode is off by
+default; existing developer dotenvs are unaffected.
 
 ### Restricted API key setup
 
@@ -204,8 +228,22 @@ introduced in #131) demonstrates the pattern:
   run: |
     set +x
     umask 077
+
+    # Source the non-secret dogfooding config (#266). The model name
+    # lives in a tracked file rather than a workflow literal so updating
+    # it is a PR diff, not an Actions UI tweak.
+    # shellcheck disable=SC1091
+    . .github/dogfooding-config.env
+
+    # Fail fast on missing / blank model config.
+    if [ -z "${GATE_KEEPER_OPENAI_MODEL:-}" ]; then
+      echo "::error::GATE_KEEPER_OPENAI_MODEL is unset or blank in .github/dogfooding-config.env" >&2
+      exit 1
+    fi
+
     mkdir -p "$HOME/.config/hermes-projects"
-    printf 'GATE_KEEPER_LLM_PROVIDER=openai\nGATE_KEEPER_OPENAI_MODEL=gpt-5.4\nOPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" \
+    printf 'GATE_KEEPER_LLM_PROVIDER=openai\nGATE_KEEPER_OPENAI_MODEL=%s\nGATE_KEEPER_REQUIRE_MODEL=1\nOPENAI_API_KEY=%s\n' \
+      "$GATE_KEEPER_OPENAI_MODEL" "$OPENAI_API_KEY" \
       > "$HOME/.config/hermes-projects/gate-keeper.env"
     chmod 600 "$HOME/.config/hermes-projects/gate-keeper.env"
 ```
@@ -215,11 +253,28 @@ The backend's default dotenv path is computed at runtime as
 GitHub-hosted runners `$HOME=/home/runner`; in a devcontainer it is
 typically `/home/vscode`. The projection target MUST follow `$HOME` so
 the backend's read path matches the workflow's write path on every host
-(issue #261). `GATE_KEEPER_OPENAI_MODEL` is pinned because the
-repository's restricted CI key is allow-listed to a specific model only;
-without it the backend default would be rejected by the provider and
-surface as `provider_error` on every rule (issue #264). The model name
-is not a secret.
+(issue #261).
+
+`GATE_KEEPER_OPENAI_MODEL` is sourced from the tracked file
+`.github/dogfooding-config.env` (#266) because the repository's
+restricted CI key is allow-listed to a specific model only; without
+that override the backend default (`gpt-4o-mini`) would be rejected by
+the provider and surface as `provider_error` on every rule (issue
+#264). The model name is not a secret — keeping it in a reviewable
+in-repo file rather than a workflow literal or Actions variable means a
+model update is a normal PR diff, with no out-of-tree GUI state to
+maintain.
+
+`GATE_KEEPER_REQUIRE_MODEL=1` is projected into the runtime dotenv
+alongside the model name (#266). It switches the backend's
+`_resolve_model` into strict mode: if `GATE_KEEPER_OPENAI_MODEL` (or
+`GATE_KEEPER_ANTHROPIC_MODEL` for the anthropic provider) is unset or
+blank, the backend emits `provider_unconfigured` with
+`evidence[0].data.failure_mode = "model_unconfigured"` and names the
+override key in the remediation string, rather than silently falling
+back to the source default. The strict-mode key is opt-in via dotenv —
+no developer flow that omits it changes behaviour. Recognised truthy
+values: `1`, `true`, `yes` (case-insensitive).
 
 Constraints to preserve when adopting this pattern in another workflow:
 

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -704,6 +704,63 @@ def _is_configured(env: dict[str, str] | None = None) -> bool:
     return bool(env.get(key_var))
 
 
+class ModelConfigurationError(RuntimeError):
+    """Raised when strict-mode resolution finds a blank / missing model override (#266).
+
+    Strict mode is opt-in via the dotenv key ``GATE_KEEPER_REQUIRE_MODEL``
+    (truthy values: ``1``, ``true``, ``yes``; case-insensitive). It exists
+    so CI environments whose provider key is allow-listed to a specific
+    model can fail fast with a clear diagnostic when the model override is
+    unset or blank, rather than silently falling back to the source
+    default (which the provider would then reject as
+    :data:`provider_error` on every rule, masking the real
+    misconfiguration).
+
+    Outside strict mode the historical silent fallback to the source
+    default constant is preserved byte-for-byte — non-CI developer flows
+    that rely on the default ``gpt-4o-mini`` / ``claude-haiku-4-5`` are
+    unaffected.
+
+    Attributes
+    ----------
+    provider:
+        Provider name (``"openai"`` or ``"anthropic"``) whose model override
+        was unset / blank.
+    override_key:
+        The exact dotenv key that was checked
+        (``GATE_KEEPER_OPENAI_MODEL`` or ``GATE_KEEPER_ANTHROPIC_MODEL``).
+    """
+
+    def __init__(self, provider: str, override_key: str) -> None:
+        super().__init__(
+            f"{override_key} is unset or blank in the dotenv but "
+            f"GATE_KEEPER_REQUIRE_MODEL is set; refusing to silently fall back "
+            f"to the source default for provider {provider!r}."
+        )
+        self.provider = provider
+        self.override_key = override_key
+
+
+_STRICT_MODEL_TRUTHY = frozenset({"1", "true", "yes"})
+
+
+def _require_model_strict(env: dict[str, str]) -> bool:
+    """Return ``True`` iff ``GATE_KEEPER_REQUIRE_MODEL`` is set truthy (#266).
+
+    Strict-mode opt-in lives in the dotenv (not ``os.environ``) to match
+    the rest of the backend's auth surface — the same single-snapshot
+    dict that decides ``_is_configured`` also decides whether
+    :func:`_resolve_model` falls back silently or raises.
+
+    Recognised truthy values (case-insensitive): ``1``, ``true``, ``yes``.
+    Anything else — including ``0``, ``false``, ``no``, an empty string,
+    or a missing key — is treated as opt-out so existing dotenvs keep
+    their historical silent-fallback behaviour.
+    """
+    raw = env.get("GATE_KEEPER_REQUIRE_MODEL", "").strip().lower()
+    return raw in _STRICT_MODEL_TRUTHY
+
+
 def _resolve_model(provider: str, env: dict[str, str]) -> str:
     """Return the model identifier to use for *provider*.
 
@@ -711,12 +768,25 @@ def _resolve_model(provider: str, env: dict[str, str]) -> str:
     and non-empty (after stripping); otherwise falls back to the source
     default constant. Empty / whitespace-only overrides are ignored so a
     blank line in the dotenv does not silently produce an invalid model id.
+
+    Strict mode (#266): when ``GATE_KEEPER_REQUIRE_MODEL`` is truthy in
+    the same dotenv snapshot, a missing / blank override raises
+    :class:`ModelConfigurationError` instead of falling back. This exists
+    for CI environments whose restricted provider key only accepts a
+    specific model — silent fallback there manifests as
+    ``provider_error`` on every rule, masking the real misconfiguration.
+    Non-strict callers (the default, all developer flows) keep the
+    historical fallback behaviour byte-for-byte.
     """
     if provider == "anthropic":
         override = env.get("GATE_KEEPER_ANTHROPIC_MODEL", "").strip()
+        if not override and _require_model_strict(env):
+            raise ModelConfigurationError("anthropic", "GATE_KEEPER_ANTHROPIC_MODEL")
         return override or ANTHROPIC_DEFAULT_MODEL
     if provider == "openai":
         override = env.get("GATE_KEEPER_OPENAI_MODEL", "").strip()
+        if not override and _require_model_strict(env):
+            raise ModelConfigurationError("openai", "GATE_KEEPER_OPENAI_MODEL")
         return override or OPENAI_DEFAULT_MODEL
     raise ValueError(f"unsupported provider: {provider!r}")
 
@@ -2474,6 +2544,50 @@ def _unavailable_unconfigured(rule: Rule, rubric_input: dict[str, Any]) -> Diagn
     )
 
 
+def _unavailable_model_unconfigured(
+    rule: Rule,
+    rubric_input: dict[str, Any],
+    exc: ModelConfigurationError,
+) -> Diagnostic:
+    """Diagnostic for strict-mode model-config failures (#266).
+
+    Distinct from :func:`_unavailable_unconfigured` so an operator can
+    tell the missing-provider case ("no key, no provider") from the
+    missing-model case ("provider configured but the model override is
+    blank under strict mode"). The evidence carries
+    ``failure_mode="model_unconfigured"`` and the override key name so a
+    PR comment or log can point straight at the dotenv line to fix.
+    """
+    return Diagnostic(
+        rule_id=rule.id,
+        source=rule.source,
+        backend=Backend.LLM_RUBRIC,
+        status=Status.UNAVAILABLE,
+        severity=rule.severity,
+        message=(
+            f"LLM rubric backend: {exc.override_key} is unset or blank under "
+            "strict-mode (GATE_KEEPER_REQUIRE_MODEL=1); skipping rule."
+        ),
+        evidence=[
+            Evidence(
+                kind="provider_unconfigured",
+                data={
+                    **rubric_input,
+                    "failure_mode": "model_unconfigured",
+                    "provider": exc.provider,
+                    "override_key": exc.override_key,
+                },
+            )
+        ],
+        remediation=(
+            f"Set {exc.override_key} to a non-blank value in the dotenv "
+            "(see docs/llm-rubric.md — Model selection / CI exception). "
+            "Or unset GATE_KEEPER_REQUIRE_MODEL to opt out of strict mode "
+            "and accept the backend's source default."
+        ),
+    )
+
+
 def _unavailable_provider_error(
     rule: Rule,
     rubric_input: dict[str, Any],
@@ -2645,7 +2759,14 @@ def _run_single_strategy(request: JudgmentRequest) -> Diagnostic:
         return _unavailable_unconfigured(rule, rubric_input)
 
     provider = env["GATE_KEEPER_LLM_PROVIDER"]
-    model = _resolve_model(provider, env)
+    try:
+        model = _resolve_model(provider, env)
+    except ModelConfigurationError as exc:
+        # Strict-mode model misconfiguration (#266). Surface as
+        # ``provider_unconfigured`` with ``failure_mode="model_unconfigured"``
+        # so the operator sees the override key by name rather than an
+        # opaque ``provider_error`` on every rule.
+        return _unavailable_model_unconfigured(rule, rubric_input, exc)
     system, user = _build_prompt(rule, target, artifact_kind)
 
     try:
@@ -2994,7 +3115,13 @@ def _run_consensus_strategy(request: JudgmentRequest) -> Diagnostic:
         return _unavailable_unconfigured(rule, rubric_input)
 
     provider = env["GATE_KEEPER_LLM_PROVIDER"]
-    model = _resolve_model(provider, env)
+    try:
+        model = _resolve_model(provider, env)
+    except ModelConfigurationError as exc:
+        # Strict-mode model misconfiguration (#266) — same dispatch as
+        # the single-strategy path; the consensus call would otherwise
+        # surface as `provider_error` on every judge call.
+        return _unavailable_model_unconfigured(rule, rubric_input, exc)
 
     # Resolve panel size from rule.params, clamp to valid range.
     raw_panel_size = rule.params.get("consensus_panel_size", _CONSENSUS_PANEL_SIZE_DEFAULT)
@@ -3548,7 +3675,13 @@ def _run_review_strategy(request: JudgmentRequest) -> Diagnostic:
         return _unavailable_unconfigured(rule, rubric_input)
 
     provider = env["GATE_KEEPER_LLM_PROVIDER"]
-    model = _resolve_model(provider, env)
+    try:
+        model = _resolve_model(provider, env)
+    except ModelConfigurationError as exc:
+        # Strict-mode model misconfiguration (#266) — review strategy
+        # bails before the primary call so neither pass hits the
+        # provider with an empty model id.
+        return _unavailable_model_unconfigured(rule, rubric_input, exc)
 
     # ---- Pass 1: primary judge (same prompt as single strategy) ----
     system, user = _build_prompt(rule, target, artifact_kind)

--- a/tests/test_dogfooding_config.py
+++ b/tests/test_dogfooding_config.py
@@ -1,0 +1,83 @@
+"""Tests for the centralised dogfooding workflow configuration (#266).
+
+The file ``.github/dogfooding-config.env`` carries the non-secret model
+value the dogfooding workflow sources into its credential-projection
+step. The workflow's strict-mode guard fails fast if
+``GATE_KEEPER_OPENAI_MODEL`` is unset/blank, but a unit test gives us a
+PR-time signal as well so a typo or accidental deletion is caught
+without waiting for a workflow run.
+
+These tests are deliberately lightweight: they verify the tracked file
+is parseable, carries the expected key with a non-blank value, and that
+the workflow YAML actually references the file. They are not a
+full workflow integration test (that lives in the dogfooding job
+itself).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CONFIG_PATH = _REPO_ROOT / ".github" / "dogfooding-config.env"
+_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "dogfooding.yml"
+
+
+class TestDogfoodingConfigFile:
+    def test_config_file_exists(self):
+        assert _CONFIG_PATH.is_file(), (
+            f"{_CONFIG_PATH} is missing — the dogfooding workflow sources it "
+            "for GATE_KEEPER_OPENAI_MODEL (#266)."
+        )
+
+    def test_config_file_carries_openai_model_key(self):
+        values = dotenv_values(_CONFIG_PATH)
+        assert "GATE_KEEPER_OPENAI_MODEL" in values
+
+    def test_config_file_openai_model_value_is_non_blank(self):
+        """The value must be present and non-blank: blank would defeat the
+        purpose of centralising it (the workflow's strict-mode guard would
+        immediately fail the run)."""
+        values = dotenv_values(_CONFIG_PATH)
+        value = values.get("GATE_KEEPER_OPENAI_MODEL")
+        assert value is not None and value.strip(), (
+            "GATE_KEEPER_OPENAI_MODEL is blank in .github/dogfooding-config.env"
+        )
+
+
+class TestDogfoodingWorkflowWiring:
+    """End-to-end wiring: the workflow must actually source the config file
+    and project the strict-mode key into the runtime dotenv."""
+
+    def test_workflow_sources_the_config_file(self):
+        body = _WORKFLOW_PATH.read_text(encoding="utf-8")
+        assert ". .github/dogfooding-config.env" in body, (
+            "dogfooding.yml no longer sources .github/dogfooding-config.env — "
+            "the model name would revert to a workflow literal (#266)."
+        )
+
+    def test_workflow_projects_model_via_interpolation(self):
+        """The printf must interpolate `$GATE_KEEPER_OPENAI_MODEL` rather than
+        a hard-pinned literal. A regression would re-introduce the very state
+        #266 was opened to remove."""
+        body = _WORKFLOW_PATH.read_text(encoding="utf-8")
+        # The %s slot is fed from "$GATE_KEEPER_OPENAI_MODEL" in the same
+        # block; verify both pieces are present.
+        assert "GATE_KEEPER_OPENAI_MODEL=%s" in body
+        assert '"$GATE_KEEPER_OPENAI_MODEL"' in body
+
+    def test_workflow_projects_strict_mode_key(self):
+        """`GATE_KEEPER_REQUIRE_MODEL=1` must be projected so the backend
+        fails closed on a blank/missing model rather than silently falling
+        back (#266)."""
+        body = _WORKFLOW_PATH.read_text(encoding="utf-8")
+        assert "GATE_KEEPER_REQUIRE_MODEL=1" in body
+
+    def test_workflow_has_blank_model_guard(self):
+        """The credentials step must fail fast on a blank model value."""
+        body = _WORKFLOW_PATH.read_text(encoding="utf-8")
+        # Match the actual guard introduced by #266; do not pin the exact
+        # wording of the error message — just verify the guard structure.
+        assert 'if [ -z "${GATE_KEEPER_OPENAI_MODEL:-}" ]' in body

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -407,6 +407,164 @@ class TestResolveModel:
 
 
 # ---------------------------------------------------------------------------
+# _resolve_model — strict-mode guard (#266)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveModelStrictMode:
+    """Issue #266 — opt-in strict mode rejects blank/missing model override.
+
+    The strict-mode guard exists for CI environments whose restricted
+    provider key only accepts a specific model. Without strict mode,
+    silently falling back to the source default would be rejected by the
+    provider and surface as opaque ``provider_error`` on every rule.
+    With strict mode, the backend reports
+    ``provider_unconfigured`` / ``failure_mode="model_unconfigured"``
+    naming the dotenv key to fix.
+
+    The default (non-strict) behaviour is preserved byte-for-byte — see
+    ``test_default_silent_fallback_preserved`` for the explicit
+    regression pin.
+    """
+
+    def test_strict_mode_raises_on_blank_openai_override(self):
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "openai",
+            "OPENAI_API_KEY": "sk-openai-test",
+            "GATE_KEEPER_OPENAI_MODEL": "   ",
+            "GATE_KEEPER_REQUIRE_MODEL": "1",
+        }
+        with pytest.raises(llm_backend.ModelConfigurationError) as excinfo:
+            llm_backend._resolve_model("openai", env)
+        assert excinfo.value.provider == "openai"
+        assert excinfo.value.override_key == "GATE_KEEPER_OPENAI_MODEL"
+
+    def test_strict_mode_raises_on_unset_openai_override(self):
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "openai",
+            "OPENAI_API_KEY": "sk-openai-test",
+            "GATE_KEEPER_REQUIRE_MODEL": "1",
+        }
+        with pytest.raises(llm_backend.ModelConfigurationError) as excinfo:
+            llm_backend._resolve_model("openai", env)
+        assert excinfo.value.provider == "openai"
+        assert excinfo.value.override_key == "GATE_KEEPER_OPENAI_MODEL"
+
+    def test_strict_mode_raises_on_blank_anthropic_override(self):
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "anthropic",
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+            "GATE_KEEPER_ANTHROPIC_MODEL": "",
+            "GATE_KEEPER_REQUIRE_MODEL": "1",
+        }
+        with pytest.raises(llm_backend.ModelConfigurationError) as excinfo:
+            llm_backend._resolve_model("anthropic", env)
+        assert excinfo.value.provider == "anthropic"
+        assert excinfo.value.override_key == "GATE_KEEPER_ANTHROPIC_MODEL"
+
+    def test_strict_mode_passes_through_non_blank_override(self):
+        """A real override + strict mode returns the override (no false positive)."""
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "openai",
+            "OPENAI_API_KEY": "sk-openai-test",
+            "GATE_KEEPER_OPENAI_MODEL": "gpt-5.4",
+            "GATE_KEEPER_REQUIRE_MODEL": "1",
+        }
+        assert llm_backend._resolve_model("openai", env) == "gpt-5.4"
+
+    @pytest.mark.parametrize("flag", ["1", "true", "TRUE", "Yes", "yes"])
+    def test_strict_mode_truthy_values_accepted(self, flag):
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "openai",
+            "OPENAI_API_KEY": "sk-openai-test",
+            "GATE_KEEPER_REQUIRE_MODEL": flag,
+        }
+        with pytest.raises(llm_backend.ModelConfigurationError):
+            llm_backend._resolve_model("openai", env)
+
+    @pytest.mark.parametrize("flag", ["0", "false", "no", "", "FALSE", "off"])
+    def test_strict_mode_falsy_values_keep_default_fallback(self, flag):
+        """Falsy / unknown values must preserve the historical silent fallback."""
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "openai",
+            "OPENAI_API_KEY": "sk-openai-test",
+            "GATE_KEEPER_REQUIRE_MODEL": flag,
+        }
+        assert llm_backend._resolve_model("openai", env) == llm_backend.OPENAI_DEFAULT_MODEL
+
+    def test_default_silent_fallback_preserved(self):
+        """Regression pin for #266: without GATE_KEEPER_REQUIRE_MODEL, blank
+        override still returns the source default constant. Non-CI developer
+        flows must keep their historical behaviour byte-for-byte.
+        """
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "openai",
+            "OPENAI_API_KEY": "sk-openai-test",
+            "GATE_KEEPER_OPENAI_MODEL": "",
+        }
+        assert llm_backend._resolve_model("openai", env) == llm_backend.OPENAI_DEFAULT_MODEL
+
+    def test_require_model_strict_helper(self):
+        assert llm_backend._require_model_strict({}) is False
+        assert llm_backend._require_model_strict({"GATE_KEEPER_REQUIRE_MODEL": ""}) is False
+        assert llm_backend._require_model_strict({"GATE_KEEPER_REQUIRE_MODEL": "0"}) is False
+        assert llm_backend._require_model_strict({"GATE_KEEPER_REQUIRE_MODEL": "1"}) is True
+        assert llm_backend._require_model_strict({"GATE_KEEPER_REQUIRE_MODEL": "  yes  "}) is True
+        assert llm_backend._require_model_strict({"GATE_KEEPER_REQUIRE_MODEL": "TRUE"}) is True
+
+    def test_check_surfaces_model_unconfigured_diagnostic(self, monkeypatch, tmp_path):
+        """End-to-end: strict mode + blank model → provider_unconfigured
+        with failure_mode=model_unconfigured."""
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "openai",
+            "OPENAI_API_KEY": "sk-openai-test",
+            "GATE_KEEPER_OPENAI_MODEL": "",
+            "GATE_KEEPER_REQUIRE_MODEL": "1",
+        }
+        _patch_env(monkeypatch, env)
+
+        # Provider helper must NOT be invoked when model config fails fast.
+        # Patch it to a sentinel that raises if called so a regression
+        # surfaces as a test failure rather than a silent network attempt.
+        def _explode(*_a, **_k):
+            raise AssertionError("provider helper called despite model misconfiguration")
+
+        monkeypatch.setattr(llm_backend, "_call_openai", _explode)
+        monkeypatch.setattr(llm_backend, "_call_anthropic", _explode)
+
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "provider_unconfigured"
+        data = diag.evidence[0].data
+        assert data["failure_mode"] == "model_unconfigured"
+        assert data["provider"] == "openai"
+        assert data["override_key"] == "GATE_KEEPER_OPENAI_MODEL"
+        assert "GATE_KEEPER_OPENAI_MODEL" in (diag.remediation or "")
+
+    def test_check_surfaces_model_unconfigured_for_anthropic(self, monkeypatch, tmp_path):
+        env = {
+            "GATE_KEEPER_LLM_PROVIDER": "anthropic",
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+            "GATE_KEEPER_REQUIRE_MODEL": "yes",
+        }
+        _patch_env(monkeypatch, env)
+
+        def _explode(*_a, **_k):
+            raise AssertionError("provider helper called despite model misconfiguration")
+
+        monkeypatch.setattr(llm_backend, "_call_openai", _explode)
+        monkeypatch.setattr(llm_backend, "_call_anthropic", _explode)
+
+        diag = llm_backend.check(_semantic_rule(), tmp_path)
+        assert diag.status is Status.UNAVAILABLE
+        assert diag.evidence[0].kind == "provider_unconfigured"
+        data = diag.evidence[0].data
+        assert data["failure_mode"] == "model_unconfigured"
+        assert data["provider"] == "anthropic"
+        assert data["override_key"] == "GATE_KEEPER_ANTHROPIC_MODEL"
+
+
+# ---------------------------------------------------------------------------
 # Provider dispatch — Anthropic (#67: updated to structured schema)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Move `GATE_KEEPER_OPENAI_MODEL` out of the dogfooding workflow literal into a new tracked file `.github/dogfooding-config.env`, so model updates are a normal PR diff rather than a workflow edit or an out-of-tree GitHub Actions variable.
- Add an opt-in **strict-mode** guard (`GATE_KEEPER_REQUIRE_MODEL=1` in the runtime dotenv) so a blank or missing model fails fast with a clear `provider_unconfigured` / `failure_mode=model_unconfigured` diagnostic, instead of silently falling back to a default (`gpt-4o-mini`) the restricted CI key would reject as `provider_error` on every rule (#264).
- Clean up `docs/llm-rubric.md` line 67 (`/home/vscode/...` literal → `$HOME/...`), refresh the CI-exception snippet to the new sourcing pattern, and document the strict-mode override in a dedicated subsection.

## Design choice — config surface

Picked a tracked in-repo file (`.github/dogfooding-config.env`) over a GitHub Actions repository variable:

- **Reviewable in a PR diff** — Actions variables are out-of-tree GUI state.
- **No `gh variable set` ceremony** or admin-token requirement.
- **Greppable** and survives fork/clone for local reproduction of the CI projection step.

The API key remains in `secrets.OPENAI_API_KEY`. The model name is not a secret.

## Strict-mode contract

Opt-in via dotenv `GATE_KEEPER_REQUIRE_MODEL` (truthy: `1`, `true`, `yes`; case-insensitive). When truthy AND the corresponding `GATE_KEEPER_<PROVIDER>_MODEL` is unset/blank/whitespace, `_resolve_model` raises a new `ModelConfigurationError` and `check()` surfaces:

- `Status.UNAVAILABLE`
- `evidence[0].kind = "provider_unconfigured"`
- `evidence[0].data.failure_mode = "model_unconfigured"`
- `evidence[0].data.provider`, `evidence[0].data.override_key`
- `remediation` names the override key and the strict-mode opt-out.

All three strategy entrypoints (`single`, `consensus`, `review`) catch the exception identically — no strategy reaches the provider with an empty model id.

The non-strict default is preserved byte-for-byte; non-CI developer flows that rely on the silent fallback to `gpt-4o-mini` / `claude-haiku-4-5` are unaffected (regression-pinned by `test_default_silent_fallback_preserved`).

## Preserved constraints

- **#261 forbidden wording.** Dogfood PR-comment body still must not contain `advisory` / `does not gate merge` / `non-gating`. The forbidden-substring regression suite (`tests/test_format_dogfooding_comment.py`, 9 tests) passes unchanged.
- **#262 dotenv path alignment.** Workflow continues to project to `\$HOME/.config/hermes-projects/gate-keeper.env`, matching the backend's `Path.home()` default.
- **Fail-closed semantics unchanged.** The strict-mode guard is purely additive and opt-in.
- **Same-repo PR dogfooding still produces real LLM verdicts** after the change — the workflow's projection step now interpolates the model name from the sourced config rather than a workflow literal.

## Out of scope

- #268 (line-range evidence refs work — landed via #270; rebased onto that HEAD).
- #263 (`provider_error` formatter — sibling).
- Broadening `provider_error` capture beyond the new `model_unconfigured` failure mode.

## Test plan

- [x] `uv run pytest` — 1508 tests pass after rebase onto `origin/main` (61b0fbe, post-#270).
- [x] `uvx ruff check .` — clean.
- [x] New: `TestResolveModelStrictMode` (19 cases) covers truthy/falsy flag matrix, override pass-through, end-to-end diagnostic shape on both providers, and the historical-silent-fallback regression pin.
- [x] New: `tests/test_dogfooding_config.py` asserts the tracked config file is parseable + non-blank and that the workflow YAML still wires it through (source statement, `%s` interpolation, strict-mode key, blank guard).
- [x] Existing `test_format_dogfooding_comment.py` forbidden-wording suite still passes.
- [ ] Live dogfood verification on this PR's CI (will surface here automatically).

Closes #266.