### PR TITLE
fix(llm-rubric): harden #268 line-range evidence edge cases (closes #275)

### DIFF
--- a/docs/llm-rubric.md
+++ b/docs/llm-rubric.md
@@ -327,6 +327,11 @@ The model is instructed (via `RUBRIC_PROMPT_TEMPLATE`, prompt version
 
 Primary contract (#268):
 - Prompt target blocks are rendered with stable 1-based line numbers.
+- Each rendered artifact carries an explicit `Path:` header — either a
+  filesystem path (`Path: <path>`) or the literal `Path: null` for inline /
+  no-path single-target artifacts. The model's evidence-ref `path` field
+  must match the rendered header (or be `null` when the header is
+  `Path: null`).
 - `supporting_evidence_refs` is validated against the exact prompt-visible
   corpus (single-target and multi-target paths share the same resolver).
 - On success, gate-keeper reconstructs `supporting_evidence_quotes`

--- a/src/gate_keeper/backends/llm_rubric.py
+++ b/src/gate_keeper/backends/llm_rubric.py
@@ -3975,7 +3975,12 @@ def _run_review_strategy(request: JudgmentRequest) -> Diagnostic:
         resolved_quotes_for_output = primary_refs_quotes
         spans = primary_refs_spans
     else:
-        artifact_text = _resolve_artifact_text(target, artifact_kind)
+        # Legacy fallback: span resolution must use the rule-aware
+        # prompt-visible corpus so multi-target quotes can still be located
+        # (#275 follow-up to #270 — _resolve_artifact_text ignores rule
+        # multi-target params and would return ``str(target)`` for the
+        # placeholder target that multi-target rules pass through).
+        artifact_text = _build_artifact_text_for_grounding(rule, target, artifact_kind)
         resolved_quotes_for_output = primary_parsed.supporting_evidence_quotes
         spans = _resolve_quote_spans(primary_parsed.supporting_evidence_quotes, artifact_text)
     evidence_data: dict[str, object] = {

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -620,3 +620,40 @@ def test_json_invalid_evidence_reference_non_string_defaults_to_grader_error():
     diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.LLM_RUBRIC)]
     parsed = json.loads(render_json(diags))
     assert parsed["diagnostics"][0]["failure_mode"] == "grader_error"
+
+
+def test_json_invalid_evidence_reference_missing_field_defaults_to_grader_error():
+    """#275 follow-up: avoid emitting "failure_mode": "None" when the
+    ``failure_mode`` key is absent on ``invalid_evidence_reference`` evidence.
+    """
+    ev = Evidence(
+        kind="invalid_evidence_reference",
+        data={"detail": "bad refs"},  # no ``failure_mode`` key at all
+    )
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.LLM_RUBRIC)]
+    parsed = json.loads(render_json(diags))
+    assert parsed["diagnostics"][0]["failure_mode"] == "grader_error"
+
+
+def test_json_invalid_evidence_reference_non_string_int_defaults_to_grader_error():
+    """#275 follow-up: a non-string ``failure_mode`` (e.g. accidental int)
+    must not be coerced via ``str()`` — fall back to ``grader_error``."""
+    ev = Evidence(
+        kind="invalid_evidence_reference",
+        data={"failure_mode": 42, "detail": "bad refs"},
+    )
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.LLM_RUBRIC)]
+    parsed = json.loads(render_json(diags))
+    assert parsed["diagnostics"][0]["failure_mode"] == "grader_error"
+
+
+def test_json_invalid_evidence_reference_empty_string_defaults_to_grader_error():
+    """#275 follow-up: empty / whitespace-only string ``failure_mode`` is
+    treated as missing and falls back to ``grader_error``."""
+    ev = Evidence(
+        kind="invalid_evidence_reference",
+        data={"failure_mode": "   ", "detail": "bad refs"},
+    )
+    diags = [_diag(status=Status.UNAVAILABLE, evidence=[ev], backend=Backend.LLM_RUBRIC)]
+    parsed = json.loads(render_json(diags))
+    assert parsed["diagnostics"][0]["failure_mode"] == "grader_error"

--- a/tests/test_llm_rubric_backend.py
+++ b/tests/test_llm_rubric_backend.py
@@ -4638,6 +4638,98 @@ class TestEvidenceRefsPrimaryContract:
         assert artifact[span["end_offset"] - 1] == "a"
         assert span["end_line"] == 2
 
+    def test_crlf_single_line_ref_span_consistency(self, monkeypatch):
+        """#275 follow-up: single-line CRLF ranges must produce LF-consistent
+        spans — the reconstructed quote, end_column, and end_offset must agree
+        on the trailing character (no dangling ``\\r`` slipping in).
+        """
+        _patch_env(monkeypatch, self._ENV)
+        artifact_lf = "alpha\nbeta\ngamma\n"
+        artifact_crlf = "alpha\r\nbeta\r\ngamma\r\n"
+        ref = {"target_id": None, "path": None, "line_start": 2, "line_end": 2}
+        response = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "Grounded.",
+                "supporting_evidence_refs": [ref],
+                "suggested_action": None,
+            }
+        )
+
+        def run(artifact: str) -> dict:
+            monkeypatch.setattr(llm_backend, "_call_openai", lambda *a, **k: _stub_response(response))
+            diag = llm_backend.check(_semantic_rule(), artifact)
+            assert diag.status is Status.PASS, diag.evidence[0].to_dict()
+            data = diag.evidence[0].data
+            return {
+                "span": data["supporting_evidence_spans"][0],
+                "quote": data["supporting_evidence_quotes"][0],
+            }
+
+        lf_result = run(artifact_lf)
+        crlf_result = run(artifact_crlf)
+
+        # Quote text is line-content only (no trailing line break of either flavour).
+        assert lf_result["quote"] == "beta"
+        assert crlf_result["quote"] == "beta"
+
+        # end_column points one past the last character of the line — must
+        # match the line's printable length + 1, independent of line endings.
+        assert lf_result["span"]["end_column"] == 5
+        assert crlf_result["span"]["end_column"] == 5
+
+        # end_offset must land on the last character of "beta" (not on a CR).
+        assert artifact_lf[lf_result["span"]["end_offset"] - 1] == "a"
+        assert artifact_crlf[crlf_result["span"]["end_offset"] - 1] == "a"
+
+
+class TestRenderNumberedArtifactText:
+    """#275 follow-up: ``_render_numbered_artifact_text`` shape contract.
+
+    The prompt rendering helper produces the model-facing artifact block.
+    The contract for inline / no-path single-target artifacts is to emit
+    an explicit ``Path: null`` line (not omit the header) so the model's
+    ``path`` field has an unambiguous source.
+    """
+
+    def test_no_path_renders_explicit_path_null_header(self):
+        artifact = llm_backend.EvidenceArtifact(
+            target_id=None,
+            path=None,
+            text="alpha\nbeta",
+            quotable=True,
+        )
+        rendered = llm_backend._render_numbered_artifact_text(artifact)
+        # Contract: an explicit ``Path: null`` header, blank line, then numbered body.
+        assert rendered.startswith("Path: null\n\n")
+        assert "   1 | alpha" in rendered
+        assert "   2 | beta" in rendered
+        # The substring ``Path: null`` is the literal contract — not ``Path: None``.
+        assert "Path: None" not in rendered
+
+    def test_concrete_path_renders_path_header(self):
+        artifact = llm_backend.EvidenceArtifact(
+            target_id="alpha",
+            path="docs/example.md",
+            text="line one",
+            quotable=True,
+        )
+        rendered = llm_backend._render_numbered_artifact_text(artifact)
+        assert rendered.startswith("Path: docs/example.md\n\n")
+        assert "   1 | line one" in rendered
+
+    def test_empty_text_still_emits_path_header_and_one_numbered_line(self):
+        """Empty body still produces a single numbered placeholder line."""
+        artifact = llm_backend.EvidenceArtifact(
+            target_id=None,
+            path=None,
+            text="",
+            quotable=True,
+        )
+        rendered = llm_backend._render_numbered_artifact_text(artifact)
+        assert rendered.startswith("Path: null\n\n")
+        assert "   1 | " in rendered
+
 
 class TestLegacyQuoteFallbackRuleAwareGrounding:
     """#268 fallback path should still ground against prompt-visible multi-target corpus."""
@@ -4699,6 +4791,91 @@ class TestLegacyQuoteFallbackRuleAwareGrounding:
         diag = llm_backend.check(rule, "ignored")
         assert diag.status is Status.PASS, diag.evidence[0].to_dict()
         assert diag.evidence[0].data["llm_strategy"] == "review"
+
+    def test_review_legacy_quote_fallback_resolves_span_against_multi_target_corpus(
+        self, monkeypatch, tmp_path
+    ):
+        """#275 follow-up: review-strategy span resolution on the legacy
+        quote-only path must use the rule-aware multi-target corpus.
+
+        Before the fix, span resolution called ``_resolve_artifact_text(target, ...)``
+        which returned ``str(target)`` (the placeholder ``"ignored"`` in this
+        test) — guaranteed not to contain the model's quote, so the span list
+        was always empty.  With the fix, spans are resolved against the
+        flat multi-target grounding corpus and the legitimate quote lands.
+        """
+        _patch_env(monkeypatch, self._ENV)
+        target_a = tmp_path / "a.md"
+        target_b = tmp_path / "b.md"
+        target_a.write_text("alpha quote substring here.", encoding="utf-8")
+        target_b.write_text("beta quote substring here.", encoding="utf-8")
+        primary_response = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "Grounded.",
+                "supporting_evidence_quotes": ["alpha quote substring"],
+                "suggested_action": None,
+            }
+        )
+        reviewer_response = json.dumps({"review_verdict": "agree", "review_reason": "Grounded."})
+        calls = iter([primary_response, reviewer_response])
+        monkeypatch.setattr(llm_backend, "_call_openai", lambda *a, **k: _stub_response(next(calls)))
+        rule = _multi_target_rule(
+            [
+                {"id": "alpha", "kind": "documentation", "path": str(target_a)},
+                {"id": "beta", "kind": "documentation", "path": str(target_b)},
+            ]
+        )
+        rule = dataclasses.replace(rule, params={**rule.params, "strategy": "review"})
+        diag = llm_backend.check(rule, "ignored")
+        assert diag.status is Status.PASS, diag.evidence[0].to_dict()
+        ev_data = diag.evidence[0].data
+        assert ev_data["llm_strategy"] == "review"
+        # Quote landed against the rule-aware corpus, not str("ignored"):
+        # spans should be non-empty and locate the alpha-target substring.
+        spans = ev_data["supporting_evidence_spans"]
+        assert len(spans) == 1, spans
+        assert spans[0]["quote"] == "alpha quote substring"
+
+    def test_review_legacy_quote_fallback_rejects_quote_fabricated_against_multi_target_corpus(
+        self, monkeypatch, tmp_path
+    ):
+        """#275 follow-up: defensive fabrication validation on the review
+        strategy's legacy fallback path must use the rule-aware multi-target
+        corpus.  A quote that exists in the str(target) placeholder
+        ("contains 'alpha'") but not in either real artifact body MUST still
+        be rejected as fabrication when the artifact corpus does not contain it.
+        """
+        _patch_env(monkeypatch, self._ENV)
+        target_a = tmp_path / "a.md"
+        target_b = tmp_path / "b.md"
+        target_a.write_text("alpha body only", encoding="utf-8")
+        target_b.write_text("beta body only", encoding="utf-8")
+        # The placeholder target string contains "ignored placeholder" but
+        # neither artifact body contains those words. The model emits a
+        # legacy quote drawn from the placeholder string. The fabrication
+        # check must use the multi-target corpus and reject the quote.
+        primary_response = json.dumps(
+            {
+                "judgment": "pass",
+                "primary_reason": "Grounded.",
+                "supporting_evidence_quotes": ["ignored placeholder"],
+                "suggested_action": None,
+            }
+        )
+        monkeypatch.setattr(llm_backend, "_call_openai", lambda *a, **k: _stub_response(primary_response))
+        rule = _multi_target_rule(
+            [
+                {"id": "alpha", "kind": "documentation", "path": str(target_a)},
+                {"id": "beta", "kind": "documentation", "path": str(target_b)},
+            ]
+        )
+        rule = dataclasses.replace(rule, params={**rule.params, "strategy": "review"})
+        diag = llm_backend.check(rule, "ignored placeholder")
+        # Quote is NOT in either real artifact body → fabrication MUST trip.
+        assert diag.status is Status.UNSUPPORTED, diag.evidence[0].to_dict()
+        assert diag.evidence[0].kind == "llm_quote_fabrication"
+        assert "ignored placeholder" in diag.evidence[0].data["fabricated_quotes"]
 
 
 class TestMultiTargetQuoteParsing:


### PR DESCRIPTION
## Summary

Follow-up to PR #270 that addresses the four Copilot-review edge cases on the v7 `supporting_evidence_refs` contract.

- **Item 1 (`invalid_evidence_reference.failure_mode` fallback)**: `_derive_failure_mode` already guards against non-string / empty `failure_mode` (added in #270); widens test coverage to missing-key, integer, and whitespace inputs so a `"failure_mode": "None"` regression cannot return undetected.
- **Item 2 (CRLF-safe span reconstruction)**: `_quote_span_from_line_range` already strips trailing `\r` alongside `\n` (added in #270); adds a regression locking in that LF and CRLF artifacts produce identical `end_offset` / `end_column` for the same line range.
- **Item 3 (explicit no-path metadata)**: `_render_numbered_artifact_text` already emits `Path: null` for inline / no-path single-target artifacts (added in #270); adds direct unit tests for the model-facing shape and documents the contract in `docs/llm-rubric.md`.
- **Item 4 (multi-target legacy fallback grounding, the only real bug fix)**: the review strategy's agree/abstain path was still calling `_resolve_artifact_text(target, artifact_kind)` for span resolution, which ignores `rule.params["targets"]` and resolves to `str(target)` — guaranteed to miss every quote for multi-target rules. Switched to `_build_artifact_text_for_grounding(rule, target, artifact_kind)` so spans land against the rule-aware corpus the model actually saw. Consensus strategy already used the rule-aware corpus.

Non-goals (per #275): no revert of v7 line-range design, no relaxed grounding, no removed legacy validation, no new strategy.

## Test plan

- [x] `uv run pytest` → 1550 passes (was 1509 at #273 baseline + 41 from the new content here and the work landed in #270 / #271 / #273 / #274 since then)
- [x] `uvx ruff check .` → all checks passed
- [x] `uvx ruff format --check .` → 81 files already formatted
- [x] `uv run pyright src/gate_keeper/backends/llm_rubric.py src/gate_keeper/diagnostics.py` → 0 errors
- [x] Verified the new `test_review_legacy_quote_fallback_resolves_span_against_multi_target_corpus` test **fails** on unfixed `_resolve_artifact_text` and passes after switching to `_build_artifact_text_for_grounding`.

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)